### PR TITLE
fix(entity): SJIP-435 fix entity table download buttons

### DIFF
--- a/src/graphql/participants/models.ts
+++ b/src/graphql/participants/models.ts
@@ -17,6 +17,7 @@ export interface IParticipantDiagnosis {
 export interface IParticipantPhenotype {
   id: string;
   age_at_event_days: number;
+  source_text: string;
   fhir_id: string;
   hpo_phenotype_observed: string;
   hpo_phenotype_observed_text: string;

--- a/src/services/api/reports/index.ts
+++ b/src/services/api/reports/index.ts
@@ -58,7 +58,7 @@ const generateReport = (config: ReportConfig) => {
     data: {
       sqon: reportSqon,
       projectId: arrangerProjectId,
-      filename: `${config.fileName || config.name}_${makeFilenameDatePart(new Date())}`,
+      filename: `include_${config.fileName || config.name}_${makeFilenameDatePart(new Date())}`,
     },
     headers: headers(),
   });

--- a/src/views/DataExploration/utils/selectionSqon.ts
+++ b/src/views/DataExploration/utils/selectionSqon.ts
@@ -1,5 +1,5 @@
-import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/utils';
 import { Key } from 'react';
+import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/utils';
 import { TAB_IDS } from 'views/DataExploration/utils/constant';
 
 export const generateSelectionSqon = (type: Omit<TAB_IDS, TAB_IDS.SUMMARY>, ids: Key[]) => {
@@ -7,7 +7,7 @@ export const generateSelectionSqon = (type: Omit<TAB_IDS, TAB_IDS.SUMMARY>, ids:
 
   switch (type) {
     case TAB_IDS.BIOSPECIMENS:
-      field = '_id';
+      field = 'sample_id';
       break;
     case TAB_IDS.DATA_FILES:
       field = 'file_id';

--- a/src/views/ParticipantEntity/AgeCell/index.tsx
+++ b/src/views/ParticipantEntity/AgeCell/index.tsx
@@ -15,7 +15,6 @@ const AgeCell = ({ ageInDays }: OwnProps) => {
   }
 
   const { years, days } = readableDistanceByDays(ageInDays);
-
   return (
     <>
       {`${years} `}

--- a/src/views/ParticipantEntity/DiagnosisTable/index.tsx
+++ b/src/views/ParticipantEntity/DiagnosisTable/index.tsx
@@ -1,13 +1,18 @@
 import intl from 'react-intl-universal';
 import { useDispatch } from 'react-redux';
+import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/utils';
 import { EntityTable } from '@ferlab/ui/core/pages/EntityPage';
+import { INDEXES } from 'graphql/constants';
 import { IParticipantDiagnosis, IParticipantEntity } from 'graphql/participants/models';
 
+import { fetchTsvReport } from 'store/report/thunks';
 import { useUser } from 'store/user';
 import { updateUserConfig } from 'store/user/thunks';
 
 import { SectionId } from '../utils/anchorLinks';
-import getDiagnosisColumns from '../utils/getDiagnosisColumns';
+import getDiagnosisDefaultColumns from '../utils/getDiagnosisColumns';
+
+const COLUMNS_PREFIX = 'diagnosis.';
 
 interface OwnProps {
   participant?: IParticipantEntity;
@@ -21,6 +26,13 @@ const DiagnosisTable = ({ participant, loading }: OwnProps) => {
     participant?.diagnosis?.hits?.edges?.map((e) => ({ key: e.node.diagnosis_id, ...e.node })) ||
     [];
 
+  const initialColumnState = (userInfo?.config.participants?.tables?.diagnosis?.columns || []).map(
+    (column) => ({
+      ...column,
+      key: column.key.replace(COLUMNS_PREFIX, ''),
+    }),
+  );
+
   return (
     <EntityTable
       id={SectionId.DIAGNOSIS}
@@ -29,14 +41,42 @@ const DiagnosisTable = ({ participant, loading }: OwnProps) => {
       total={diagnoses.length}
       title={intl.get('entities.participant.diagnosis')}
       header={intl.get('entities.participant.diagnosis')}
-      columns={getDiagnosisColumns()}
-      initialColumnState={userInfo?.config.participants?.tables?.diagnosis?.columns}
+      columns={getDiagnosisDefaultColumns()}
+      initialColumnState={initialColumnState}
       headerConfig={{
         enableTableExport: true,
         enableColumnSort: true,
         onColumnSortChange: (newState) =>
           dispatch(
-            updateUserConfig({ participants: { tables: { diagnosis: { columns: newState } } } }),
+            updateUserConfig({
+              participants: {
+                tables: {
+                  diagnosis: {
+                    columns: newState.map((column) => ({
+                      ...column,
+                      key: `${COLUMNS_PREFIX}${column.key}`,
+                    })),
+                  },
+                },
+              },
+            }),
+          ),
+        onTableExportClick: () =>
+          dispatch(
+            fetchTsvReport({
+              columnStates: userInfo?.config.participants?.tables?.diagnosis?.columns,
+              columns: getDiagnosisDefaultColumns(),
+              index: INDEXES.PARTICIPANT,
+              sqon: generateQuery({
+                newFilters: [
+                  generateValueFilter({
+                    field: 'participant_id',
+                    index: INDEXES.PARTICIPANT,
+                    value: participant?.participant_id ? [participant?.participant_id] : [],
+                  }),
+                ],
+              }),
+            }),
           ),
       }}
     />

--- a/src/views/ParticipantEntity/PhenotypeTable/index.tsx
+++ b/src/views/ParticipantEntity/PhenotypeTable/index.tsx
@@ -1,13 +1,18 @@
 import intl from 'react-intl-universal';
 import { useDispatch } from 'react-redux';
+import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/utils';
 import { EntityTable } from '@ferlab/ui/core/pages/EntityPage';
+import { INDEXES } from 'graphql/constants';
 import { IParticipantEntity, IParticipantPhenotype } from 'graphql/participants/models';
 
+import { fetchTsvReport } from 'store/report/thunks';
 import { useUser } from 'store/user';
 import { updateUserConfig } from 'store/user/thunks';
 
 import { SectionId } from '../utils/anchorLinks';
-import getPhenotypeColumns from '../utils/getPhenotypeColumns';
+import getPhenotypeDefaultColumns from '../utils/getPhenotypeColumns';
+
+const COLUMNS_PREFIX = 'phenotype.';
 
 interface OwnProps {
   participant?: IParticipantEntity;
@@ -21,6 +26,13 @@ const PhenotypeTable = ({ participant, loading }: OwnProps) => {
   const phenotype: IParticipantPhenotype[] =
     participant?.phenotype?.hits?.edges?.map((e) => ({ key: e.node.fhir_id, ...e.node })) || [];
 
+  const initialColumnState = (userInfo?.config.participants?.tables?.phenotype?.columns || []).map(
+    (column) => ({
+      ...column,
+      key: column.key.replace(COLUMNS_PREFIX, ''),
+    }),
+  );
+
   return (
     <EntityTable
       id={SectionId.PHENOTYPE}
@@ -29,14 +41,42 @@ const PhenotypeTable = ({ participant, loading }: OwnProps) => {
       total={phenotype.length}
       title={intl.get('entities.participant.phenotype')}
       header={intl.get('entities.participant.phenotype')}
-      columns={getPhenotypeColumns()}
-      initialColumnState={userInfo?.config.participants?.tables?.phenotype?.columns}
+      columns={getPhenotypeDefaultColumns()}
+      initialColumnState={initialColumnState}
       headerConfig={{
         enableTableExport: true,
         enableColumnSort: true,
         onColumnSortChange: (newState) =>
           dispatch(
-            updateUserConfig({ participants: { tables: { phenotype: { columns: newState } } } }),
+            updateUserConfig({
+              participants: {
+                tables: {
+                  phenotype: {
+                    columns: newState.map((column) => ({
+                      ...column,
+                      key: `${COLUMNS_PREFIX}${column.key}`,
+                    })),
+                  },
+                },
+              },
+            }),
+          ),
+        onTableExportClick: () =>
+          dispatch(
+            fetchTsvReport({
+              columnStates: userInfo?.config.participants?.tables?.phenotype?.columns,
+              columns: getPhenotypeDefaultColumns(),
+              index: INDEXES.PARTICIPANT,
+              sqon: generateQuery({
+                newFilters: [
+                  generateValueFilter({
+                    field: 'participant_id',
+                    index: INDEXES.PARTICIPANT,
+                    value: participant?.participant_id ? [participant?.participant_id] : [],
+                  }),
+                ],
+              }),
+            }),
           ),
       }}
     />

--- a/src/views/ParticipantEntity/utils/biospecimens.tsx
+++ b/src/views/ParticipantEntity/utils/biospecimens.tsx
@@ -9,105 +9,100 @@ import { TABLE_EMPTY_PLACE_HOLDER } from 'common/constants';
 import AgeCell from '../AgeCell';
 import CollectionIdLink from '../BiospecimenTable/CollectionIdLink';
 
-export const getBiospecimenColumns = (): ProColumnType[] => [
+export const getBiospecimensDefaultColumns = (): ProColumnType[] => [
   {
-    key: 'sample_id',
-    dataIndex: 'sample_id',
+    key: 'files.biospecimens.sample_id',
     title: intl.get('entities.biospecimen.sample_id'),
-    render: (sample_id: string) => sample_id || TABLE_EMPTY_PLACE_HOLDER,
+    render: (biospecimen: IBiospecimenEntity) => biospecimen.sample_id || TABLE_EMPTY_PLACE_HOLDER,
   },
   {
-    key: 'collection_sample_id',
-    dataIndex: 'collection_sample_id',
+    key: 'files.biospecimens.collection_sample_id',
     title: intl.get('entities.biospecimen.collection_id'),
-    render: (collection_sample_id: string) =>
-      collection_sample_id ? (
-        <CollectionIdLink collectionId={collection_sample_id} />
+    render: (biospecimen: IBiospecimenEntity) =>
+      biospecimen.collection_sample_id ? (
+        <CollectionIdLink collectionId={biospecimen?.collection_sample_id} />
       ) : (
         TABLE_EMPTY_PLACE_HOLDER
       ),
   },
   {
-    key: 'sample_type',
-    dataIndex: 'sample_type',
+    key: 'files.biospecimens.sample_type',
     title: intl.get('entities.biospecimen.sample_type'),
-    render: (sample_type: string) => sample_type || TABLE_EMPTY_PLACE_HOLDER,
+    render: (biospecimen: IBiospecimenEntity) =>
+      biospecimen?.sample_type || TABLE_EMPTY_PLACE_HOLDER,
   },
   {
-    key: 'collection_sample_type',
-    dataIndex: 'collection_sample_type',
+    key: 'files.biospecimens.collection_sample_type',
     title: intl.get('entities.biospecimen.collection_sample_type'),
-    render: (collection_sample_type: string) => collection_sample_type || TABLE_EMPTY_PLACE_HOLDER,
+    render: (biospecimen: IBiospecimenEntity) =>
+      biospecimen?.collection_sample_type || TABLE_EMPTY_PLACE_HOLDER,
   },
   {
-    key: 'age_at_biospecimen_collection',
-    dataIndex: 'age_at_biospecimen_collection',
+    key: 'files.biospecimens.age_at_biospecimen_collection',
     title: intl.get('entities.participant.age'),
     tooltip: intl.get('entities.biospecimen.age_tooltip'),
-    render: (age_at_biospecimen_collection: number) => (
-      <AgeCell ageInDays={age_at_biospecimen_collection} />
+    render: (biospecimen: IBiospecimenEntity) => (
+      <AgeCell ageInDays={biospecimen?.age_at_biospecimen_collection} />
     ),
   },
   {
-    key: 'container_id',
-    dataIndex: 'container_id',
+    key: 'files.biospecimens.container_id',
     title: intl.get('entities.biospecimen.container_id'),
-    render: (container_id: string) => container_id || TABLE_EMPTY_PLACE_HOLDER,
+    render: (biospecimen: IBiospecimenEntity) =>
+      biospecimen?.container_id || TABLE_EMPTY_PLACE_HOLDER,
     defaultHidden: true,
   },
   {
-    key: 'volume_ul',
-    dataIndex: 'volume_ul',
+    key: 'files.biospecimens.volume_ul',
     title: intl.get('entities.biospecimen.volume'),
-    render: (volume_ul: number) => volume_ul || TABLE_EMPTY_PLACE_HOLDER,
+    render: (biospecimen: IBiospecimenEntity) => biospecimen?.volume_ul || TABLE_EMPTY_PLACE_HOLDER,
     defaultHidden: true,
   },
   {
-    key: 'volume_unit',
-    dataIndex: 'volume_unit',
+    key: 'files.biospecimens.volume_unit',
     title: intl.get('entities.biospecimen.volume_unit'),
-    render: (volume_unit: string) => volume_unit || TABLE_EMPTY_PLACE_HOLDER,
+    render: (biospecimen: IBiospecimenEntity) =>
+      biospecimen?.volume_unit || TABLE_EMPTY_PLACE_HOLDER,
     defaultHidden: true,
   },
   {
-    key: 'status',
-    dataIndex: 'status',
+    key: 'files.biospecimens.status',
     title: intl.get('entities.biospecimen.sample_availabilty'),
     defaultHidden: true,
-    render: (status: Status) => {
+    render: (biospecimen: IBiospecimenEntity) => {
+      const status = biospecimen?.status;
       if (!status) {
         return TABLE_EMPTY_PLACE_HOLDER;
       }
-
       return status === Status.AVAILABLE ? intl.get('global.yes') : intl.get('global.no');
     },
   },
   {
-    key: 'laboratory_procedure',
-    dataIndex: 'laboratory_procedure',
+    key: 'files.biospecimens.laboratory_procedure',
     title: intl.get('entities.biospecimen.laboratory_procedure'),
-    render: (laboratory_procedure: string) => laboratory_procedure || TABLE_EMPTY_PLACE_HOLDER,
+    render: (biospecimen: IBiospecimenEntity) =>
+      biospecimen?.laboratory_procedure || TABLE_EMPTY_PLACE_HOLDER,
     defaultHidden: true,
   },
   {
-    key: 'biospecimen_storage',
-    dataIndex: 'biospecimen_storage',
+    key: 'files.biospecimens.biospecimen_storage',
     title: intl.get('entities.biospecimen.biospecimen_storage'),
-    render: (biospecimen_storage: string) => biospecimen_storage || TABLE_EMPTY_PLACE_HOLDER,
+    render: (biospecimen: IBiospecimenEntity) =>
+      biospecimen?.biospecimen_storage || TABLE_EMPTY_PLACE_HOLDER,
     defaultHidden: true,
   },
   {
-    key: 'parent_sample_id',
-    dataIndex: 'parent_sample_id',
+    key: 'files.biospecimens.parent_sample_id',
     title: intl.get('entities.biospecimen.parent_sample_id'),
-    render: (parent_sample_id: string) => parent_sample_id || TABLE_EMPTY_PLACE_HOLDER,
+    render: (biospecimen: IBiospecimenEntity) =>
+      biospecimen?.parent_sample_id || TABLE_EMPTY_PLACE_HOLDER,
     defaultHidden: true,
   },
   {
-    key: 'parent_sample_type',
-    dataIndex: 'parent_sample_type',
+    key: 'files.biospecimens.parent_sample_type',
     title: intl.get('entities.biospecimen.parent_sample_type'),
-    render: (parent_sample_type: string) => parent_sample_type || TABLE_EMPTY_PLACE_HOLDER,
+    render: (biospecimen: IBiospecimenEntity) =>
+      biospecimen?.parent_sample_type || TABLE_EMPTY_PLACE_HOLDER,
     defaultHidden: true,
   },
 ];

--- a/src/views/ParticipantEntity/utils/getDiagnosisColumns.tsx
+++ b/src/views/ParticipantEntity/utils/getDiagnosisColumns.tsx
@@ -1,6 +1,8 @@
 import intl from 'react-intl-universal';
 import ExternalLink from '@ferlab/ui/core/components/ExternalLink';
 import { ProColumnType } from '@ferlab/ui/core/components/ProTable/types';
+import ExpandableCell from '@ferlab/ui/core/components/tables/ExpandableCell';
+import { IParticipantDiagnosis } from 'graphql/participants/models';
 import { capitalize } from 'lodash';
 import { extractMondoTitleAndCode } from 'views/DataExploration/utils/helper';
 
@@ -9,51 +11,75 @@ import { TABLE_EMPTY_PLACE_HOLDER } from 'common/constants';
 import AgeCell from '../AgeCell';
 import MondoParticipantCount from '../DiagnosisTable/MondoParticipantCount';
 
-const getDiagnosisColumns = (): ProColumnType[] => [
+const getDiagnosisDefaultColumns = (): ProColumnType[] => [
   {
     key: 'mondo_id_diagnosis',
-    dataIndex: 'mondo_id_diagnosis',
     title: intl.get('entities.participant.mondo_diagnosis'),
-    render: (mondo_id_diagnosis: string) => {
-      if (!mondo_id_diagnosis) {
-        return TABLE_EMPTY_PLACE_HOLDER;
-      }
-
-      const mondoInfo = extractMondoTitleAndCode(mondo_id_diagnosis);
-
+    render: (diagnosis: IParticipantDiagnosis) => {
+      const mondoNames = diagnosis?.mondo_id_diagnosis;
       return (
-        <>
-          {capitalize(mondoInfo?.title)} (MONDO:{' '}
-          <ExternalLink href={`http://purl.obolibrary.org/obo/MONDO_${mondoInfo?.code}`}>
-            {mondoInfo?.code}
-          </ExternalLink>
-          )
-        </>
+        <ExpandableCell
+          nOfElementsWhenCollapsed={1}
+          dataSource={[mondoNames]}
+          renderItem={(mondo_id, index): React.ReactNode => {
+            const mondoInfo = extractMondoTitleAndCode(mondo_id);
+            return mondoInfo ? (
+              <div key={index}>
+                {capitalize(mondoInfo.title)} (MONDO:
+                <ExternalLink href={`http://purl.obolibrary.org/obo/MONDO_${mondoInfo.code}`}>
+                  {mondoInfo.code}
+                </ExternalLink>
+                )
+              </div>
+            ) : (
+              TABLE_EMPTY_PLACE_HOLDER
+            );
+          }}
+        />
       );
     },
   },
   {
-    key: 'source_text',
-    dataIndex: 'source_text',
+    key: 'diagnosis_source_text',
     title: intl.get('entities.participant.source_text'),
-    render: (source_text: string) => source_text || TABLE_EMPTY_PLACE_HOLDER,
+    render: (diagnosis: IParticipantDiagnosis) => {
+      const sourceTexts = diagnosis?.source_text;
+
+      if (!sourceTexts || sourceTexts.length === 0) {
+        return TABLE_EMPTY_PLACE_HOLDER;
+      }
+
+      return (
+        <ExpandableCell
+          nOfElementsWhenCollapsed={1}
+          dataSource={[sourceTexts]}
+          renderItem={(sourceText, index): React.ReactNode => <div key={index}>{sourceText}</div>}
+        />
+      );
+    },
   },
   {
     key: 'age_at_event_days',
-    dataIndex: 'age_at_event_days',
     title: intl.get('entities.participant.age'),
     tooltip: intl.get('entities.participant.age_tooltip_diagnosis'),
-    render: (age_at_event_days: number) => <AgeCell ageInDays={age_at_event_days} />,
+    render: (diagnosis: IParticipantDiagnosis) =>
+      diagnosis?.age_at_event_days ? (
+        <AgeCell ageInDays={diagnosis.age_at_event_days} />
+      ) : (
+        TABLE_EMPTY_PLACE_HOLDER
+      ),
   },
   {
     key: 'mondo_term',
-    dataIndex: 'mondo_id_diagnosis',
     title: intl.get('entities.participant.mondo_term'),
     tooltip: intl.get('entities.participant.mondo_term_tooltip'),
-    render: (mondo_id_diagnosis: string) => (
-      <MondoParticipantCount diagnosis={mondo_id_diagnosis} />
-    ),
+    render: (diagnosis: IParticipantDiagnosis) =>
+      diagnosis?.mondo_id_diagnosis ? (
+        <MondoParticipantCount diagnosis={diagnosis.mondo_id_diagnosis} />
+      ) : (
+        TABLE_EMPTY_PLACE_HOLDER
+      ),
   },
 ];
 
-export default getDiagnosisColumns;
+export default getDiagnosisDefaultColumns;

--- a/src/views/ParticipantEntity/utils/getPhenotypeColumns.tsx
+++ b/src/views/ParticipantEntity/utils/getPhenotypeColumns.tsx
@@ -1,55 +1,75 @@
 import intl from 'react-intl-universal';
 import ExternalLink from '@ferlab/ui/core/components/ExternalLink';
 import { ProColumnType } from '@ferlab/ui/core/components/ProTable/types';
+import ExpandableCell from '@ferlab/ui/core/components/tables/ExpandableCell';
+import { IParticipantPhenotype } from 'graphql/participants/models';
+import { capitalize } from 'lodash';
 import { extractPhenotypeTitleAndCode } from 'views/DataExploration/utils/helper';
 
 import { TABLE_EMPTY_PLACE_HOLDER } from 'common/constants';
 
 import AgeCell from '../AgeCell';
 import HpoParticipantCount from '../PhenotypeTable/HpoParticipantCount';
-const getPhenotypeColumns = (): ProColumnType[] => [
+const getPhenotypeDefaultColumns = (): ProColumnType[] => [
   {
     key: 'hpo_phenotype_observed',
-    dataIndex: 'hpo_phenotype_observed',
     title: intl.get('entities.participant.phenotype_hpo'),
-    render: (hpo_phenotype_observed: string) => {
-      if (!hpo_phenotype_observed) {
+    render: (phenotype: IParticipantPhenotype) => {
+      const phenotypeNames = phenotype?.hpo_phenotype_observed;
+      if (!phenotypeNames || phenotypeNames.length === 0) {
         return TABLE_EMPTY_PLACE_HOLDER;
       }
-      const phenotypeInfo = extractPhenotypeTitleAndCode(hpo_phenotype_observed);
-
       return (
-        <>
-          {`${phenotypeInfo?.title}`} (HP:{' '}
-          <ExternalLink href={`http://purl.obolibrary.org/obo/HP_${phenotypeInfo?.code}`}>
-            {phenotypeInfo?.code}
-          </ExternalLink>
-          )
-        </>
+        <ExpandableCell
+          nOfElementsWhenCollapsed={1}
+          dataSource={[phenotypeNames]}
+          renderItem={(hpo_id_phenotype, index): React.ReactNode => {
+            const phenotypeInfo = extractPhenotypeTitleAndCode(hpo_id_phenotype);
+
+            return phenotypeInfo ? (
+              <div key={index}>
+                {capitalize(phenotypeInfo.title)} (HP:
+                <ExternalLink href={`http://purl.obolibrary.org/obo/HP_${phenotypeInfo.code}`}>
+                  {phenotypeInfo.code}
+                </ExternalLink>
+                )
+              </div>
+            ) : (
+              TABLE_EMPTY_PLACE_HOLDER
+            );
+          }}
+        />
       );
     },
   },
   {
     key: 'source_text',
-    dataIndex: 'source_text',
     title: intl.get('entities.participant.source_text'),
+    render: (phenotype: IParticipantPhenotype) =>
+      phenotype?.source_text ? phenotype.source_text : TABLE_EMPTY_PLACE_HOLDER,
   },
   {
     key: 'age_at_event_days',
-    dataIndex: 'age_at_event_days',
     title: intl.get('entities.participant.age'),
     tooltip: intl.get('entities.participant.age_tooltip_phenotype'),
-    render: (age_at_event_days: number) => <AgeCell ageInDays={age_at_event_days} />,
+    render: (diagnosis: IParticipantPhenotype) =>
+      diagnosis.age_at_event_days ? (
+        <AgeCell ageInDays={diagnosis.age_at_event_days} />
+      ) : (
+        TABLE_EMPTY_PLACE_HOLDER
+      ),
   },
   {
     key: 'hpo_term',
-    dataIndex: 'hpo_phenotype_observed',
     title: intl.get('entities.participant.hpo_term'),
     tooltip: intl.get('entities.participant.hpo_term_tooltip'),
-    render: (hpo_phenotype_observed: string) => (
-      <HpoParticipantCount phenotype={hpo_phenotype_observed} />
-    ),
+    render: (diagnosis: IParticipantPhenotype) =>
+      diagnosis?.hpo_phenotype_observed ? (
+        <HpoParticipantCount phenotype={diagnosis.hpo_phenotype_observed} />
+      ) : (
+        TABLE_EMPTY_PLACE_HOLDER
+      ),
   },
 ];
 
-export default getPhenotypeColumns;
+export default getPhenotypeDefaultColumns;


### PR DESCRIPTION
# FIX 

- closes #[435](https://d3b.atlassian.net/browse/SJIP-435)

## Description

The Download [Entity] buttons are not working. It seems like there is no call that is being made to Report API. The behaviour should be the same as what we see in PROD. The Data teams use the reports for QA purposes especially with the upcoming release. 

## Screenshot
![image](https://github.com/include-dcc/include-portal-ui/assets/65532894/c573f7f2-5de2-4962-8a98-7cfbf3b170b7)
![image](https://github.com/include-dcc/include-portal-ui/assets/65532894/d616a2a5-10a7-4a60-8573-1ded6214d924)
![image](https://github.com/include-dcc/include-portal-ui/assets/65532894/174a08a5-331f-484b-af49-908f61e605ed)
![image](https://github.com/include-dcc/include-portal-ui/assets/65532894/f12bb383-06fc-4d2c-b774-5a3745e7957d)


