### PR TITLE
feat(study): SJIP-467 remove external link from studies from cavantic…

### DIFF
--- a/src/views/Studies/index.tsx
+++ b/src/views/Studies/index.tsx
@@ -20,6 +20,8 @@ import { getProTableDictionary } from 'utils/translation';
 
 import StudyPopoverRedirect from '../DataExploration/components/StudyPopoverRedirect';
 
+import { CavaticaStudiesList, CavaticaStudy } from './utils/constant';
+
 import styles from './index.module.scss';
 
 const { Title } = Typography;
@@ -40,9 +42,12 @@ const columns: ProColumnType<any>[] = [
   {
     key: 'study_id',
     title: 'Study Code',
-    render: (record: IStudyEntity) => (
-      <ExternalLink href={record.website}>{record.study_id}</ExternalLink>
-    ),
+    render: (record: IStudyEntity) =>
+      CavaticaStudiesList.includes(record.study_id as CavaticaStudy) ? (
+        record.study_id
+      ) : (
+        <ExternalLink href={record.website}>{record.study_id}</ExternalLink>
+      ),
   },
   {
     key: 'study_name',

--- a/src/views/Studies/utils/constant.ts
+++ b/src/views/Studies/utils/constant.ts
@@ -1,0 +1,6 @@
+export enum CavaticaStudy {
+  X01_HAKONARSON = 'X01-Hakon',
+  X01_DESMITH = 'X01-deSmith',
+}
+
+export const CavaticaStudiesList = [CavaticaStudy.X01_HAKONARSON, CavaticaStudy.X01_DESMITH];


### PR DESCRIPTION
…a studies

# FEATURE

- closes #[467](https://d3b.atlassian.net/browse/SJIP-467)

## Description
Since the website team won’t have the study pages up for  X01-Hakonarson & X01-deSmith, we will temporarily disable the hyperlink for these two studies as they lead to nowhere. 

## Screenshot 
### Before
![image](https://github.com/include-dcc/include-portal-ui/assets/65532894/a87e9061-9041-4644-98d2-8c5931718d87)


### After
![image](https://github.com/include-dcc/include-portal-ui/assets/65532894/d3dce69d-6e02-49d9-8c75-dce80a4bc36e)


