### PR TITLE
fix: SJIP-356 Saved sets scroll

### DIFF
--- a/src/views/Dashboard/components/DashboardCards/SavedSets/index.module.scss
+++ b/src/views/Dashboard/components/DashboardCards/SavedSets/index.module.scss
@@ -19,6 +19,7 @@
 
   :global(.ant-tabs-content) {
     height: 100%;
+    overflow: auto;
   }
 
   :global(.ant-tabs-tab) {


### PR DESCRIPTION
# BUG
- closes [SJIP-356](https://d3b.atlassian.net/browse/SJIP-356)

## Description
- Fix scroll in Saved Sets dashboard card

## Screenshot
Before:
![151C4F49-2A6A-4036-AB4D-A80A1BA10DCD](https://user-images.githubusercontent.com/116835792/221692896-eff601cc-e538-4d1f-ad1d-8fa9a4159468.jpeg)


After:
![95267787-F165-432B-899F-B3C0243CDADE](https://user-images.githubusercontent.com/116835792/221692878-ed42ce63-21a3-4c49-bfb2-6de53728a61a.jpeg)