### PR TITLE
fix(hpobrowser): SJIP-352 allow / to be searched

### DIFF
--- a/src/views/DataExploration/components/TreeFacet/helpers.tsx
+++ b/src/views/DataExploration/components/TreeFacet/helpers.tsx
@@ -1,6 +1,7 @@
-import { TreeNode } from 'views/DataExploration/utils/OntologyTree';
-import TreeNodeTitle from './TreeNodeTitle';
 import { Typography } from 'antd';
+import { TreeNode } from 'views/DataExploration/utils/OntologyTree';
+
+import TreeNodeTitle from './TreeNodeTitle';
 
 import styles from './index.module.scss';
 
@@ -56,7 +57,7 @@ export const searchInTree = (
   treeNode: TreeNode,
   hitTreeNodes: string[] = [],
 ) => {
-  const cleanSearchText = searchText.replace(/[-/\\^$*+?.()|[\]{}]/g, '');
+  const cleanSearchText = searchText.replace(/[-\\^$*+?.()|[\]{}]/g, '');
   const regex = new RegExp('\\b(\\w*' + cleanSearchText + '\\w*)\\b', 'gi');
   const text = treeNode.title;
   const key = treeNode.key;
@@ -82,11 +83,11 @@ export const searchInTree = (
       const [before, hit, after] = treeNode.title.split(regex);
       if (hit) {
         treeNode.name = (
-            <Typography.Text>
-              {before}
-              <div className={styles.highlight}>{hit}</div>
-              {after}
-            </Typography.Text>
+          <Typography.Text>
+            {before}
+            <div className={styles.highlight}>{hit}</div>
+            {after}
+          </Typography.Text>
         );
       }
     }


### PR DESCRIPTION
# BUG 

- closes #[352](https://d3b.atlassian.net/browse/SJIP-352)

## Description
Issue: Currently, the HPO/MONDO browsers do not seem to accept “/”. The search request becomes null as soon as a letter is added after inputting “/”. Aplasia/Hypoplasia of the breasts (HP:0010311) can be used an example. 

The Search input should be able to accept “/”. 

This error is seen across KF and INCLUDE

## Screenshot 
![image](https://user-images.githubusercontent.com/65532894/236026090-c5d51a9c-4768-424b-b706-6033688743b2.png)


