### PR TITLE
fix(variant): SJIP-394 fix text colors

### DIFF
--- a/src/views/VariantEntity/SummaryHeader/index.module.scss
+++ b/src/views/VariantEntity/SummaryHeader/index.module.scss
@@ -54,7 +54,7 @@
 }
 
 .text {
-  color: $body-2;
+  color: $gray-7;
   line-height: 32px;
   margin-top: 4px;
 }


### PR DESCRIPTION
# BUG 

- closes #[394](https://d3b.atlassian.net/browse/SJIP-394)

## Description
La couleur des mots (Study, Participants) devrait être gray-7

Acceptance Criterias

## Screenshot 
### Before
![image](https://user-images.githubusercontent.com/65532894/235996314-68ac4da7-4fdd-479e-b282-7205203906ae.png)

### After
![image](https://user-images.githubusercontent.com/65532894/235996068-c378e3bc-1ac0-44a5-928a-9cdc5b198892.png)

