### PR TITLE
feat(data exploration): SJIP-448 format age in biospecimen table

### DIFF
--- a/src/views/DataExploration/components/PageContent/tabs/Biospecimens/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Biospecimens/index.tsx
@@ -29,6 +29,7 @@ import {
   TAB_IDS,
 } from 'views/DataExploration/utils/constant';
 import { generateSelectionSqon } from 'views/DataExploration/utils/selectionSqon';
+import AgeCell from 'views/ParticipantEntity/AgeCell';
 import { DEFAULT_OFFSET } from 'views/Variants/utils/constants';
 
 import { TABLE_EMPTY_PLACE_HOLDER } from 'common/constants';
@@ -141,12 +142,11 @@ const getDefaultColumns = (): ProColumnType<any>[] => [
   {
     key: 'age_at_biospecimen_collection',
     tooltip: 'Age at Biospecimen Collection',
-    title: 'Age (days)',
+    title: 'Age',
     dataIndex: 'age_at_biospecimen_collection',
-    render: (age_at_biospecimen_collection: number) =>
-      age_at_biospecimen_collection
-        ? numberWithCommas(age_at_biospecimen_collection)
-        : TABLE_EMPTY_PLACE_HOLDER,
+    render: (age_at_biospecimen_collection) => (
+      <AgeCell ageInDays={age_at_biospecimen_collection} />
+    ),
   },
   {
     key: 'container_id',


### PR DESCRIPTION
# FEAT : Format age

- closes [SJIP-448](https://d3b.atlassian.net/browse/SJIP-448)

## Description

- Format age in biospecimen table
- Update column title

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
![Screenshot from 2023-06-08 12-35-03](https://github.com/include-dcc/include-portal-ui/assets/133775440/5476adc4-3b0b-4af8-8336-8fd0599713c0)

### After
![Screenshot from 2023-06-08 12-35-23](https://github.com/include-dcc/include-portal-ui/assets/133775440/07d24c75-0018-4808-a4d3-d5c659f02866)

