### PR TITLE
fix: SJIP-351 Add underline to data access link

### DIFF
--- a/src/views/FileEntity/Title/index.module.scss
+++ b/src/views/FileEntity/Title/index.module.scss
@@ -7,3 +7,11 @@
 .unlocked {
     color: $green-7;
 }
+
+.link {
+    text-decoration: underline;
+
+    &:hover {
+        text-decoration: none;
+    }
+}

--- a/src/views/FileEntity/Title/index.tsx
+++ b/src/views/FileEntity/Title/index.tsx
@@ -41,7 +41,10 @@ const FileEntityTitle: React.FC<OwnProps> = ({ file, loading }) => {
         title={
           <>
             <>{intl.get('entities.file.locked')}</>
-            <ExternalLink href="https://help.includedcc.org/docs/applying-for-access">
+            <ExternalLink
+              className={styles.link}
+              href="https://help.includedcc.org/docs/applying-for-access"
+            >
               {intl.get('entities.file.apply_data_access')}
             </ExternalLink>
             <>.</>


### PR DESCRIPTION
# BUG
- closes [SJIP-351](https://d3b.atlassian.net/browse/SJIP-351)

## Description
- Fix style to link to apply for data access

## Screenshot 
Before:
![image (1)](https://user-images.githubusercontent.com/116835792/219790515-954991be-4557-4ee3-a756-066fd97b077a.png)

After:
![CC2F07B5-23B7-48C0-80E2-9FE770B3F3B6_4_5005_c](https://user-images.githubusercontent.com/116835792/219790537-ddfd5e96-c7b5-418d-9b99-f046c762865b.jpeg)