### PR TITLE
style(dataExploration): SJIP-442 fix ID cell display

### DIFF
--- a/src/views/DataExploration/components/PageContent/tabs/Biospecimens/index.module.scss
+++ b/src/views/DataExploration/components/PageContent/tabs/Biospecimens/index.module.scss
@@ -1,11 +1,11 @@
 .biospecimenTabWrapper {
-    display: flex;
+  display: flex;
 
-    :global(.ant-pagination) {
-        margin-bottom: 0;
-    }
+  :global(.ant-pagination) {
+    margin-bottom: 0;
+  }
 
-    .ncitTissueCell {
-        min-width: 300px;
-    }
+  .sampleIdCell {
+    white-space: nowrap;
+  }
 }

--- a/src/views/DataExploration/components/PageContent/tabs/Biospecimens/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Biospecimens/index.tsx
@@ -53,6 +53,7 @@ const getDefaultColumns = (): ProColumnType<any>[] => [
     title: 'Sample ID',
     dataIndex: 'sample_id',
     sorter: { multiple: 1 },
+    className: styles.sampleIdCell,
     render: (sample_id: string) => sample_id || TABLE_EMPTY_PLACE_HOLDER,
   },
   {

--- a/src/views/DataExploration/components/PageContent/tabs/Participants/index.module.scss
+++ b/src/views/DataExploration/components/PageContent/tabs/Participants/index.module.scss
@@ -1,15 +1,20 @@
 .participantTabWrapper {
-    display: flex;
+  display: flex;
 
-    :global(.ant-pagination) {
-        margin-bottom: 0;
-    }
+  :global(.ant-pagination) {
+    margin-bottom: 0;
+  }
 
-    .diagnosisCell, .phenotypeCell {
-        min-width: 300px;
-    }
+  .diagnosisCell,
+  .phenotypeCell {
+    min-width: 300px;
+  }
 
-    .studyIdCell {
-        min-width: 85px
-    }
+  .studyIdCell {
+    min-width: 85px;
+  }
+
+  .participantIdCell {
+    white-space: nowrap;
+  }
 }

--- a/src/views/DataExploration/components/PageContent/tabs/Participants/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Participants/index.tsx
@@ -70,6 +70,7 @@ const defaultColumns: ProColumnType<any>[] = [
     sorter: {
       multiple: 1,
     },
+    className: styles.participantIdCell,
     render: (participant_id: string) => (
       <Link to={`${STATIC_ROUTES.PARTICIPANTS}/${participant_id}`}>{participant_id}</Link>
     ),


### PR DESCRIPTION
# STYLE: display in one line ID cells

- closes [SJIP-446](https://d3b.atlassian.net/browse/SJIP-446)

## Description

Slightly widen the ID columns for Participant ID, Sample ID to ensure the IDs do not wrap. 

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/3f749ff3-21a5-4f49-b37d-b68bcca8e0f1)
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/e700a9a5-dcb3-4040-869f-e11c33408380)

### After
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/ffc4dad7-4175-4726-bf22-2a1f4fff2a4e)
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/ea939d91-dd3e-4f3f-8227-bd41c06f1900)
