### PR TITLE
fix(all): SJIP-407 add dash in empty cell

### DIFF
--- a/src/views/DataExploration/components/PageContent/tabs/Biospecimens/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Biospecimens/index.tsx
@@ -94,29 +94,33 @@ const getDefaultColumns = (): ProColumnType<any>[] => [
     title: 'Participant ID',
     dataIndex: 'participant',
     sorter: { multiple: 1 },
-    render: (participant: IParticipantEntity) => participant.participant_id,
+    render: (participant: IParticipantEntity) =>
+      participant?.participant_id || TABLE_EMPTY_PLACE_HOLDER,
   },
   {
     key: 'collection_sample_id',
     title: 'Collection ID',
     dataIndex: 'collection_sample_id',
     sorter: { multiple: 1 },
-    render: (collection_sample_id: string) => (
-      // eslint-disable-next-line
-      <a
-        type="link"
-        onClick={() =>
-          updateActiveQueryField({
-            queryBuilderId: DATA_EXPLORATION_QB_ID,
-            field: 'collection_sample_id',
-            value: [collection_sample_id],
-            index: INDEXES.BIOSPECIMEN,
-          })
-        }
-      >
-        {collection_sample_id}
-      </a>
-    ),
+    render: (collection_sample_id: string) => {
+      collection_sample_id ? (
+        <a
+          type="link"
+          onClick={() =>
+            updateActiveQueryField({
+              queryBuilderId: DATA_EXPLORATION_QB_ID,
+              field: 'collection_sample_id',
+              value: [collection_sample_id],
+              index: INDEXES.BIOSPECIMEN,
+            })
+          }
+        >
+          {collection_sample_id}
+        </a>
+      ) : (
+        TABLE_EMPTY_PLACE_HOLDER
+      );
+    },
   },
   {
     key: 'collection_sample_type',
@@ -166,12 +170,14 @@ const getDefaultColumns = (): ProColumnType<any>[] => [
     title: 'Laboratory Procedure',
     dataIndex: 'laboratory_procedure',
     defaultHidden: true,
+    render: (laboratory_procedure: string) => laboratory_procedure || TABLE_EMPTY_PLACE_HOLDER,
   },
   {
     key: 'biospecimen_storage',
     title: 'Biospecimen Storage',
     dataIndex: 'biospecimen_storage',
     defaultHidden: true,
+    render: (biospecimen_storage: string) => biospecimen_storage || TABLE_EMPTY_PLACE_HOLDER,
   },
   {
     key: 'nb_files',
@@ -201,7 +207,7 @@ const getDefaultColumns = (): ProColumnType<any>[] => [
           {nbFiles}
         </Link>
       ) : (
-        nbFiles
+        nbFiles || 0
       );
     },
   },

--- a/src/views/DataExploration/components/PageContent/tabs/Biospecimens/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Biospecimens/index.tsx
@@ -103,7 +103,10 @@ const getDefaultColumns = (): ProColumnType<any>[] => [
     dataIndex: 'collection_sample_id',
     sorter: { multiple: 1 },
     render: (collection_sample_id: string) => {
-      collection_sample_id ? (
+      if (!collection_sample_id) {
+        return TABLE_EMPTY_PLACE_HOLDER;
+      }
+      return (
         <a
           type="link"
           onClick={() =>
@@ -117,8 +120,6 @@ const getDefaultColumns = (): ProColumnType<any>[] => [
         >
           {collection_sample_id}
         </a>
-      ) : (
-        TABLE_EMPTY_PLACE_HOLDER
       );
     },
   },

--- a/src/views/DataExploration/components/PageContent/tabs/DataFiles/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/DataFiles/index.tsx
@@ -89,10 +89,11 @@ const getDefaultColumns = (
     dataIndex: 'controlled_access',
     align: 'center',
     width: 75,
-    render: (controlled_access: string) =>
-      !controlled_access ? (
-        '-'
-      ) : controlled_access.toLowerCase() === FileAccessType.CONTROLLED.toLowerCase() ? (
+    render: (controlled_access: string) => {
+      if (!controlled_access) {
+        return TABLE_EMPTY_PLACE_HOLDER;
+      }
+      return controlled_access.toLowerCase() === FileAccessType.CONTROLLED.toLowerCase() ? (
         <Tooltip title="Controlled">
           <Tag color="geekblue">C</Tag>
         </Tooltip>
@@ -100,7 +101,8 @@ const getDefaultColumns = (
         <Tooltip title="Registered">
           <Tag color="green">R</Tag>
         </Tooltip>
-      ),
+      );
+    },
   },
   {
     key: 'file_id',
@@ -115,6 +117,7 @@ const getDefaultColumns = (
     dataIndex: 'file_name',
     sorter: { multiple: 1 },
     defaultHidden: true,
+    render: (file_name: string) => file_name || TABLE_EMPTY_PLACE_HOLDER,
   },
   {
     key: 'study.study_id',
@@ -135,6 +138,7 @@ const getDefaultColumns = (
     title: 'Data Category',
     dataIndex: 'data_category',
     sorter: { multiple: 1 },
+    render: (data_category: string) => data_category || TABLE_EMPTY_PLACE_HOLDER,
   },
   {
     key: 'data_type',
@@ -160,12 +164,14 @@ const getDefaultColumns = (
     dataIndex: 'access_urls',
     sorter: { multiple: 1 },
     defaultHidden: true,
+    render: (access_urls: string) => access_urls || TABLE_EMPTY_PLACE_HOLDER,
   },
   {
     key: 'file_format',
     title: 'Format',
     dataIndex: 'file_format',
     sorter: { multiple: 1 },
+    render: (file_format: string) => file_format || TABLE_EMPTY_PLACE_HOLDER,
   },
   {
     key: 'size',
@@ -202,7 +208,7 @@ const getDefaultColumns = (
           {nb_participants}
         </Link>
       ) : (
-        nb_participants
+        nb_participants || 0
       );
     },
   },
@@ -234,7 +240,7 @@ const getDefaultColumns = (
           {nb_biospecimens}
         </Link>
       ) : (
-        nb_biospecimens
+        nb_biospecimens || 0
       );
     },
   },

--- a/src/views/DataExploration/components/PageContent/tabs/Participants/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Participants/index.tsx
@@ -282,7 +282,7 @@ const defaultColumns: ProColumnType<any>[] = [
           {nb_biospecimens}
         </Link>
       ) : (
-        nb_biospecimens
+        nb_biospecimens || 0
       );
     },
   },

--- a/src/views/Studies/index.tsx
+++ b/src/views/Studies/index.tsx
@@ -34,7 +34,7 @@ const enum DataCategory {
 }
 
 const hasDataCategory = (dataCategory: string[], category: DataCategory) =>
-  dataCategory ? dataCategory.includes(category) ? <CheckOutlined /> : undefined : undefined;
+  dataCategory?.includes(category) ? <CheckOutlined /> : TABLE_EMPTY_PLACE_HOLDER;
 
 const columns: ProColumnType<any>[] = [
   {

--- a/src/views/Variants/components/PageContent/VariantsTable/index.tsx
+++ b/src/views/Variants/components/PageContent/VariantsTable/index.tsx
@@ -82,6 +82,7 @@ const defaultColumns: ProColumnType[] = [
     sorter: {
       multiple: 1,
     },
+    render: (variant_class: string) => variant_class || TABLE_EMPTY_PLACE_HOLDER,
   },
   {
     key: 'rsnumber',
@@ -202,7 +203,8 @@ const defaultColumns: ProColumnType[] = [
     tooltip: intl.get('screen.variants.table.alt.tooltip'),
     dataIndex: 'frequencies',
     key: 'alternate',
-    render: (frequencies: IExternalFrequenciesEntity) => frequencies?.internal?.upper_bound_kf?.ac,
+    render: (frequencies: IExternalFrequenciesEntity) =>
+      frequencies?.internal?.upper_bound_kf?.ac || TABLE_EMPTY_PLACE_HOLDER,
   },
   {
     title: intl.get('screen.variants.table.homozygotes.title'),
@@ -210,7 +212,7 @@ const defaultColumns: ProColumnType[] = [
     dataIndex: 'frequencies',
     key: 'homozygotes',
     render: (frequencies: IExternalFrequenciesEntity) =>
-      frequencies?.internal?.upper_bound_kf?.homozygotes,
+      frequencies?.internal?.upper_bound_kf?.homozygotes || 0,
   },
 ];
 
@@ -262,6 +264,7 @@ const VariantsTable = ({
           loading={results.loading}
           initialSelectedKey={selectedKeys}
           showSorterTooltip={false}
+          // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
           onChange={({ current }, _, sorter) => {
             setPageIndex(DEFAULT_PAGE_INDEX);
             setQueryConfig({


### PR DESCRIPTION
#[BUG] [Display dash in empty cell]

- closes [SJIP-407](https://d3b.atlassian.net/browse/SJIP-407)

## Description
Impacted pages : 

- Data exploration / participant tab : 
  - (biospecimens 0 if no data)

- Data exploration / biospecimens tab : 
  - participant
  - collection ID
  - laboratory procedure
  - biospecimen storage
  - (files 0 if no data)

- Data exploration / Data files tab : 
  - data access
  - file name
  - data category
  - access url
  - format
  - (particpants 0 if no data)
  - (biospecimens 0 if no data)

- Studies
  - Genomic
  - transcriptomic
  - proteomic
  - Immun map
  - metabolic

  - Variant
  - type
  - frequencies
  - homozygotes

## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot 
### Before
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/0b997928-ffcd-4d15-aae1-613d7117c201)
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/de0c577d-c0a4-4ba5-b924-7b2004761b71)

### After
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/d5b02da7-42e4-4d1b-8e72-0537d5bb70b9)
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/755598d8-3463-4972-83fd-2d90c34af5b2)
