### PR TITLE
fix(variant): SJIP-452 manage OMIM empty value

### DIFF
--- a/src/views/VariantEntity/utils/summary.tsx
+++ b/src/views/VariantEntity/utils/summary.tsx
@@ -41,28 +41,37 @@ export const getSummaryItems = (variant?: IVariantEntity): IEntitySummaryColumns
           {
             label: intl.get('screen.variants.summary.genes'),
             value: variant?.genes?.hits?.edges?.length
-              ? variant.genes.hits.edges.map((gene) => (
-                  <ExternalLink
-                    key={gene.node.symbol}
-                    className={styles.geneExternalLink}
-                    href={`https://useast.ensembl.org/Homo_sapiens/Gene/Summary?g=${gene.node.symbol}`}
-                  >
-                    {gene.node.symbol}
-                  </ExternalLink>
-                ))
+              ? variant.genes.hits.edges.map((gene) => {
+                  if (!gene?.node?.symbol) return;
+                  else
+                    return (
+                      <ExternalLink
+                        key={gene.node.symbol}
+                        className={styles.geneExternalLink}
+                        href={`https://useast.ensembl.org/Homo_sapiens/Gene/Summary?g=${gene.node.symbol}`}
+                      >
+                        {gene.node.symbol}
+                      </ExternalLink>
+                    );
+                })
               : TABLE_EMPTY_PLACE_HOLDER,
           },
           {
             label: intl.get('screen.variants.summary.omim'),
             value: variant?.genes?.hits?.edges?.length
-              ? variant.genes.hits.edges.map((gene) => (
-                  <ExternalLink
-                    key={gene.node.omim_gene_id}
-                    href={`https://omim.org/entry/${variant.genes.hits.edges[0].node.omim_gene_id}`}
-                  >
-                    {variant.genes.hits.edges[0].node.omim_gene_id}
-                  </ExternalLink>
-                ))
+              ? variant.genes.hits.edges.map((gene) => {
+                  if (!gene?.node?.omim_gene_id) return;
+                  else
+                    return (
+                      <ExternalLink
+                        key={gene.node.omim_gene_id}
+                        className={styles.geneExternalLink}
+                        href={`https://omim.org/entry/${gene.node.omim_gene_id}`}
+                      >
+                        {gene.node.omim_gene_id}
+                      </ExternalLink>
+                    );
+                })
               : TABLE_EMPTY_PLACE_HOLDER,
           },
           {


### PR DESCRIPTION
[SJIP-452](https://d3b.atlassian.net/browse/SJIP-452)

## Description
The issue was not the one describe in the ticket because the dash displayed when no data was already manage.
In this case we have a null value for OMIM id and it was not manage and crash the display.
I have applied the same fix on the previous cell 'Genes' which can have the same issue I think.

## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot 
### Before
Empty cell like the screenshot in the ticket.

### After
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/6702b1a4-f1d8-46ac-8cf1-14dc17ebd865)
