### PR TITLE
fix(gene): SJIP-398 fix gene without alias

### DIFF
--- a/src/views/Variants/components/GeneUploadIds/index.tsx
+++ b/src/views/Variants/components/GeneUploadIds/index.tsx
@@ -97,11 +97,11 @@ const GenesUploadIds = ({ queryBuilderId }: OwnProps) => (
       return genes?.flatMap((gene) => {
         const matchedIds: string[] = ids.filter((id: string) => {
           const lowerCaseId = id.toLocaleLowerCase();
-          const lowerCaseAliases = gene.alias.map((alias) => alias.toLocaleLowerCase());
+          const lowerCaseAliases = (gene.alias || []).map((alias) => alias.toLocaleLowerCase());
 
           return (
-            gene.symbol.toLocaleLowerCase() === lowerCaseId ||
-            gene.ensembl_gene_id.toLocaleLowerCase() === lowerCaseId ||
+            gene.symbol?.toLocaleLowerCase() === lowerCaseId ||
+            gene.ensembl_gene_id?.toLocaleLowerCase() === lowerCaseId ||
             lowerCaseAliases.includes(lowerCaseId)
           );
         });


### PR DESCRIPTION
# BUG

- closes #[398](https://d3b.atlassian.net/browse/SJIP-398)

## Description
Dans l’upload gene list de la page des variants, tenter de loader ce fichier ou copier/coller la liste de gènes.


## Screenshot 
### Before
![image](https://user-images.githubusercontent.com/65532894/236477615-578fc645-e345-470b-b1fd-4313e132da28.png)

### After
https://user-images.githubusercontent.com/65532894/236477670-e13d7b07-c6c0-4115-b8c5-0e6e8f585322.mp4


