### PR TITLE
feat(paticipant): SJIP-460 add external id column

### DIFF
--- a/src/views/DataExploration/components/PageContent/tabs/Participants/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Participants/index.tsx
@@ -153,6 +153,16 @@ const defaultColumns: ProColumnType<any>[] = [
     render: (ethnicity: string) => ethnicity || TABLE_EMPTY_PLACE_HOLDER,
   },
   {
+    key: 'external_id',
+    title: 'External Participant ID',
+    dataIndex: 'external_id',
+    defaultHidden: true,
+    sorter: {
+      multiple: 1,
+    },
+    render: (external_id: string) => external_id || TABLE_EMPTY_PLACE_HOLDER,
+  },
+  {
     key: 'family_type',
     title: 'Family Unit',
     dataIndex: 'family_type',


### PR DESCRIPTION
# FEAT : Add external participant ID column

- closes [SPIJ-460](https://d3b.atlassian.net/browse/SJIP-460)

## Description
Add external participant ID column in the participant table form data exploration.

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/c0f3408d-56b0-4903-a5d3-c8819d7b90fc)

### After
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/19e483e7-8f59-4a42-92dd-c48aeac99db6)
