### PR TITLE
feat(data exploration): SJIP-447 add participant link in bio tab

### DIFF
--- a/src/views/DataExploration/components/PageContent/tabs/Biospecimens/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Biospecimens/index.tsx
@@ -97,7 +97,13 @@ const getDefaultColumns = (): ProColumnType<any>[] => [
     dataIndex: 'participant',
     sorter: { multiple: 1 },
     render: (participant: IParticipantEntity) =>
-      participant?.participant_id || TABLE_EMPTY_PLACE_HOLDER,
+      participant?.participant_id ? (
+        <Link to={`${STATIC_ROUTES.PARTICIPANTS}/${participant.participant_id}`}>
+          {participant.participant_id}
+        </Link>
+      ) : (
+        TABLE_EMPTY_PLACE_HOLDER
+      ),
   },
   {
     key: 'collection_sample_id',
@@ -209,7 +215,7 @@ const getDefaultColumns = (): ProColumnType<any>[] => [
             })
           }
         >
-          {numberWithCommas(1000)}
+          {numberWithCommas(nbFiles)}
         </Link>
       ) : (
         nbFiles


### PR DESCRIPTION
# FEAT : Add participant link in biospecimen tab

- closes [SJIP-447](https://d3b.atlassian.net/browse/SJIP-447)

## Description

Add the Entity page redirect to the Participant ID in Biospecimen tab similar to the redirect for this field in the Participant tab

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/bb37e62c-39a3-4cbd-913e-13d28808f9a3)

### After
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/168f98d6-a74e-4cc1-a15d-70bd71728f60)
