### PR TITLE
fix(sets): SJIP-392 add savedsets and filters

### DIFF
--- a/src/components/Icons/index.tsx
+++ b/src/components/Icons/index.tsx
@@ -1,8 +1,8 @@
 export type IconProps = {
   alt?: string;
-  height?: number;
+  height?: number | string;
   style?: object;
-  width?: number;
+  width?: number | string;
   className?: string;
   svgClass?: string;
 };

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -690,6 +690,14 @@ const en = {
         biospecimen: 'Biospecimen',
         datafiles: 'Data File',
       },
+      setsManagementDropdown: {
+        newTitle: 'Save {filter} set',
+        editTitle: 'Edit {filter} set',
+        create: 'Save as new set',
+        add: 'Add to existing set',
+        remove: 'Remove from existing set',
+        selected: '{count, plural, =0 {# {type}} =1 {# {type}} other {# {type}s}} selected',
+      },
       hpoTree: {
         modal: {
           title: 'Observed Phenotype (HPO) Browser',

--- a/src/services/api/savedFilter/models.ts
+++ b/src/services/api/savedFilter/models.ts
@@ -8,7 +8,7 @@ export type TUserSavedFilter = ISavedFilter & {
 };
 
 export enum SavedFilterTag {
-  ParticipantsExplorationPage = 'participants-data-exploration-page',
+  ParticipantsExplorationPage = 'data-exploration',
   VariantsExplorationPage = 'variants-variants-exploration-page',
 }
 

--- a/src/services/api/savedSet/models.ts
+++ b/src/services/api/savedSet/models.ts
@@ -30,5 +30,5 @@ export enum SetType {
   PARTICIPANT = 'participant',
   FILE = 'file',
   BIOSPECIMEN = 'biospecimen',
-  VARIANT = 'variant',
+  VARIANT = 'variants',
 }

--- a/src/views/Dashboard/components/DashboardCards/SavedFilters/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/SavedFilters/index.tsx
@@ -1,14 +1,18 @@
 import intl from 'react-intl-universal';
+import { FileSearchOutlined } from '@ant-design/icons';
 import Empty from '@ferlab/ui/core/components/Empty';
 import ExternalLink from '@ferlab/ui/core/components/ExternalLink';
 import GridCard from '@ferlab/ui/core/view/v2/GridCard';
-import { List, Typography } from 'antd';
+import { List, Tabs, Typography } from 'antd';
+import cx from 'classnames';
+import { TabPane } from 'rc-tabs';
 import CardErrorPlaceholder from 'views/Dashboard/components/CardErrorPlaceHolder';
 import CardHeader from 'views/Dashboard/components/CardHeader';
 import { DashboardCardProps } from 'views/Dashboard/components/DashboardCards';
 
+import LineStyleIcon from 'components/Icons/LineStyleIcon';
 import PopoverContentLink from 'components/uiKit/PopoverContentLink';
-import { TUserSavedFilter } from 'services/api/savedFilter/models';
+import { SavedFilterTag, TUserSavedFilter } from 'services/api/savedFilter/models';
 import { SUPPORT_EMAIL } from 'store/report/thunks';
 import { useSavedFilter } from 'store/savedFilter';
 import { STATIC_ROUTES } from 'utils/routes';
@@ -18,6 +22,50 @@ import SavedFiltersListItem from './ListItem';
 import styles from './index.module.scss';
 
 const { Text } = Typography;
+
+type SavedFilterListWrapperOwnprops = {
+  tag: SavedFilterTag;
+  savedFilters: TUserSavedFilter[];
+  fetchingError: boolean;
+  isLoading: boolean;
+};
+
+const SavedFilterListWrapper = ({
+  tag,
+  savedFilters,
+  fetchingError,
+  isLoading,
+}: SavedFilterListWrapperOwnprops) => (
+  <List<TUserSavedFilter>
+    className={styles.savedFiltersList}
+    key={tag}
+    bordered
+    locale={{
+      emptyText: fetchingError ? (
+        <CardErrorPlaceholder
+          title="Failed to Fetch Saved Filters"
+          subTitle={
+            <Text>
+              Please refresh and try again or
+              <ExternalLink href={`mailto:${SUPPORT_EMAIL}`}>
+                <Text>contact our support</Text>
+              </ExternalLink>
+              .
+            </Text>
+          }
+        />
+      ) : (
+        <Empty
+          imageType="grid"
+          description={intl.get('screen.dashboard.cards.savedFilters.noSavedFilters')}
+        />
+      ),
+    }}
+    dataSource={fetchingError ? [] : savedFilters.filter((s) => s.tag === tag)}
+    loading={isLoading}
+    renderItem={(item) => <SavedFiltersListItem id={item.id} data={item} />}
+  />
+);
 
 const SavedFilters = ({ id, key, className = '' }: DashboardCardProps) => {
   const { savedFilters, isLoading, fetchingError } = useSavedFilter();
@@ -50,35 +98,54 @@ const SavedFilters = ({ id, key, className = '' }: DashboardCardProps) => {
         />
       }
       content={
-        <List<TUserSavedFilter>
-          className={styles.savedFiltersList}
-          key="2"
-          bordered
-          locale={{
-            emptyText: fetchingError ? (
-              <CardErrorPlaceholder
-                title="Failed to Fetch Saved Filters"
-                subTitle={
-                  <Text>
-                    Please refresh and try again or{' '}
-                    <ExternalLink href={`mailto:${SUPPORT_EMAIL}`}>
-                      <Text>contact our support</Text>
-                    </ExternalLink>
-                    .
-                  </Text>
+        <Tabs
+          className={cx(styles.setTabs, 'navNoMarginBtm')}
+          defaultActiveKey={SavedFilterTag.ParticipantsExplorationPage}
+        >
+          <TabPane
+            key={SavedFilterTag.ParticipantsExplorationPage}
+            tab={
+              <div>
+                <FileSearchOutlined />
+                Data Exploration (
+                {
+                  savedFilters.filter((s) => s.tag === SavedFilterTag.ParticipantsExplorationPage)
+                    .length
                 }
-              />
-            ) : (
-              <Empty
-                imageType="grid"
-                description={intl.get('screen.dashboard.cards.savedFilters.noSavedFilters')}
-              />
-            ),
-          }}
-          dataSource={fetchingError ? [] : savedFilters}
-          loading={isLoading}
-          renderItem={(item) => <SavedFiltersListItem id={item.id} data={item} />}
-        />
+                )
+              </div>
+            }
+          >
+            <SavedFilterListWrapper
+              tag={SavedFilterTag.ParticipantsExplorationPage}
+              savedFilters={savedFilters}
+              fetchingError={fetchingError}
+              isLoading={isLoading}
+            />
+          </TabPane>
+
+          <TabPane
+            key={SavedFilterTag.VariantsExplorationPage}
+            tab={
+              <div>
+                <LineStyleIcon height={14} width={14} />
+                Variants (
+                {
+                  savedFilters.filter((s) => s.tag === SavedFilterTag.VariantsExplorationPage)
+                    .length
+                }
+                )
+              </div>
+            }
+          >
+            <SavedFilterListWrapper
+              tag={SavedFilterTag.VariantsExplorationPage}
+              savedFilters={savedFilters}
+              fetchingError={fetchingError}
+              isLoading={isLoading}
+            />
+          </TabPane>
+        </Tabs>
       }
     />
   );

--- a/src/views/Dashboard/components/DashboardCards/SavedSets/ListItem/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/SavedSets/ListItem/index.tsx
@@ -12,13 +12,16 @@ import { formatDistance } from 'date-fns';
 import { INDEXES } from 'graphql/constants';
 import { SetActionType } from 'views/DataExploration/components/SetsManagementDropdown';
 import {
-  DATA_EPLORATION_FILTER_TAG,
-  DATA_EXPLORATION_QB_ID,
+  BIOSPECIMENS_SAVED_SETS_FIELD,
+  DATA_FILES_SAVED_SETS_FIELD,
+  PARTICIPANTS_SAVED_SETS_FIELD,
 } from 'views/DataExploration/utils/constant';
+import { VARIANT_SAVED_SETS_FIELD } from 'views/Variants/utils/constants';
 
 import { IUserSetOutput } from 'services/api/savedSet/models';
 import { getSetFieldId } from 'store/savedSet';
 import { deleteSavedSet } from 'store/savedSet/thunks';
+import { STATIC_ROUTES } from 'utils/routes';
 
 import CreateEditModal from '../CreateEditModal';
 
@@ -27,6 +30,7 @@ import styles from './index.module.scss';
 interface OwnProps {
   data: IUserSetOutput;
   icon: ReactElement;
+  queryBuilderId: string;
 }
 
 const { Text } = Typography;
@@ -34,17 +38,32 @@ const { Text } = Typography;
 const redirectToPage = (setType: string) => {
   switch (setType) {
     case INDEXES.FILE:
-      return `${DATA_EPLORATION_FILTER_TAG}/datafiles`;
+      return STATIC_ROUTES.DATA_EXPLORATION_DATAFILES;
     case INDEXES.PARTICIPANT:
-      return `${DATA_EPLORATION_FILTER_TAG}/participants`;
+      return STATIC_ROUTES.DATA_EXPLORATION_PARTICIPANTS;
     case INDEXES.BIOSPECIMEN:
-      return `${DATA_EPLORATION_FILTER_TAG}/biospecimens`;
+      return STATIC_ROUTES.DATA_EXPLORATION_BIOSPECIMENS;
+    case INDEXES.VARIANTS:
+      return STATIC_ROUTES.VARIANTS;
     default:
-      return DATA_EPLORATION_FILTER_TAG;
+      return STATIC_ROUTES.DATA_EXPLORATION;
   }
 };
 
-const ListItem = ({ data, icon }: OwnProps) => {
+const getIdField = (setType: string) => {
+  switch (setType) {
+    case INDEXES.FILE:
+      return DATA_FILES_SAVED_SETS_FIELD;
+    case INDEXES.PARTICIPANT:
+      return PARTICIPANTS_SAVED_SETS_FIELD;
+    case INDEXES.BIOSPECIMEN:
+      return BIOSPECIMENS_SAVED_SETS_FIELD;
+    default:
+      return VARIANT_SAVED_SETS_FIELD;
+  }
+};
+
+const ListItem = ({ data, icon, queryBuilderId }: OwnProps) => {
   const [modalVisible, setModalVisible] = useState(false);
   const dispatch = useDispatch();
   const history = useHistory();
@@ -85,7 +104,7 @@ const ListItem = ({ data, icon }: OwnProps) => {
 
           const setValue = `${SET_ID_PREFIX}${data.id}`;
           addQuery({
-            queryBuilderId: DATA_EXPLORATION_QB_ID,
+            queryBuilderId: queryBuilderId,
             query: generateQuery({
               newFilters: [
                 generateValueFilter({
@@ -99,11 +118,16 @@ const ListItem = ({ data, icon }: OwnProps) => {
           });
         }}
         title={data.tag}
-        description={intl.get('screen.dashboard.cards.savedFilters.lastSaved', {
-          date: formatDistance(new Date(), new Date(data.updated_date)),
-        })}
+        description={
+          data.updated_date
+            ? intl.get('screen.dashboard.cards.savedFilters.lastSaved', {
+                date: formatDistance(new Date(), new Date(data.updated_date)),
+              })
+            : undefined
+        }
       />
       <CreateEditModal
+        idField={getIdField(data.setType)}
         title={intl.get('components.savedSets.modal.edit.title')}
         setType={data.setType}
         hideModalCb={onCancel}

--- a/src/views/Dashboard/components/DashboardCards/SavedSets/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/SavedSets/index.tsx
@@ -1,22 +1,27 @@
+import { ReactElement } from 'react';
+import intl from 'react-intl-universal';
+import { ExperimentOutlined, FileTextOutlined, UserOutlined } from '@ant-design/icons';
+import Empty from '@ferlab/ui/core/components/Empty';
+import ExternalLink from '@ferlab/ui/core/components/ExternalLink';
 import GridCard from '@ferlab/ui/core/view/v2/GridCard';
 import { List, Tabs, Typography } from 'antd';
-import intl from 'react-intl-universal';
-import { DashboardCardProps } from 'views/Dashboard/components/DashboardCards';
-import CardHeader from 'views/Dashboard/components/CardHeader';
-import Empty from '@ferlab/ui/core/components/Empty';
-import ListItem from './ListItem';
-import { ReactElement } from 'react';
-import { useSavedSet } from 'store/savedSet';
-import { IUserSetOutput, SetType } from 'services/api/savedSet/models';
-import CardErrorPlaceholder from 'views/Dashboard/components/CardErrorPlaceHolder';
-import ExternalLink from '@ferlab/ui/core/components/ExternalLink';
-import { ExperimentOutlined, FileTextOutlined, UserOutlined } from '@ant-design/icons';
 import cx from 'classnames';
-import { STATIC_ROUTES } from 'utils/routes';
+import CardErrorPlaceholder from 'views/Dashboard/components/CardErrorPlaceHolder';
+import CardHeader from 'views/Dashboard/components/CardHeader';
+import { DashboardCardProps } from 'views/Dashboard/components/DashboardCards';
+import { DATA_EXPLORATION_QB_ID } from 'views/DataExploration/utils/constant';
+import { VARIANT_REPO_QB_ID } from 'views/Variants/utils/constants';
+
+import LineStyleIcon from 'components/Icons/LineStyleIcon';
 import PopoverContentLink from 'components/uiKit/PopoverContentLink';
+import { IUserSetOutput, SetType } from 'services/api/savedSet/models';
+import { SUPPORT_EMAIL } from 'store/report/thunks';
+import { useSavedSet } from 'store/savedSet';
+import { STATIC_ROUTES } from 'utils/routes';
+
+import ListItem from './ListItem';
 
 import styles from './index.module.scss';
-import {SUPPORT_EMAIL} from "store/report/thunks";
 
 const { Text } = Typography;
 const { TabPane } = Tabs;
@@ -27,38 +32,37 @@ const getItemList = (
   fetchingError: boolean,
   isLoading: boolean,
   icon: ReactElement,
-) => {
-  return (
-    <List<IUserSetOutput>
-      className={styles.savedFiltersList}
-      bordered
-      locale={{
-        emptyText: fetchingError ? (
-          <CardErrorPlaceholder
-            title="Failed to Fetch Saved Filters"
-            subTitle={
-              <Text>
-                Please refresh and try again or{' '}
-                <ExternalLink href={`mailto:${SUPPORT_EMAIL}`}>
-                  <Text>contact our support</Text>
-                </ExternalLink>
-                .
-              </Text>
-            }
-          />
-        ) : (
-          <Empty
-            imageType="grid"
-            description={intl.get('screen.dashboard.cards.savedSets.noSavedFilters')}
-          />
-        ),
-      }}
-      dataSource={fetchingError ? [] : savedSets.filter((s) => s.setType === type)}
-      loading={isLoading}
-      renderItem={(item) => <ListItem data={item} icon={icon} />}
-    />
-  );
-};
+  queryBuilderId = DATA_EXPLORATION_QB_ID,
+) => (
+  <List<IUserSetOutput>
+    className={styles.savedSetsList}
+    bordered
+    locale={{
+      emptyText: fetchingError ? (
+        <CardErrorPlaceholder
+          title={intl.get('screen.dashboard.cards.savedSets.errorCard.failedToFetch')}
+          subTitle={
+            <Text>
+              {intl.get('screen.dashboard.cards.savedSets.errorCard.refresh')}{' '}
+              <ExternalLink href={`mailto:${SUPPORT_EMAIL}`}>
+                <Text>{intl.get('screen.dashboard.cards.savedSets.errorCard.contactSupport')}</Text>
+              </ExternalLink>
+              .
+            </Text>
+          }
+        />
+      ) : (
+        <Empty
+          imageType="grid"
+          description={intl.get('screen.dashboard.cards.savedSets.noSavedFilters')}
+        />
+      ),
+    }}
+    dataSource={fetchingError ? [] : savedSets.filter((s) => s.setType === type)}
+    loading={isLoading}
+    renderItem={(item) => <ListItem data={item} icon={icon} queryBuilderId={queryBuilderId} />}
+  />
+);
 
 const SavedSets = ({ id, key, className = '' }: DashboardCardProps) => {
   const { savedSets, isLoading, fetchingError } = useSavedSet();
@@ -137,6 +141,24 @@ const SavedSets = ({ id, key, className = '' }: DashboardCardProps) => {
             key="files"
           >
             {getItemList(SetType.FILE, savedSets, fetchingError, isLoading, <FileTextOutlined />)}
+          </TabPane>
+          <TabPane
+            tab={
+              <div>
+                <LineStyleIcon />
+                Variants ({savedSets.filter((s) => s.setType === SetType.VARIANT).length})
+              </div>
+            }
+            key="variants"
+          >
+            {getItemList(
+              SetType.VARIANT,
+              savedSets,
+              fetchingError,
+              isLoading,
+              <LineStyleIcon />,
+              VARIANT_REPO_QB_ID,
+            )}
           </TabPane>
         </Tabs>
       }

--- a/src/views/DataExploration/components/PageContent/tabs/Biospecimens/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Biospecimens/index.tsx
@@ -9,7 +9,6 @@ import useQueryBuilderState, {
 } from '@ferlab/ui/core/components/QueryBuilder/utils/useQueryBuilderState';
 import { ISqonGroupFilter } from '@ferlab/ui/core/data/sqon/types';
 import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/utils';
-import { SorterResult } from 'antd/lib/table/interface';
 import { IBiospecimenEntity } from 'graphql/biospecimens/models';
 import { INDEXES } from 'graphql/constants';
 import { IQueryResults } from 'graphql/models';
@@ -273,6 +272,7 @@ const BioSpecimenTab = ({ results, setQueryConfig, queryConfig, sqon }: OwnProps
           ),
         extra: [
           <SetsManagementDropdown
+            idField="fhir_id"
             key="setManagementDropdown"
             results={results}
             sqon={getCurrentSqon()}

--- a/src/views/DataExploration/components/PageContent/tabs/DataFiles/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/DataFiles/index.tsx
@@ -10,7 +10,6 @@ import useQueryBuilderState, {
 import { ISqonGroupFilter } from '@ferlab/ui/core/data/sqon/types';
 import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/utils';
 import { Tag, Tooltip } from 'antd';
-import { SorterResult } from 'antd/lib/table/interface';
 import { INDEXES } from 'graphql/constants';
 import { FileAccessType, IFileEntity, ITableFileEntity } from 'graphql/files/models';
 import { IQueryResults } from 'graphql/models';
@@ -327,6 +326,7 @@ const DataFilesTab = ({ results, setQueryConfig, queryConfig, sqon }: OwnProps) 
             ),
           extra: [
             <SetsManagementDropdown
+              idField="fhir_id"
               key="setManagementDropdown"
               results={results}
               sqon={getCurrentSqon()}

--- a/src/views/DataExploration/components/PageContent/tabs/Participants/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Participants/index.tsx
@@ -12,7 +12,6 @@ import ExpandableCell from '@ferlab/ui/core/components/tables/ExpandableCell';
 import { ISqonGroupFilter } from '@ferlab/ui/core/data/sqon/types';
 import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/utils';
 import { Tag, Tooltip } from 'antd';
-import { SorterResult } from 'antd/lib/table/interface';
 import { INDEXES } from 'graphql/constants';
 import { ArrangerResultsTree, IQueryResults } from 'graphql/models';
 import {
@@ -386,6 +385,7 @@ const ParticipantsTab = ({ results, setQueryConfig, queryConfig, sqon }: OwnProp
         onSelectedRowsChange: (keys) => setSelectedKeys(keys),
         extra: [
           <SetsManagementDropdown
+            idField="fhir_id"
             key="setManagementDropdown"
             results={results}
             selectedKeys={selectedKeys}

--- a/src/views/DataExploration/components/SetsManagementDropdown/AddRemoveSaveSetModal.tsx
+++ b/src/views/DataExploration/components/SetsManagementDropdown/AddRemoveSaveSetModal.tsx
@@ -1,18 +1,21 @@
 import { useState } from 'react';
-import { Form, Modal } from 'antd';
-import UserSetsForm from './UserSetForm';
-import { Store } from 'antd/lib/form/interface';
-import { SetActionType } from './index';
-import { ISqonGroupFilter } from '@ferlab/ui/core/data/sqon/types';
-import { IUserSetOutput, SetType } from 'services/api/savedSet/models';
-import { updateSavedSet } from 'store/savedSet/thunks';
-import { useDispatch } from 'react-redux';
-import { PROJECT_ID, useSavedSet } from 'store/savedSet';
 import intl from 'react-intl-universal';
+import { useDispatch } from 'react-redux';
+import { ISqonGroupFilter } from '@ferlab/ui/core/data/sqon/types';
+import { Form, Modal } from 'antd';
+import { Store } from 'antd/lib/form/interface';
+
+import { IUserSetOutput, SetType } from 'services/api/savedSet/models';
+import { PROJECT_ID, useSavedSet } from 'store/savedSet';
+import { updateSavedSet } from 'store/savedSet/thunks';
+
+import { SetActionType, singularizeSetTypeIfNeeded } from './index';
+import UserSetsForm from './UserSetForm';
 
 const FORM_NAME = 'add-remove-set';
 
 type OwnProps = {
+  idField: string;
   hideModalCb: Function;
   userSets: IUserSetOutput[];
   sqon?: ISqonGroupFilter;
@@ -34,15 +37,26 @@ const finishButtonText = (type: string) => {
 const formTitle = (setActionType: string, type: SetType) => {
   switch (setActionType) {
     case SetActionType.ADD_IDS:
-      return intl.get('components.savedSets.modal.add.title', { type });
+      return intl.get('components.savedSets.modal.add.title', {
+        type: singularizeSetTypeIfNeeded(type).toLocaleLowerCase(),
+      });
     case SetActionType.REMOVE_IDS:
-      return intl.get('components.savedSets.modal.remove.title', { type });
+      return intl.get('components.savedSets.modal.remove.title', {
+        type: singularizeSetTypeIfNeeded(type).toLocaleLowerCase(),
+      });
     default:
       break;
   }
 };
 
-const AddRemoveSaveSetModal = ({ hideModalCb, userSets, setActionType, sqon, type }: OwnProps) => {
+const AddRemoveSaveSetModal = ({
+  idField,
+  hideModalCb,
+  userSets,
+  setActionType,
+  sqon,
+  type,
+}: OwnProps) => {
   const [form] = Form.useForm();
   const [isVisible, setIsVisible] = useState(true);
   const [hasSetSelection, setHasSetSelection] = useState(false);
@@ -67,7 +81,7 @@ const AddRemoveSaveSetModal = ({ hideModalCb, userSets, setActionType, sqon, typ
           updateSavedSet({
             id: setId,
             subAction: setActionType,
-            idField: 'fhir_id',
+            idField,
             projectId: PROJECT_ID,
             sqon: sqon!,
             onCompleteCb: onSuccessCreateCb,

--- a/src/views/DataExploration/utils/constant.ts
+++ b/src/views/DataExploration/utils/constant.ts
@@ -1,6 +1,8 @@
 import { IQueryConfig } from 'common/searchPageTypes';
 
+export const PARTICIPANTS_SAVED_SETS_FIELD = 'participant_id';
 export const DATA_FILES_SAVED_SETS_FIELD = 'file_id';
+export const BIOSPECIMENS_SAVED_SETS_FIELD = 'sample_id';
 
 export const DATA_EXPLORATION_QB_ID = 'data-exploration-repo-key';
 


### PR DESCRIPTION
# BUG
- close #[392](https://d3b.atlassian.net/browse/SJIP-392)

Descriptions
Goal: Add variants to saved sets and saved filters as it is done in KF-QA-Next. 

Saved Filters: Add a tab for Data Exploration and Variants. If a user saves a filter on the respective page, it will update the corresponding tab in the Saved Filters widget.

Saved Sets: Add Variants tab to the Saved Sets, if a user selects X variants in the Variants page, and saves them, it will save them in the set


## Screenshots
![image](https://user-images.githubusercontent.com/65532894/235516640-99e6b55e-e530-4792-92f8-53812c6a2fc3.png)
