### PR TITLE
fix(sets): SJIP-345 change icons

### DIFF
--- a/src/components/Icons/ListAddIcon.tsx
+++ b/src/components/Icons/ListAddIcon.tsx
@@ -1,0 +1,21 @@
+import Icon from '@ant-design/icons';
+
+import { IconProps } from '.';
+
+const ListAddIcon = (props: IconProps) => (
+  <Icon {...props}>
+    <svg viewBox="0 0 16 16" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M1.33333 4H9.33333V5.33333H1.33333V4ZM1.33333 6.66667H9.33333V8H1.33333V6.66667ZM12 9.33333V6.66667H10.6667V9.33333H7.99999V10.6667H10.6667V13.3333H12V10.6667H14.6667V9.33333H12ZM6.66666 10.6667H1.33333V9.33333H6.66666V10.6667Z"
+      />
+    </svg>
+  </Icon>
+);
+
+ListAddIcon.defaultProps = {
+  viewBox: '0 0 1024 1024',
+};
+
+export default ListAddIcon;

--- a/src/components/Icons/ListRemoveIcon.tsx
+++ b/src/components/Icons/ListRemoveIcon.tsx
@@ -1,0 +1,21 @@
+import Icon from '@ant-design/icons';
+
+import { IconProps } from '.';
+
+const ListRemoveIcon = (props: IconProps) => (
+  <Icon {...props}>
+    <svg viewBox="0 0 16 16" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M1.33333 4H9.33333V5.33333H1.33333V4ZM1.33333 6.66667H9.33333V8H1.33333V6.66667ZM13.2596 9.87892L12.4111 9.03039L10.714 10.7274L9.01698 9.03039L8.16845 9.87892L9.86551 11.576L8.16845 13.273L9.01698 14.1216L10.714 12.4245L12.4111 14.1216L13.2596 13.273L11.5626 11.576L13.2596 9.87892ZM6.66666 10.6667H1.33333V9.33333H6.66666V10.6667Z"
+      />
+    </svg>
+  </Icon>
+);
+
+ListRemoveIcon.defaultProps = {
+  viewBox: '0 0 1024 1024',
+};
+
+export default ListRemoveIcon;

--- a/src/views/DataExploration/components/SetsManagementDropdown/index.tsx
+++ b/src/views/DataExploration/components/SetsManagementDropdown/index.tsx
@@ -6,8 +6,6 @@ import {
   FileTextOutlined,
   InfoCircleOutlined,
   PlusOutlined,
-  UsergroupAddOutlined,
-  UsergroupDeleteOutlined,
   UserOutlined,
 } from '@ant-design/icons';
 import { ISqonGroupFilter } from '@ferlab/ui/core/data/sqon/types';
@@ -21,6 +19,8 @@ import { MenuClickEventHandler } from 'rc-menu/lib/interface';
 import CreateEditModal from 'views/Dashboard/components/DashboardCards/SavedSets/CreateEditModal';
 
 import LineStyleIcon from 'components/Icons/LineStyleIcon';
+import ListAddIcon from 'components/Icons/ListAddIcon';
+import ListRemoveIcon from 'components/Icons/ListRemoveIcon';
 import { SetType } from 'services/api/savedSet/models';
 import { useSavedSet } from 'store/savedSet';
 import { numberWithCommas } from 'utils/string';
@@ -144,13 +144,13 @@ const menu = (
       },
       {
         key: 'add_ids',
-        icon: <UsergroupAddOutlined />,
+        icon: <ListAddIcon />,
         label: intl.get('screen.dataExploration.setsManagementDropdown.add'),
         disabled: isEditDisabled,
       },
       {
         key: 'remove_ids',
-        icon: <UsergroupDeleteOutlined />,
+        icon: <ListRemoveIcon />,
         label: intl.get('screen.dataExploration.setsManagementDropdown.remove'),
         disabled: isEditDisabled,
       },


### PR DESCRIPTION
# FIX
- close https://d3b.atlassian.net/browse/SJIP-345

# Description
Goal: Currently, we have the functionality of adding and removing saved sets across participants, biospecimen, and files. However, the icon illustrating these actions only represents a “participant” icon. We should replace this icon with a “list” icon that will be applied globally to the Participants, Biospecimen, Data files tab, and eventually for the variants page once we have the saved sets implemented. Ensure the icons matches the INCLUDE theme. 

![image](https://user-images.githubusercontent.com/65532894/235935978-02d89d95-02bc-4ca3-a2e0-095c8a79424a.png)

![image](https://user-images.githubusercontent.com/65532894/235935937-e54f9f86-ead3-4cf7-8796-83a5307fecdc.png)
