### PR TITLE
feat(entity): SJIP-414 add entity table total

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@apollo/client": "^3.5.10",
         "@dnd-kit/core": "^4.0.3",
         "@dnd-kit/sortable": "^5.1.0",
-        "@ferlab/ui": "^7.2.0",
+        "@ferlab/ui": "^7.3.0",
         "@loadable/component": "^5.15.2",
         "@nivo/bar": "^0.79.1",
         "@nivo/pie": "^0.79.1",
@@ -2742,9 +2742,9 @@
       }
     },
     "node_modules/@ferlab/ui": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-7.2.0.tgz",
-      "integrity": "sha512-rifHDa+3uQoi8gfxQU8ncP6z4WSzpqRxDuEdoKjhnJNeagni1+HveuTHcuMyXan5PX9BlTCKBOd/E4qrqpLcLg==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-7.3.0.tgz",
+      "integrity": "sha512-uiWrMGEm4XJ6ddVb/BFYn37UpHGkR6W+w92fgIaUKn1QmS8h7SGo0g0CAJYlwiW2db5yGDnda4RDfmQwi05KyA==",
       "dependencies": {
         "@ant-design/icons": "^4.7.0",
         "@dnd-kit/core": "^4.0.3",
@@ -23288,9 +23288,9 @@
       "requires": {}
     },
     "@ferlab/ui": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-7.2.0.tgz",
-      "integrity": "sha512-rifHDa+3uQoi8gfxQU8ncP6z4WSzpqRxDuEdoKjhnJNeagni1+HveuTHcuMyXan5PX9BlTCKBOd/E4qrqpLcLg==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-7.3.0.tgz",
+      "integrity": "sha512-uiWrMGEm4XJ6ddVb/BFYn37UpHGkR6W+w92fgIaUKn1QmS8h7SGo0g0CAJYlwiW2db5yGDnda4RDfmQwi05KyA==",
       "requires": {
         "@ant-design/icons": "^4.7.0",
         "@dnd-kit/core": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@apollo/client": "^3.5.10",
     "@dnd-kit/core": "^4.0.3",
     "@dnd-kit/sortable": "^5.1.0",
-    "@ferlab/ui": "^7.2.0",
+    "@ferlab/ui": "^7.3.0",
     "@loadable/component": "^5.15.2",
     "@nivo/bar": "^0.79.1",
     "@nivo/pie": "^0.79.1",

--- a/src/views/FileEntity/BiospecimenTable/index.tsx
+++ b/src/views/FileEntity/BiospecimenTable/index.tsx
@@ -25,6 +25,7 @@ const BiospecimenTable = ({ file, loading }: OwnProps) => {
       id={SectionId.PARTICIPANT_SAMPLE}
       loading={loading}
       data={biospecimens}
+      total={biospecimens.length}
       title={intl.get('entities.file.participant_sample')}
       header={intl.get('entities.file.participant_sample')}
       columns={getBiospecimenColumns()}

--- a/src/views/ParticipantEntity/BiospecimenTable/index.tsx
+++ b/src/views/ParticipantEntity/BiospecimenTable/index.tsx
@@ -25,7 +25,7 @@ const BiospecimenTable = ({ participant, loading }: OwnProps) => {
   const { userInfo } = useUser();
   const dispatch = useDispatch();
 
-  const { biospecimens } = getBiospecimensFromParticipant(participant);
+  const { biospecimens, total } = getBiospecimensFromParticipant(participant);
 
   return (
     <EntityTable
@@ -57,6 +57,7 @@ const BiospecimenTable = ({ participant, loading }: OwnProps) => {
           {intl.get('global.viewInDataExploration')}
         </EntityTableRedirectLink>,
       ]}
+      total={total}
       header={intl.get('entities.biospecimen.biospecimen')}
       columns={getBiospecimenColumns()}
       initialColumnState={userInfo?.config.participants?.tables?.biospecimens?.columns}

--- a/src/views/ParticipantEntity/DiagnosisTable/index.tsx
+++ b/src/views/ParticipantEntity/DiagnosisTable/index.tsx
@@ -26,6 +26,7 @@ const DiagnosisTable = ({ participant, loading }: OwnProps) => {
       id={SectionId.DIAGNOSIS}
       loading={loading}
       data={diagnoses}
+      total={diagnoses.length}
       title={intl.get('entities.participant.diagnosis')}
       header={intl.get('entities.participant.diagnosis')}
       columns={getDiagnosisColumns()}

--- a/src/views/ParticipantEntity/FileTable/index.tsx
+++ b/src/views/ParticipantEntity/FileTable/index.tsx
@@ -34,6 +34,7 @@ const FileTable = ({ participant, loading }: IFilesTableProps) => {
   return (
     <div>
       <EntityTableMultiple
+        total={fileCount}
         id={SectionId.FILES}
         loading={loading}
         title={intl.get('entities.file.file')}

--- a/src/views/ParticipantEntity/PhenotypeTable/index.tsx
+++ b/src/views/ParticipantEntity/PhenotypeTable/index.tsx
@@ -26,6 +26,7 @@ const PhenotypeTable = ({ participant, loading }: OwnProps) => {
       id={SectionId.PHENOTYPE}
       loading={loading}
       data={phenotype}
+      total={phenotype.length}
       title={intl.get('entities.participant.phenotype')}
       header={intl.get('entities.participant.phenotype')}
       columns={getPhenotypeColumns()}


### PR DESCRIPTION
# FEATURE

- closes #[414](https://d3b.atlassian.net/browse/SJIP-414)

## Description
Goal:  Add number of total row items per table and place it beside the respective Table titles. 

This applies to the Diagnosis, Phenotype, Biospecimen Data File in Participant Entity page. 

This applies to the Participant / Sample table in the File Entity page

In the case of Data files table, since the files are not enumerated per row, take the total number of files associated with the Entity. 

Do not indicate the number “0” beside the table title if there is no data in the table.

## Screenshot 
![image](https://github.com/include-dcc/include-portal-ui/assets/65532894/cce2a627-ff9b-49b4-bb36-d1cd89a5123b)
![image](https://github.com/include-dcc/include-portal-ui/assets/65532894/22bdb88c-5b08-472c-9a2a-4177ff06a6ab)
![image](https://github.com/include-dcc/include-portal-ui/assets/65532894/b09e56c4-5cb3-45ab-a126-b27d77ce7d53)


