### PR TITLE
fix: SJIP-360 condition source text same for phenotype and diagnosis

### DIFF
--- a/src/graphql/participants/queries.ts
+++ b/src/graphql/participants/queries.ts
@@ -179,6 +179,7 @@ export const GET_PARTICIPANT_ENTITY = gql`
                     fhir_id
                     hpo_phenotype_observed
                     observed
+                    source_text
                   }
                 }
               }

--- a/src/views/ParticipantEntity/utils/getPhenotypeColumns.tsx
+++ b/src/views/ParticipantEntity/utils/getPhenotypeColumns.tsx
@@ -31,13 +31,8 @@ const getPhenotypeColumns = (): ProColumnType[] => [
   },
   {
     key: 'source_text',
-    dataIndex: 'hpo_phenotype_observed',
+    dataIndex: 'source_text',
     title: intl.get('entities.participant.source_text'),
-    render: (hpo_phenotype_observed: string) => {
-      const phenotypeInfo = extractPhenotypeTitleAndCode(hpo_phenotype_observed);
-
-      return phenotypeInfo?.title || TABLE_EMPTY_PLACE_HOLDER;
-    },
   },
   {
     key: 'age_at_event_days',


### PR DESCRIPTION
#Condition Source Text should be the same for Phenotype and Diagnosis
- closes [SJIP-360](https://d3b.atlassian.net/browse/SJIP-360)

## Description

Phenotype source text should be the same a diagnosis source text

## Validation

- [ ] Code Approved
- [ ] QA Done


## Screenshot 
patient for testing : pt-4ijygj6gkk
### Before
![image](https://github.com/include-dcc/include-portal-ui/assets/29788342/47abcb4a-cf85-4b4c-b725-1de63f490cc6)


### After
![image](https://github.com/include-dcc/include-portal-ui/assets/29788342/cddd44fd-8527-4f7b-aff0-84dbaae8bcf3)


## QA

Steps to validate
Url (storybook, ...)
...

## Mention

@ QA, Design ...
