### PR TITLE
fix(facet): SJIP-409 change study id to study code

### DIFF
--- a/src/utils/translation.ts
+++ b/src/utils/translation.ts
@@ -5,6 +5,7 @@ import { IDictionary as QueryBuilderDict } from '@ferlab/ui/core/components/Quer
 import { SET_ID_PREFIX } from '@ferlab/ui/core/data/sqon/types';
 
 import { IUserSetOutput } from 'services/api/savedSet/models';
+
 import { numberWithCommas } from './string';
 
 export const getEntityExpandableTableMultiple = () => ({
@@ -239,6 +240,7 @@ export const getQueryBuilderDictionary = (
 });
 
 export const getFacetsDictionary = () => ({
+  study_id: 'Study Code',
   study: {
     study_name: 'Study Name',
     study_code: 'Study Code',


### PR DESCRIPTION
# BUG

- closes #[409](https://d3b.atlassian.net/browse/SJIP-409)

## Description
Issue: Use the term “Study Code” in the facet instead of “Study Id” similar to how it is in done in the query pill below.  We want to show the Study Codes that look like : DS-COG-ALL, DS-Sleep, ABC-DS, X01-Hakon, HTP, etc. . Not to be confused with the operational study codes that CHOP uses internally (SD____). These operational study codes should not be displayed as they mean nothing to the public 

## Screenshot 
### Before
![image](https://user-images.githubusercontent.com/65532894/236909990-7e1cdb75-17c1-4d20-bafc-1f1a2c575094.png)

### After
![image](https://user-images.githubusercontent.com/65532894/236909970-28742bdd-d242-4557-a955-3bf8e291382d.png)


