### PR TITLE
feat(data exploration): SJIP-442 remove duplicate experimental strategy

### DIFF
--- a/src/views/DataExploration/components/PageContent/tabs/DataFiles/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/DataFiles/index.tsx
@@ -152,12 +152,15 @@ const getDefaultColumns = (
     key: 'sequencing_experiment.experiment_strategy',
     title: 'Experimental Strategy',
     sorter: { multiple: 1 },
-    render: (record: IFileEntity) =>
-      record?.sequencing_experiment
-        ? record.sequencing_experiment.hits?.edges
-            .map((edge) => edge.node.experiment_strategy)
-            .join(', ')
-        : TABLE_EMPTY_PLACE_HOLDER,
+    render: (record: IFileEntity) => {
+      if (!record?.sequencing_experiment?.hits?.edges) {
+        return TABLE_EMPTY_PLACE_HOLDER;
+      }
+      return record.sequencing_experiment.hits.edges
+        .map((edge) => edge.node.experiment_strategy)
+        .filter((strategy, index, array) => array.indexOf(strategy) === index)
+        .join(', ');
+    },
   },
   {
     key: 'access_urls',


### PR DESCRIPTION
#[FEATURE] [Only display 1 experimental strategy for a file]

- ticket [SJIP-442](https://d3b.atlassian.net/browse/SJIP-442)

## Description
In data files tab from data exploration page, we want to see only one time each value.

## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot 
### Before
![Screenshot from 2023-06-06 15-07-53](https://github.com/include-dcc/include-portal-ui/assets/133775440/9234ac15-032d-4a65-a8e6-fdd9cc64b9e8)

### After
![Screenshot from 2023-06-06 15-08-15](https://github.com/include-dcc/include-portal-ui/assets/133775440/2604f9fd-5233-415b-a704-62116bd69213)

