### PR TITLE
feat(dataexplo): SJIP-465 update placeholders

### DIFF
--- a/src/views/DataExploration/components/BiospecimenSearch.tsx
+++ b/src/views/DataExploration/components/BiospecimenSearch.tsx
@@ -1,14 +1,15 @@
 import { ExperimentOutlined } from '@ant-design/icons';
 import useQueryBuilderState from '@ferlab/ui/core/components/QueryBuilder/utils/useQueryBuilderState';
 import { ISqonGroupFilter } from '@ferlab/ui/core/data/sqon/types';
-import GlobalSearch, { ICustomSearchProps } from 'components/uiKit/search/GlobalSearch';
-import { highlightSearchMatch } from 'components/uiKit/search/GlobalSearch/utils';
-import SelectItem from 'components/uiKit/select/SelectItem';
 import { IBiospecimenEntity } from 'graphql/biospecimens/models';
 import { BIOSPECIMEN_SEARCH_BY_ID_QUERY } from 'graphql/biospecimens/queries';
 import useBiospecimenResolvedSqon from 'graphql/biospecimens/useBiospecimenResolvedSqon';
 import { INDEXES } from 'graphql/constants';
 import { uniqBy } from 'lodash';
+
+import GlobalSearch, { ICustomSearchProps } from 'components/uiKit/search/GlobalSearch';
+import { highlightSearchMatch } from 'components/uiKit/search/GlobalSearch/utils';
+import SelectItem from 'components/uiKit/select/SelectItem';
 
 const BiospecimenSearch = ({ queryBuilderId }: ICustomSearchProps) => {
   const { activeQuery } = useQueryBuilderState(queryBuilderId);
@@ -18,7 +19,7 @@ const BiospecimenSearch = ({ queryBuilderId }: ICustomSearchProps) => {
       queryBuilderId={queryBuilderId}
       field="sample_id"
       index={INDEXES.BIOSPECIMEN}
-      placeholder={'e.g. BS_011DYZ2J, HTP0001B2_Plasma'}
+      placeholder={'e.g. bs-019260B4'}
       emptyDescription={'No samples found'}
       query={BIOSPECIMEN_SEARCH_BY_ID_QUERY}
       sqon={activeQuery as ISqonGroupFilter}
@@ -46,7 +47,7 @@ const BiospecimenCollectionSearch = ({ queryBuilderId }: ICustomSearchProps) => 
       queryBuilderId={queryBuilderId}
       field="collection_sample_id"
       index={INDEXES.BIOSPECIMEN}
-      placeholder={'e.g. HTP0001B2_Whole blood, BS_1YEZ2XR4_Saliva'}
+      placeholder={'e.g. bs-022KAEZW'}
       emptyDescription={'No collection ID found'}
       query={BIOSPECIMEN_SEARCH_BY_ID_QUERY}
       sqon={sqon}

--- a/src/views/DataExploration/components/ParticipantSearch.tsx
+++ b/src/views/DataExploration/components/ParticipantSearch.tsx
@@ -1,12 +1,13 @@
 import { UserOutlined } from '@ant-design/icons';
 import useQueryBuilderState from '@ferlab/ui/core/components/QueryBuilder/utils/useQueryBuilderState';
 import { ISqonGroupFilter } from '@ferlab/ui/core/data/sqon/types';
-import GlobalSearch, { ICustomSearchProps } from 'components/uiKit/search/GlobalSearch';
-import { highlightSearchMatch } from 'components/uiKit/search/GlobalSearch/utils';
-import SelectItem from 'components/uiKit/select/SelectItem';
 import { INDEXES } from 'graphql/constants';
 import { IParticipantEntity } from 'graphql/participants/models';
 import { PARTICIPANT_SEARCH_BY_ID_QUERY } from 'graphql/participants/queries';
+
+import GlobalSearch, { ICustomSearchProps } from 'components/uiKit/search/GlobalSearch';
+import { highlightSearchMatch } from 'components/uiKit/search/GlobalSearch/utils';
+import SelectItem from 'components/uiKit/select/SelectItem';
 
 const ParticipantSearch = ({ queryBuilderId }: ICustomSearchProps) => {
   const { activeQuery } = useQueryBuilderState(queryBuilderId);
@@ -16,12 +17,12 @@ const ParticipantSearch = ({ queryBuilderId }: ICustomSearchProps) => {
       queryBuilderId={queryBuilderId}
       field="participant_id"
       index={INDEXES.PARTICIPANT}
-      placeholder={'e.g. PT_WFB3TQP4'}
+      placeholder={'e.g. pt-005X8BR9'}
       emptyDescription={'No participants found'}
       query={PARTICIPANT_SEARCH_BY_ID_QUERY}
       sqon={activeQuery as ISqonGroupFilter}
-      optionsFormatter={(options, matchRegex, search) => {
-        return options.map((option) => ({
+      optionsFormatter={(options, matchRegex, search) =>
+        options.map((option) => ({
           label: (
             <SelectItem
               icon={<UserOutlined />}
@@ -29,8 +30,8 @@ const ParticipantSearch = ({ queryBuilderId }: ICustomSearchProps) => {
             />
           ),
           value: option.participant_id,
-        }));
-      }}
+        }))
+      }
       title={'Search by Participant ID'}
     />
   );

--- a/src/views/DataExploration/components/UploadIds/BiospecimenUploadIds.tsx
+++ b/src/views/DataExploration/components/UploadIds/BiospecimenUploadIds.tsx
@@ -3,13 +3,15 @@ import { updateActiveQueryField } from '@ferlab/ui/core/components/QueryBuilder/
 import { BooleanOperators } from '@ferlab/ui/core/data/sqon/operators';
 import { MERGE_VALUES_STRATEGIES } from '@ferlab/ui/core/data/sqon/types';
 import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/utils';
-import { INDEXES } from 'graphql/constants';
-import { hydrateResults } from 'graphql/models';
-import { ArrangerApi } from 'services/api/arranger';
-import EntityUploadIds from './EntityUploadIds';
 import { IBiospecimenEntity } from 'graphql/biospecimens/models';
 import { CHECK_BIOSPECIMEN_MATCH } from 'graphql/biospecimens/queries';
+import { INDEXES } from 'graphql/constants';
+import { hydrateResults } from 'graphql/models';
 import { uniqBy } from 'lodash';
+
+import { ArrangerApi } from 'services/api/arranger';
+
+import EntityUploadIds from './EntityUploadIds';
 
 interface OwnProps {
   queryBuilderId: string;
@@ -20,7 +22,7 @@ const BiospecimenUploadIds = ({ queryBuilderId }: OwnProps) => (
     entityId="biospecimen"
     entityIdTrans="Sample"
     entityIdentifiers="Sample ID"
-    placeHolder="e.g. HTP0001B2_Whole blood, BS_011DYZ2J_DNA, 238981007"
+    placeHolder="e.g. bs-022KAEZW"
     fetchMatch={async (ids) => {
       const response = await ArrangerApi.graphqlRequest({
         query: CHECK_BIOSPECIMEN_MATCH.loc?.source.body,
@@ -44,7 +46,7 @@ const BiospecimenUploadIds = ({ queryBuilderId }: OwnProps) => (
         response.data?.data?.biospecimen?.hits?.edges || [],
       );
 
-      return uniqBy(biospecimens, "sample_id").map((biospecimen) => ({
+      return uniqBy(biospecimens, 'sample_id').map((biospecimen) => ({
         key: biospecimen.fhir_id,
         submittedId: ids.find((id) => [biospecimen.sample_id].includes(id))!,
         mappedTo: biospecimen.sample_id,

--- a/src/views/DataExploration/components/UploadIds/ParticipantUploadIds.tsx
+++ b/src/views/DataExploration/components/UploadIds/ParticipantUploadIds.tsx
@@ -6,8 +6,10 @@ import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/ut
 import { INDEXES } from 'graphql/constants';
 import { hydrateResults } from 'graphql/models';
 import { IParticipantEntity } from 'graphql/participants/models';
-import { ArrangerApi } from 'services/api/arranger';
 import { CHECK_PARTICIPANT_MATCH } from 'graphql/participants/queries';
+
+import { ArrangerApi } from 'services/api/arranger';
+
 import EntityUploadIds from './EntityUploadIds';
 
 interface OwnProps {
@@ -19,7 +21,7 @@ const ParticipantUploadIds = ({ queryBuilderId }: OwnProps) => (
     entityId="participant"
     entityIdTrans="Participant"
     entityIdentifiers="Participant ID"
-    placeHolder="e.g. PT_03Y3K025, HTP0001, 10214"
+    placeHolder="e.g. pt-005X8BR9"
     fetchMatch={async (ids) => {
       const response = await ArrangerApi.graphqlRequest({
         query: CHECK_PARTICIPANT_MATCH.loc?.source.body,
@@ -45,9 +47,7 @@ const ParticipantUploadIds = ({ queryBuilderId }: OwnProps) => (
 
       return participants.map((participant) => ({
         key: participant.fhir_id,
-        submittedId: ids.find((id) =>
-          [participant.participant_id].includes(id),
-        )!,
+        submittedId: ids.find((id) => [participant.participant_id].includes(id))!,
         mappedTo: participant.study_id,
         matchTo: participant.participant_id,
       }));


### PR DESCRIPTION
# FEAT: Update placeholders in data exploration

- closes [SJIP-465](https://d3b.atlassian.net/browse/SJIP-465)

## Description

Since the data team changed how the IDs are represented in this data release, we will need to update the placeholders

- Search by Participant ID: e.g. pt-005X8BR9
- Search by Sample ID: e.g. bs-019260B4
- Search by Collection ID: e.g. bs-022KAEZW
- Upload participant list: e.g. pt-005X8BR9
- Upload sample list: e.g. bs-022KAEZW

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before

### After
![Screenshot from 2023-06-07 14-38-32](https://github.com/include-dcc/include-portal-ui/assets/133775440/eade0b36-5b2c-4991-9a52-34678d528305)

![Screenshot from 2023-06-07 14-38-18](https://github.com/include-dcc/include-portal-ui/assets/133775440/2b72f2cd-3611-4f9e-b70e-dd1af24c3c9b)

![Screenshot from 2023-06-07 14-38-44](https://github.com/include-dcc/include-portal-ui/assets/133775440/9f330e7f-3652-47d0-a6f1-0673733fd2b4)

![Screenshot from 2023-06-07 14-38-04](https://github.com/include-dcc/include-portal-ui/assets/133775440/7300f1b7-5be5-4f11-8891-703221ae5cac)
