### PR TITLE
fix(apollo): should prevent inecessary request on route change

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,12 +21,14 @@ import loadable from '@loadable/component';
 import { useLang } from 'store/global';
 import { ConfigProvider } from 'antd';
 import { LANG } from 'common/constants';
+import { GraphqlBackend } from 'provider/types';
 import frFR from 'antd/lib/locale/fr_FR';
 import enUS from 'antd/lib/locale/en_US';
 import ErrorBoundary from 'components/ErrorBoundary';
 import FenceRedirect from 'views/FenceRedirect';
 import { FENCE_NAMES } from 'common/fenceTypes';
 import NotificationContextHolder from 'components/utils/NotificationContextHolder';
+import ApolloProvider from 'provider/ApolloProvider';
 
 const loadableProps = { fallback: <Spinner size="large" /> };
 const Dashboard = loadable(() => import('views/Dashboard'), loadableProps);
@@ -47,62 +49,64 @@ const App = () => {
       locale={lang === LANG.FR ? frFR : enUS}
       renderEmpty={() => <Empty imageType="grid" />}
     >
-      <div className="App" id="appContainer">
-        {keycloakIsReady ? (
-          <AuthMiddleware>
-            <Router>
-              <Switch>
-                <Route
-                  path={STATIC_ROUTES.GEN3_FENCE_REDIRECT}
-                  exact
-                  render={() => <FenceRedirect fence={FENCE_NAMES.gen3} />}
-                />
-                <Route
-                  path={STATIC_ROUTES.CAVATICA_FENCE_REDIRECT}
-                  exact
-                  render={() => <FenceRedirect fence={FENCE_NAMES.cavatica} />}
-                />
-                <Route exact path={STATIC_ROUTES.LOGIN}>
-                  <SideImageLayout sideImgSrc={MainSideImage}>
-                    <Login />
-                  </SideImageLayout>
-                </Route>
-                <Route
-                  path={DYNAMIC_ROUTES.ERROR}
-                  render={(props: RouteComponentProps<{ status?: any }>) => (
-                    <ErrorPage status={props.match.params.status} />
-                  )}
-                />
-                <ProtectedRoute exact path={STATIC_ROUTES.DASHBOARD} layout={PageLayout}>
-                  <Dashboard />
-                </ProtectedRoute>
-                <ProtectedRoute exact path={STATIC_ROUTES.COMMUNITY} layout={PageLayout}>
-                  <Community />
-                </ProtectedRoute>
-                <ProtectedRoute exact path={DYNAMIC_ROUTES.COMMUNITY_MEMBER} layout={PageLayout}>
-                  <CommunityMember />
-                </ProtectedRoute>
-                <ProtectedRoute exact path={STATIC_ROUTES.PROFILE_SETTINGS} layout={PageLayout}>
-                  <ProfileSettings />
-                </ProtectedRoute>
-                <ProtectedRoute exact path={STATIC_ROUTES.STUDIES} layout={PageLayout}>
-                  <Studies />
-                </ProtectedRoute>
-                <ProtectedRoute exact path={DYNAMIC_ROUTES.DATA_EXPLORATION} layout={PageLayout}>
-                  <DataExploration />
-                </ProtectedRoute>
-                <ProtectedRoute exact path={DYNAMIC_ROUTES.VARIANT} layout={PageLayout}>
-                  <Variants />
-                </ProtectedRoute>
-                <Redirect from="*" to={STATIC_ROUTES.DASHBOARD} />
-              </Switch>
-              <NotificationContextHolder />
-            </Router>
-          </AuthMiddleware>
-        ) : (
-          <Spinner size={'large'} />
-        )}
-      </div>
+      <ApolloProvider backend={GraphqlBackend.ARRANGER}>
+        <div className="App" id="appContainer">
+          {keycloakIsReady ? (
+            <AuthMiddleware>
+              <Router>
+                <Switch>
+                  <Route
+                    path={STATIC_ROUTES.GEN3_FENCE_REDIRECT}
+                    exact
+                    render={() => <FenceRedirect fence={FENCE_NAMES.gen3} />}
+                  />
+                  <Route
+                    path={STATIC_ROUTES.CAVATICA_FENCE_REDIRECT}
+                    exact
+                    render={() => <FenceRedirect fence={FENCE_NAMES.cavatica} />}
+                  />
+                  <Route exact path={STATIC_ROUTES.LOGIN}>
+                    <SideImageLayout sideImgSrc={MainSideImage}>
+                      <Login />
+                    </SideImageLayout>
+                  </Route>
+                  <Route
+                    path={DYNAMIC_ROUTES.ERROR}
+                    render={(props: RouteComponentProps<{ status?: any }>) => (
+                      <ErrorPage status={props.match.params.status} />
+                    )}
+                  />
+                  <ProtectedRoute exact path={STATIC_ROUTES.DASHBOARD} layout={PageLayout}>
+                    <Dashboard />
+                  </ProtectedRoute>
+                  <ProtectedRoute exact path={STATIC_ROUTES.COMMUNITY} layout={PageLayout}>
+                    <Community />
+                  </ProtectedRoute>
+                  <ProtectedRoute exact path={DYNAMIC_ROUTES.COMMUNITY_MEMBER} layout={PageLayout}>
+                    <CommunityMember />
+                  </ProtectedRoute>
+                  <ProtectedRoute exact path={STATIC_ROUTES.PROFILE_SETTINGS} layout={PageLayout}>
+                    <ProfileSettings />
+                  </ProtectedRoute>
+                  <ProtectedRoute exact path={STATIC_ROUTES.STUDIES} layout={PageLayout}>
+                    <Studies />
+                  </ProtectedRoute>
+                  <ProtectedRoute exact path={DYNAMIC_ROUTES.DATA_EXPLORATION} layout={PageLayout}>
+                    <DataExploration />
+                  </ProtectedRoute>
+                  <ProtectedRoute exact path={DYNAMIC_ROUTES.VARIANT} layout={PageLayout}>
+                    <Variants />
+                  </ProtectedRoute>
+                  <Redirect from="*" to={STATIC_ROUTES.DASHBOARD} />
+                </Switch>
+                <NotificationContextHolder />
+              </Router>
+            </AuthMiddleware>
+          ) : (
+            <Spinner size={'large'} />
+          )}
+        </div>
+      </ApolloProvider>
     </ConfigProvider>
   );
 };

--- a/src/auth/keycloak-api/index.ts
+++ b/src/auth/keycloak-api/index.ts
@@ -1,4 +1,4 @@
-import { RptManager } from "auth/keycloak-api/manager";
+import { RptManager } from 'auth/keycloak-api/manager';
 
 export const userAuthPermissions = async () => {
   try {

--- a/src/auth/keycloak-api/manager.ts
+++ b/src/auth/keycloak-api/manager.ts
@@ -3,8 +3,8 @@ import {
   rptRequest,
   Rpt,
   getAccessTokenStatus,
-} from "auth/keycloak-api/utils";
-import { keycloakConfig } from "./config";
+} from 'auth/keycloak-api/utils';
+import { keycloakConfig } from './config';
 
 export class RptManager {
   private static storedRpt?: Rpt;
@@ -14,7 +14,7 @@ export class RptManager {
       JSON.stringify({
         grant_type: KEYCLOAK_AUTH_GRANT_TYPE,
         audience: keycloakConfig.clientId,
-      })
+      }),
     );
     return rptRequest(data);
   }

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -19,7 +19,7 @@ export type QueryVariable = {
 };
 
 export const INDEX_EXTENDED_MAPPING = (index: string) => gql`
-query ExtendedMapping {
+query ExtendedMapping_${index} {
   ${index} {
     extended
   }

--- a/src/hooks/graphql/useGetExtendedMappings.ts
+++ b/src/hooks/graphql/useGetExtendedMappings.ts
@@ -1,11 +1,11 @@
-import { ExtendedMappingResults } from "graphql/models";
-import { INDEX_EXTENDED_MAPPING } from "graphql/queries";
-import { useLazyResultQueryOnLoadOnly } from "hooks/graphql/useLazyResultQuery";
+import { ExtendedMappingResults } from 'graphql/models';
+import { INDEX_EXTENDED_MAPPING } from 'graphql/queries';
+import { useLazyResultQueryOnLoadOnly } from 'hooks/graphql/useLazyResultQuery';
 
 const useGetExtendedMappings = (index: string): ExtendedMappingResults => {
-  const { loading, result } = useLazyResultQueryOnLoadOnly<any>(
-    INDEX_EXTENDED_MAPPING(index)
-  );
+  const { loading, result } = useLazyResultQueryOnLoadOnly<any>(INDEX_EXTENDED_MAPPING(index), {
+    fetchPolicy: 'no-cache',
+  });
 
   return {
     loading,

--- a/src/provider/ApolloProvider.tsx
+++ b/src/provider/ApolloProvider.tsx
@@ -1,19 +1,19 @@
-import { ReactElement } from "react";
+import { ReactElement } from 'react';
 import {
   ApolloClient,
   ApolloProvider,
   createHttpLink,
   InMemoryCache,
   NormalizedCacheObject,
-} from "@apollo/client";
-import { setContext } from "@apollo/client/link/context";
-import { GraphqlBackend, GraphqlProvider } from "provider/types";
-import EnvironmentVariables from "helpers/EnvVariables";
-import keycloak from "auth/keycloak-api/keycloak";
+} from '@apollo/client';
+import { setContext } from '@apollo/client/link/context';
+import { GraphqlBackend, GraphqlProvider } from 'provider/types';
+import EnvironmentVariables from 'helpers/EnvVariables';
+import keycloak from 'auth/keycloak-api/keycloak';
 
-const ARRANGER_API = EnvironmentVariables.configFor("ARRANGER_API");
-const PROJECT_ID = EnvironmentVariables.configFor("ARRANGER_PROJECT_ID");
-const FHIR_API = EnvironmentVariables.configFor("FHIR_API");
+const ARRANGER_API = EnvironmentVariables.configFor('ARRANGER_API');
+const PROJECT_ID = EnvironmentVariables.configFor('ARRANGER_PROJECT_ID');
+const FHIR_API = EnvironmentVariables.configFor('FHIR_API');
 
 export const ARRANGER_API_DOWNLOAD_URL = `${ARRANGER_API}/${PROJECT_ID}/download`;
 export const ARRANGER_API_PROJECT_URL = `${ARRANGER_API}/${PROJECT_ID}/graphql`;
@@ -38,10 +38,7 @@ const getAuthLink = () =>
 const backendUrl = (backend: GraphqlBackend) =>
   backend === GraphqlBackend.FHIR ? fhirLink : arrangerLink;
 
-const Provider = ({
-  children,
-  backend = GraphqlBackend.FHIR,
-}: GraphqlProvider): ReactElement => {
+const Provider = ({ children, backend = GraphqlBackend.FHIR }: GraphqlProvider): ReactElement => {
   const header = getAuthLink();
 
   const client: ApolloClient<NormalizedCacheObject> = new ApolloClient({

--- a/src/views/DataExploration/components/PageContent/tabs/Summary/SunburstGraphCard/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/SunburstGraphCard/index.tsx
@@ -78,6 +78,7 @@ const SunburstGraphCard = ({ id, className = '', field }: OwnProps) => {
 
     return () => {
       updateSunburst.current = undefined;
+      setIsLoading(false);
     };
     // eslint-disable-next-line
   }, [JSON.stringify(sqon)]);

--- a/src/views/DataExploration/index.tsx
+++ b/src/views/DataExploration/index.tsx
@@ -3,7 +3,6 @@ import intl from 'react-intl-universal';
 import ScrollContent from '@ferlab/ui/core/layout/ScrollContent';
 import { ExperimentOutlined, UserOutlined, FileSearchOutlined } from '@ant-design/icons';
 import PageContent from 'views/DataExploration/components/PageContent';
-import ApolloProvider from 'provider/ApolloProvider';
 import { Spin } from 'antd';
 import { ExtendedMappingResults } from 'graphql/models';
 import FilterList, { TCustomFilterMapper } from 'components/uiKit/FilterList';
@@ -196,10 +195,4 @@ const DataExploration = (props: OwnProps) => {
   );
 };
 
-const DataExplorationWrapper = (props: OwnProps) => (
-  <ApolloProvider backend={GraphqlBackend.ARRANGER}>
-    <DataExploration {...props} />
-  </ApolloProvider>
-);
-
-export default DataExplorationWrapper;
+export default DataExploration;

--- a/src/views/Studies/index.tsx
+++ b/src/views/Studies/index.tsx
@@ -3,8 +3,6 @@ import GridCard from '@ferlab/ui/core/view/v2/GridCard';
 import { Space, Typography } from 'antd';
 import { ProColumnType } from '@ferlab/ui/core/components/ProTable/types';
 import { useStudies } from 'graphql/studies/actions';
-import ApolloProvider from 'provider/ApolloProvider';
-import { GraphqlBackend } from 'provider/types';
 import { getProTableDictionary } from 'utils/translation';
 import { Link } from 'react-router-dom';
 import { STATIC_ROUTES } from 'utils/routes';
@@ -208,12 +206,4 @@ const Studies = () => {
   );
 };
 
-const StudiesWrapper = (props: any) => {
-  return (
-    <ApolloProvider backend={GraphqlBackend.ARRANGER}>
-      <Studies {...props} />
-    </ApolloProvider>
-  );
-};
-
-export default StudiesWrapper;
+export default Studies;

--- a/src/views/Variants/index.tsx
+++ b/src/views/Variants/index.tsx
@@ -5,8 +5,6 @@ import ScrollContent from '@ferlab/ui/core/layout/ScrollContent';
 import { SCROLL_WRAPPER_ID, TAB_IDS } from './utils/constants';
 import intl from 'react-intl-universal';
 import PageContent from './components/PageContent';
-import { GraphqlBackend } from 'provider/types';
-import ApolloProvider from 'provider/ApolloProvider';
 
 import styles from 'views/Variants/index.module.scss';
 
@@ -55,10 +53,4 @@ const Variants = (props: OwnProps) => {
   );
 };
 
-const VariantWrapper = (props: OwnProps) => (
-  <ApolloProvider backend={GraphqlBackend.ARRANGER}>
-    <Variants {...props} />
-  </ApolloProvider>
-);
-
-export default VariantWrapper;
+export default Variants;


### PR DESCRIPTION
Since apollo wasn't at the root, everytime a new page was called, a new apollo instance was created, invalidating the cache and re-do all the grapql request. Should be fix now