### PR TITLE
feat(dataexplo): SJIP-445 fix upload query pill

### DIFF
--- a/src/views/DataExploration/components/UploadIds/ParticipantUploadIds.tsx
+++ b/src/views/DataExploration/components/UploadIds/ParticipantUploadIds.tsx
@@ -6,8 +6,10 @@ import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/ut
 import { INDEXES } from 'graphql/constants';
 import { hydrateResults } from 'graphql/models';
 import { IParticipantEntity } from 'graphql/participants/models';
-import { ArrangerApi } from 'services/api/arranger';
 import { CHECK_PARTICIPANT_MATCH } from 'graphql/participants/queries';
+
+import { ArrangerApi } from 'services/api/arranger';
+
 import EntityUploadIds from './EntityUploadIds';
 
 interface OwnProps {
@@ -45,9 +47,7 @@ const ParticipantUploadIds = ({ queryBuilderId }: OwnProps) => (
 
       return participants.map((participant) => ({
         key: participant.fhir_id,
-        submittedId: ids.find((id) =>
-          [participant.participant_id].includes(id),
-        )!,
+        submittedId: ids.find((id) => [participant.participant_id].includes(id))!,
         mappedTo: participant.study_id,
         matchTo: participant.participant_id,
       }));
@@ -60,6 +60,7 @@ const ParticipantUploadIds = ({ queryBuilderId }: OwnProps) => (
         index: INDEXES.PARTICIPANT,
         overrideValuesName: intl.get('components.uploadIds.modal.pillTitle'),
         merge_strategy: MERGE_VALUES_STRATEGIES.OVERRIDE_VALUES,
+        isUploadedList: true,
       })
     }
   />


### PR DESCRIPTION
# FEAT : Improve query pill display on a participant upload

- closes [SJIP-445](https://d3b.atlassian.net/browse/SJIP-445)

## Description

- As it is in PRD, modify the pill dropdown of the Upload entity ID so that it is disabled once an uploaded list is added. 
- As it is in PRD, change the symbol to the Element-of symbol Participant ID ∈  ____ instead of Participant ID = ____

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/bd92f1a3-622b-4d29-a99b-380e5c717639)

### After
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/078d3e68-39ae-4eed-9276-d64f9ae355db)
