### PR TITLE
fix(number): SJIP-397 add thousand separator

### DIFF
--- a/src/graphql/studies/models.ts
+++ b/src/graphql/studies/models.ts
@@ -1,4 +1,4 @@
-import { ArrangerResultsTree } from "graphql/models";
+import { ArrangerResultsTree } from 'graphql/models';
 
 export interface IStudyResultTree {
   study: ArrangerResultsTree<IStudyEntity>;
@@ -14,6 +14,6 @@ export interface IStudyEntity {
   family_count: number;
   participant_count: number;
   biospecimen_count: number;
-  data_category: string[]
+  data_category: string[];
   website: string;
 }

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,6 +1,5 @@
 export const truncateString = (text: string, maxLength: number) =>
   `${text.substring(0, maxLength)}${text.length > maxLength ? '...' : ''}`;
 
-export const numberWithCommas = (number: number) => {
-  return number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
-};
+export const numberWithCommas = (number: number) =>
+  number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');

--- a/src/views/Community/index.tsx
+++ b/src/views/Community/index.tsx
@@ -8,6 +8,7 @@ import { MAIN_SCROLL_WRAPPER_ID } from 'common/constants';
 import { UserApi } from 'services/api/user';
 import { TUser } from 'services/api/user/models';
 import { scrollToTop } from 'utils/helper';
+import { numberWithCommas } from 'utils/string';
 
 import FiltersBox from './components/Filters/Box';
 import { SortItems } from './components/Filters/Sorter';
@@ -72,6 +73,7 @@ const CommunityPage = () => {
               selected: '',
               selectedPlural: '',
             },
+            numberFormat: numberWithCommas,
           }}
         ></TableHeader>
         <List

--- a/src/views/Dashboard/components/DashboardCards/SavedSets/ListItem/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/SavedSets/ListItem/index.tsx
@@ -22,6 +22,7 @@ import { IUserSetOutput } from 'services/api/savedSet/models';
 import { getSetFieldId } from 'store/savedSet';
 import { deleteSavedSet } from 'store/savedSet/thunks';
 import { STATIC_ROUTES } from 'utils/routes';
+import { numberWithCommas } from 'utils/string';
 
 import CreateEditModal from '../CreateEditModal';
 
@@ -92,7 +93,7 @@ const ListItem = ({ data, icon, queryBuilderId }: OwnProps) => {
         extra={
           <Row gutter={8} className={styles.countDisplay}>
             <Col>
-              <Text className={styles.count}>{data.size}</Text>
+              <Text className={styles.count}>{numberWithCommas(data.size)}</Text>
             </Col>
             <Col>
               <Text type="secondary">{icon}</Text>

--- a/src/views/ParticipantEntity/DiagnosisTable/MondoParticipantCount.tsx
+++ b/src/views/ParticipantEntity/DiagnosisTable/MondoParticipantCount.tsx
@@ -6,6 +6,7 @@ import { useParticipantsFromField } from 'graphql/participants/actions';
 import { DATA_EXPLORATION_QB_ID } from 'views/DataExploration/utils/constant';
 
 import { STATIC_ROUTES } from 'utils/routes';
+import { numberWithCommas } from 'utils/string';
 
 interface OwnProps {
   diagnosis: string;
@@ -36,7 +37,7 @@ const MondoParticipantCount = ({ diagnosis }: OwnProps) => {
         })
       }
     >
-      {total}
+      {numberWithCommas(total)}
     </Link>
   );
 };

--- a/src/views/ParticipantEntity/PhenotypeTable/HpoParticipantCount.tsx
+++ b/src/views/ParticipantEntity/PhenotypeTable/HpoParticipantCount.tsx
@@ -6,6 +6,7 @@ import { useParticipantsFromField } from 'graphql/participants/actions';
 import { DATA_EXPLORATION_QB_ID } from 'views/DataExploration/utils/constant';
 
 import { STATIC_ROUTES } from 'utils/routes';
+import { numberWithCommas } from 'utils/string';
 
 interface OwnProps {
   phenotype: string;
@@ -36,7 +37,7 @@ const HpoParticipantCount = ({ phenotype }: OwnProps) => {
         })
       }
     >
-      {total}
+      {numberWithCommas(total)}
     </Link>
   );
 };

--- a/src/views/Studies/index.tsx
+++ b/src/views/Studies/index.tsx
@@ -15,6 +15,7 @@ import { DATA_EXPLORATION_QB_ID } from 'views/DataExploration/utils/constant';
 
 import { TABLE_EMPTY_PLACE_HOLDER } from 'common/constants';
 import { STATIC_ROUTES } from 'utils/routes';
+import { numberWithCommas } from 'utils/string';
 import { getProTableDictionary } from 'utils/translation';
 
 import StudyPopoverRedirect from '../DataExploration/components/StudyPopoverRedirect';
@@ -99,7 +100,7 @@ const columns: ProColumnType<any>[] = [
             })
           }
         >
-          {participantCount}
+          {numberWithCommas(participantCount)}
         </Link>
       ) : (
         participantCount || 0
@@ -110,6 +111,8 @@ const columns: ProColumnType<any>[] = [
     key: 'family_count',
     title: 'Families',
     dataIndex: 'family_count',
+    render: (family_count: number) =>
+      family_count ? numberWithCommas(family_count) : TABLE_EMPTY_PLACE_HOLDER,
   },
   {
     key: 'biospecimen_count',
@@ -136,7 +139,7 @@ const columns: ProColumnType<any>[] = [
             })
           }
         >
-          {biospecimenCount}
+          {numberWithCommas(biospecimenCount)}
         </Link>
       ) : (
         biospecimenCount || 0


### PR DESCRIPTION
[SJIP-397](https://d3b.atlassian.net/browse/SJIP-397)

## Description

Add comma as separator to thousand number.
Impacted pages:

- Dashboard => saved set number
- Studies table => column participants, biospecimen and families
- Community => member count
- Participant entity => diagnosis table MONDO shared term column, phenotype table HPO term column


## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot 
### After
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/11d022cc-e698-4a52-9449-24a64721175b)

![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/f6d8bd3d-c677-419e-8873-5c66c725f8eb)

![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/2a344f24-2699-4e20-be3c-343e8ffbece9)

![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/7f1efbc0-619e-4af9-983a-4c1a094490cd)
