### PR TITLE
fix(file): SJIP-455 remove asc desc tooltip

### DIFF
--- a/src/views/DataExploration/components/PageContent/tabs/DataFiles/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/DataFiles/index.tsx
@@ -330,6 +330,7 @@ const DataFilesTab = ({ sqon }: OwnProps) => {
           connectionStatus.cavatica === FENCE_CONNECTION_STATUSES.connected,
           connectionStatus.gen3 === FENCE_CONNECTION_STATUSES.connected,
         )}
+        showSorterTooltip={false}
         initialSelectedKey={selectedKeys}
         wrapperClassName={styles.dataFilesTabWrapper}
         loading={results.loading}


### PR DESCRIPTION
# BUG

- closes #[455](https://d3b.atlassian.net/browse/SJIP-455)

## Description

Issue: The tooltip for the “Sort” of a column only appears in the Data Files tab of the Data Exploration page. This was not implemented previously and seems to have automatically updated with FerlabUI ProTable. However, this tooltip only appears in the Data files tab and not the other two Participants, Biospecimens tables. Therefore, we will update the ProTable for the Participants and Biospecimens tab as well and any other ProTable used in the portal.

## Screenshot 
### Before
![image](https://github.com/include-dcc/include-portal-ui/assets/65532894/5028c251-0d19-45a0-83f7-a632ec955555)

### After

https://github.com/include-dcc/include-portal-ui/assets/65532894/d8a57f25-9226-4f3c-b277-d7b5f29ebc41


