### PR TITLE
feat(data exploration): SJIP-470 move default container ID column

### DIFF
--- a/src/views/DataExploration/components/PageContent/tabs/Biospecimens/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Biospecimens/index.tsx
@@ -139,6 +139,12 @@ const getDefaultColumns = (): ProColumnType<any>[] => [
     render: (collection_sample_type: string) => collection_sample_type || TABLE_EMPTY_PLACE_HOLDER,
   },
   {
+    key: 'container_id',
+    title: 'Container ID',
+    dataIndex: 'container_id',
+    render: (container_id: string) => container_id || TABLE_EMPTY_PLACE_HOLDER,
+  },
+  {
     key: 'age_at_biospecimen_collection',
     tooltip: 'Age at Biospecimen Collection',
     title: 'Age (days)',
@@ -147,13 +153,6 @@ const getDefaultColumns = (): ProColumnType<any>[] => [
       age_at_biospecimen_collection
         ? numberWithCommas(age_at_biospecimen_collection)
         : TABLE_EMPTY_PLACE_HOLDER,
-  },
-  {
-    key: 'container_id',
-    title: 'Container ID',
-    dataIndex: 'container_id',
-    defaultHidden: true,
-    render: (container_id: string) => container_id || TABLE_EMPTY_PLACE_HOLDER,
   },
   {
     key: 'volume_ul',


### PR DESCRIPTION
# FEAT : TITLE

- closes [SJIP-470](https://d3b.atlassian.net/browse/SJIP-470)

## Description
We will make container ID a default column placed in the Biospecimens Table of the Data Exploration page between Collection Sample Type and  Age (days). 

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/a91a0ed6-0646-4eb9-b86d-1311d7868627)

### After
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/ea956a04-9723-4c28-9beb-8894b3711c8a)
