### PR TITLE
feat(entity): SJIP-423 add table extra and redirect link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@apollo/client": "^3.5.10",
         "@dnd-kit/core": "^4.0.3",
         "@dnd-kit/sortable": "^5.1.0",
-        "@ferlab/ui": "^7.0.1",
+        "@ferlab/ui": "^7.2.0",
         "@loadable/component": "^5.15.2",
         "@nivo/bar": "^0.79.1",
         "@nivo/pie": "^0.79.1",
@@ -2742,9 +2742,9 @@
       }
     },
     "node_modules/@ferlab/ui": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-7.0.1.tgz",
-      "integrity": "sha512-QG0CgGidKmu733jTLG9JHRtOE7sp49BubbGbBR5/utm8I7e9RwtaS7IpZVzeKy9wvEzbY+SQrQ9IhKotAP0z0w==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-7.2.0.tgz",
+      "integrity": "sha512-rifHDa+3uQoi8gfxQU8ncP6z4WSzpqRxDuEdoKjhnJNeagni1+HveuTHcuMyXan5PX9BlTCKBOd/E4qrqpLcLg==",
       "dependencies": {
         "@ant-design/icons": "^4.7.0",
         "@dnd-kit/core": "^4.0.3",
@@ -23288,9 +23288,9 @@
       "requires": {}
     },
     "@ferlab/ui": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-7.0.1.tgz",
-      "integrity": "sha512-QG0CgGidKmu733jTLG9JHRtOE7sp49BubbGbBR5/utm8I7e9RwtaS7IpZVzeKy9wvEzbY+SQrQ9IhKotAP0z0w==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-7.2.0.tgz",
+      "integrity": "sha512-rifHDa+3uQoi8gfxQU8ncP6z4WSzpqRxDuEdoKjhnJNeagni1+HveuTHcuMyXan5PX9BlTCKBOd/E4qrqpLcLg==",
       "requires": {
         "@ant-design/icons": "^4.7.0",
         "@dnd-kit/core": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@apollo/client": "^3.5.10",
     "@dnd-kit/core": "^4.0.3",
     "@dnd-kit/sortable": "^5.1.0",
-    "@ferlab/ui": "^7.0.1",
+    "@ferlab/ui": "^7.2.0",
     "@loadable/component": "^5.15.2",
     "@nivo/bar": "^0.79.1",
     "@nivo/pie": "^0.79.1",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -100,6 +100,7 @@ const en = {
       selected: 'item selected',
       selectedPlural: 'items selected',
     },
+    viewInDataExploration: 'View in data exploration',
   },
   // API
   api: {

--- a/src/views/FileEntity/index.tsx
+++ b/src/views/FileEntity/index.tsx
@@ -1,7 +1,17 @@
 import intl from 'react-intl-universal';
 import { useParams } from 'react-router-dom';
-import EntityPage, { EntityDescriptions } from '@ferlab/ui/core/pages/EntityPage';
+import { addQuery } from '@ferlab/ui/core/components/QueryBuilder/utils/useQueryBuilderState';
+import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/utils';
+import EntityPage, {
+  EntityDescriptions,
+  EntityTableRedirectLink,
+} from '@ferlab/ui/core/pages/EntityPage';
+import { INDEXES } from 'graphql/constants';
 import { useFileEntity } from 'graphql/files/actions';
+import { DATA_EXPLORATION_QB_ID } from 'views/DataExploration/utils/constant';
+
+import ExternalLinkIcon from 'components/Icons/ExternalLinkIcon';
+import { STATIC_ROUTES } from 'utils/routes';
 
 import { getLinks, SectionId } from './utils/anchorLinks';
 import getDataAccessItems from './utils/getDataAccessItems';
@@ -48,6 +58,30 @@ export default function FileEntity() {
         loading={loading}
         descriptions={getDataTypeItems(file)}
         title={intl.get('entities.file.data_type')}
+        titleExtra={[
+          <EntityTableRedirectLink
+            key="1"
+            to={STATIC_ROUTES.DATA_EXPLORATION_PARTICIPANTS}
+            onClick={() =>
+              addQuery({
+                queryBuilderId: DATA_EXPLORATION_QB_ID,
+                query: generateQuery({
+                  newFilters: [
+                    generateValueFilter({
+                      field: 'file_id',
+                      value: file ? [file.file_id] : [],
+                      index: INDEXES.FILE,
+                    }),
+                  ],
+                }),
+                setAsActive: true,
+              })
+            }
+            icon={<ExternalLinkIcon width={14} />}
+          >
+            {intl.get('global.viewInDataExploration')}
+          </EntityTableRedirectLink>,
+        ]}
         header={intl.get('entities.file.data_type')}
       />
 

--- a/src/views/ParticipantEntity/BiospecimenTable/index.tsx
+++ b/src/views/ParticipantEntity/BiospecimenTable/index.tsx
@@ -1,11 +1,17 @@
 import intl from 'react-intl-universal';
 import { useDispatch } from 'react-redux';
-import { EntityTable } from '@ferlab/ui/core/pages/EntityPage';
+import { addQuery } from '@ferlab/ui/core/components/QueryBuilder/utils/useQueryBuilderState';
+import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/utils';
+import { EntityTable, EntityTableRedirectLink } from '@ferlab/ui/core/pages/EntityPage';
+import { INDEXES } from 'graphql/constants';
 import { IParticipantEntity } from 'graphql/participants/models';
+import { DATA_EXPLORATION_QB_ID } from 'views/DataExploration/utils/constant';
 
 import DownloadDataButton from 'components/Biospecimens/DownloadDataButton';
+import ExternalLinkIcon from 'components/Icons/ExternalLinkIcon';
 import { useUser } from 'store/user';
 import { updateUserConfig } from 'store/user/thunks';
+import { STATIC_ROUTES } from 'utils/routes';
 
 import { SectionId } from '../utils/anchorLinks';
 import { getBiospecimenColumns, getBiospecimensFromParticipant } from '../utils/biospecimens';
@@ -27,6 +33,30 @@ const BiospecimenTable = ({ participant, loading }: OwnProps) => {
       loading={loading}
       data={biospecimens}
       title={intl.get('entities.biospecimen.biospecimen')}
+      titleExtra={[
+        <EntityTableRedirectLink
+          key="1"
+          to={STATIC_ROUTES.DATA_EXPLORATION_BIOSPECIMENS}
+          icon={<ExternalLinkIcon width={14} />}
+          onClick={() =>
+            addQuery({
+              queryBuilderId: DATA_EXPLORATION_QB_ID,
+              query: generateQuery({
+                newFilters: [
+                  generateValueFilter({
+                    field: 'participant_id',
+                    value: participant ? [participant.participant_id] : [],
+                    index: INDEXES.PARTICIPANT,
+                  }),
+                ],
+              }),
+              setAsActive: true,
+            })
+          }
+        >
+          {intl.get('global.viewInDataExploration')}
+        </EntityTableRedirectLink>,
+      ]}
       header={intl.get('entities.biospecimen.biospecimen')}
       columns={getBiospecimenColumns()}
       initialColumnState={userInfo?.config.participants?.tables?.biospecimens?.columns}

--- a/src/views/ParticipantEntity/FileTable/index.tsx
+++ b/src/views/ParticipantEntity/FileTable/index.tsx
@@ -1,7 +1,14 @@
 import intl from 'react-intl-universal';
-import { EntityTableMultiple } from '@ferlab/ui/core/pages/EntityPage';
+import { addQuery } from '@ferlab/ui/core/components/QueryBuilder/utils/useQueryBuilderState';
+import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/utils';
+import { EntityTableMultiple, EntityTableRedirectLink } from '@ferlab/ui/core/pages/EntityPage';
+import { INDEXES } from 'graphql/constants';
 import { IFileEntity } from 'graphql/files/models';
 import { IParticipantEntity } from 'graphql/participants/models';
+import { DATA_EXPLORATION_QB_ID } from 'views/DataExploration/utils/constant';
+
+import ExternalLinkIcon from 'components/Icons/ExternalLinkIcon';
+import { STATIC_ROUTES } from 'utils/routes';
 
 import { SectionId } from '../utils/anchorLinks';
 import { getDataCategoryColumns, getDataCategoryInfo } from '../utils/dataCategory';
@@ -30,6 +37,30 @@ const FileTable = ({ participant, loading }: IFilesTableProps) => {
         id={SectionId.FILES}
         loading={loading}
         title={intl.get('entities.file.file')}
+        titleExtra={[
+          <EntityTableRedirectLink
+            key="1"
+            to={STATIC_ROUTES.DATA_EXPLORATION_DATAFILES}
+            onClick={() =>
+              addQuery({
+                queryBuilderId: DATA_EXPLORATION_QB_ID,
+                query: generateQuery({
+                  newFilters: [
+                    generateValueFilter({
+                      field: 'participant_id',
+                      value: participant ? [participant.participant_id] : [],
+                      index: INDEXES.PARTICIPANT,
+                    }),
+                  ],
+                }),
+                setAsActive: true,
+              })
+            }
+            icon={<ExternalLinkIcon width={14} />}
+          >
+            {intl.get('global.viewInDataExploration')}
+          </EntityTableRedirectLink>,
+        ]}
         header={intl.get('entities.file.file')}
         tables={[
           {


### PR DESCRIPTION
#  FEATURE

- closes #[423](https://d3b.atlassian.net/browse/SJIP-423)

## Description
 Similar to the Statistic buttons that are used to redirect to the Data Exploration, we will add a button “View in data exploration” on the right side of the table title for the respective entities. The filter to the Data Exploration page will be the same as the filters in the statistic button for the respective entity. 

Participant Entity tables:

Biospecimen (query = Participant ID, tab = Biospecimens)

Data File (query = Participant ID, tab = Data Files)

File Entity tables:

Participant / Sample  (query = File ID, tab = Participants)

## Screenshot
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/7cf8b818-8e92-480d-8a6e-18d2a58e7e71)
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/8eced0bf-84dd-43b0-aa08-e03e5354713e)
![image](https://github.com/Ferlab-Ste-Justine/ferlab-ui/assets/65532894/ce282882-576f-4a58-880c-786b1b36d2c0)


## Mention
@luclemo @kstonge

