### PR TITLE
fix(participant entity): SJIP-471 display all data category in data files table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "@types/uuid": "^8.3.2",
         "@typescript-eslint/eslint-plugin": "^5.33.0",
         "@typescript-eslint/parser": "^5.33.0",
-        "antd": "^4.20.0",
+        "antd": "^4.24.10",
         "antd-img-crop": "^4.2.4",
         "axios": "^0.24.0",
         "classnames": "^2.3.1",
@@ -66,7 +66,7 @@
         "redux-persist": "^6.0.0",
         "redux-persist-transform-filter": "^0.0.20",
         "sass": "^1.53.0",
-        "typescript": "^4.4.4",
+        "typescript": "^4.9.5",
         "uuid": "^8.3.2"
       },
       "devDependencies": {
@@ -20390,9 +20390,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
-      "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -36452,9 +36452,9 @@
       }
     },
     "typescript": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
-      "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA=="
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="
     },
     "typical": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@types/uuid": "^8.3.2",
     "@typescript-eslint/eslint-plugin": "^5.33.0",
     "@typescript-eslint/parser": "^5.33.0",
-    "antd": "^4.20.0",
+    "antd": "^4.24.10",
     "antd-img-crop": "^4.2.4",
     "axios": "^0.24.0",
     "classnames": "^2.3.1",
@@ -110,7 +110,7 @@
     "redux-persist": "^6.0.0",
     "redux-persist-transform-filter": "^0.0.20",
     "sass": "^1.53.0",
-    "typescript": "^4.4.4",
+    "typescript": "^4.9.5",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/src/graphql/participants/actions.ts
+++ b/src/graphql/participants/actions.ts
@@ -9,8 +9,18 @@ import { INDEXES } from 'graphql/constants';
 
 import useLazyResultQuery from 'hooks/graphql/useLazyResultQuery';
 
-import { IParticipantEntity, IParticipantResultTree } from './models';
-import { GET_PARTICIPANT_COUNT, GET_PARTICIPANT_ENTITY, SEARCH_PARTICIPANT_QUERY } from './queries';
+import {
+  IDataFile,
+  IDataFileResultTree,
+  IParticipantEntity,
+  IParticipantResultTree,
+} from './models';
+import {
+  GET_DATA_FILE_AGG,
+  GET_PARTICIPANT_COUNT,
+  GET_PARTICIPANT_ENTITY,
+  SEARCH_PARTICIPANT_QUERY,
+} from './queries';
 
 export const useParticipants = (
   variables?: IQueryVariable,
@@ -86,5 +96,25 @@ export const useParticipantsFromField = ({
     loading,
     participants: hydrateResults(result?.participant?.hits?.edges || []),
     total: result?.participant?.hits?.total || 0,
+  };
+};
+
+export const useDataFileAgg = (
+  query = GET_DATA_FILE_AGG,
+): { loading: boolean; dataFileAgg?: IDataFile } => {
+  const sqon = {
+    content: [],
+    op: 'and',
+  };
+
+  const { loading, result } = useLazyResultQuery<IDataFileResultTree>(query, {
+    variables: { sqon },
+  });
+
+  const dataFileAgg = result?.file?.aggregations || undefined;
+
+  return {
+    loading,
+    dataFileAgg,
   };
 };

--- a/src/graphql/participants/models.ts
+++ b/src/graphql/participants/models.ts
@@ -128,6 +128,5 @@ export interface IDataFileResultTree {
   file: {
     aggregations: IDataFile;
   };
-
   loading: boolean;
 }

--- a/src/graphql/participants/models.ts
+++ b/src/graphql/participants/models.ts
@@ -118,3 +118,16 @@ export enum FamilyType {
   TRIO = 'trio',
   OTHER = 'other',
 }
+
+export interface IDataFile {
+  data_category: { buckets: [{ key: string }] };
+  exp_strategies: { buckets: [{ key: string }] };
+}
+
+export interface IDataFileResultTree {
+  file: {
+    aggregations: IDataFile;
+  };
+
+  loading: boolean;
+}

--- a/src/graphql/participants/queries.ts
+++ b/src/graphql/participants/queries.ts
@@ -242,3 +242,22 @@ export const GET_PARTICIPANT_DOWN_SYNDROME_STATUS = gql`
     }
   }
 `;
+
+export const GET_DATA_FILE_AGG = gql`
+  query getDataFileAgg($sqon: JSON) {
+    file {
+      aggregations(filters: $sqon, include_missing: false) {
+        exp_strategies: sequencing_experiment__experiment_strategy {
+          buckets {
+            key
+          }
+        }
+        data_category {
+          buckets {
+            key
+          }
+        }
+      }
+    }
+  }
+`;

--- a/src/views/ParticipantEntity/FileTable/index.tsx
+++ b/src/views/ParticipantEntity/FileTable/index.tsx
@@ -4,6 +4,7 @@ import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/ut
 import { EntityTableMultiple, EntityTableRedirectLink } from '@ferlab/ui/core/pages/EntityPage';
 import { INDEXES } from 'graphql/constants';
 import { IFileEntity } from 'graphql/files/models';
+import { useDataFileAgg } from 'graphql/participants/actions';
 import { IParticipantEntity } from 'graphql/participants/models';
 import { DATA_EXPLORATION_QB_ID } from 'views/DataExploration/utils/constant';
 
@@ -23,21 +24,31 @@ interface IFilesTableProps {
   loading: boolean;
 }
 
-const FileTable = ({ participant, loading }: IFilesTableProps) => {
+const FileTable = ({ participant, loading: participantLoading }: IFilesTableProps) => {
   const participantId = participant?.participant_id || '';
 
   const files: IFileEntity[] = participant?.files?.hits.edges.map(({ node }) => node) || [];
   const fileCount = participant?.nb_files || 0;
 
-  const dataCategoryInfo = getDataCategoryInfo(files, participantId);
-  const experimentalStrategyInfo = getFileCountByExperimentalStrategy(files, participantId);
+  const { loading: dataFileLoading, dataFileAgg } = useDataFileAgg();
+
+  const dataCategoryInfo = getDataCategoryInfo(
+    files,
+    participantId,
+    dataFileAgg?.data_category?.buckets,
+  );
+  const experimentalStrategyInfo = getFileCountByExperimentalStrategy(
+    files,
+    participantId,
+    dataFileAgg?.exp_strategies?.buckets,
+  );
 
   return (
     <div>
       <EntityTableMultiple
         total={fileCount}
         id={SectionId.FILES}
-        loading={loading}
+        loading={participantLoading || dataFileLoading}
         title={intl.get('entities.file.file')}
         titleExtra={[
           <EntityTableRedirectLink

--- a/src/views/ParticipantEntity/FileTable/index.tsx
+++ b/src/views/ParticipantEntity/FileTable/index.tsx
@@ -34,13 +34,13 @@ const FileTable = ({ participant, loading: participantLoading }: IFilesTableProp
 
   const dataCategoryInfo = getDataCategoryInfo(
     files,
-    participantId,
     dataFileAgg?.data_category?.buckets,
+    participantId,
   );
   const experimentalStrategyInfo = getFileCountByExperimentalStrategy(
     files,
-    participantId,
     dataFileAgg?.exp_strategies?.buckets,
+    participantId,
   );
 
   return (

--- a/src/views/ParticipantEntity/FileTable/index.tsx
+++ b/src/views/ParticipantEntity/FileTable/index.tsx
@@ -14,9 +14,8 @@ import { STATIC_ROUTES } from 'utils/routes';
 import { SectionId } from '../utils/anchorLinks';
 import {
   getDataCategoryColumns,
-  getDataCategoryInfo,
   getExperimentalStrategyColumns,
-  getFileCountByExperimentalStrategy,
+  getFilesInfoByType,
 } from '../utils/files';
 
 interface IFilesTableProps {
@@ -32,16 +31,20 @@ const FileTable = ({ participant, loading: participantLoading }: IFilesTableProp
 
   const { loading: dataFileLoading, dataFileAgg } = useDataFileAgg();
 
-  const dataCategoryInfo = getDataCategoryInfo(
-    files,
-    dataFileAgg?.data_category?.buckets,
+  const dataCategoryInfo = getFilesInfoByType({
+    files: files.filter((file) => file?.data_category) || [],
+    allTypes: dataFileAgg?.data_category?.buckets?.map((dataCategory) => dataCategory.key) || [],
+    callbackFilter: (file: IFileEntity, type: string) => file.data_category === type,
     participantId,
-  );
-  const experimentalStrategyInfo = getFileCountByExperimentalStrategy(
-    files,
-    dataFileAgg?.exp_strategies?.buckets,
+  });
+
+  const experimentalStrategyInfo = getFilesInfoByType({
+    files: files.filter((file) => file?.sequencing_experiment) || [],
+    allTypes: dataFileAgg?.exp_strategies?.buckets?.map((x) => x.key) || [],
+    callbackFilter: (file: IFileEntity, type: string) =>
+      file.sequencing_experiment.hits.edges.some((e) => e.node.experiment_strategy === type),
     participantId,
-  );
+  });
 
   return (
     <div>

--- a/src/views/ParticipantEntity/FileTable/index.tsx
+++ b/src/views/ParticipantEntity/FileTable/index.tsx
@@ -32,14 +32,14 @@ const FileTable = ({ participant, loading: participantLoading }: IFilesTableProp
   const { loading: dataFileLoading, dataFileAgg } = useDataFileAgg();
 
   const dataCategoryInfo = getFilesInfoByType({
-    files: files.filter((file) => file?.data_category) || [],
+    files: files.filter((file) => file?.data_category),
     allTypes: dataFileAgg?.data_category?.buckets?.map((dataCategory) => dataCategory.key) || [],
     callbackFilter: (file: IFileEntity, type: string) => file.data_category === type,
     participantId,
   });
 
   const experimentalStrategyInfo = getFilesInfoByType({
-    files: files.filter((file) => file?.sequencing_experiment) || [],
+    files: files.filter((file) => file?.sequencing_experiment),
     allTypes: dataFileAgg?.exp_strategies?.buckets?.map((x) => x.key) || [],
     callbackFilter: (file: IFileEntity, type: string) =>
       file.sequencing_experiment.hits.edges.some((e) => e.node.experiment_strategy === type),

--- a/src/views/ParticipantEntity/utils/files.tsx
+++ b/src/views/ParticipantEntity/utils/files.tsx
@@ -25,62 +25,33 @@ interface IDataCategory {
   percentage: number;
 }
 
-export const getDataCategoryInfo = (
-  files: IFileEntity[],
-  dataCategories?: [{ key: string }],
-  participant_id?: string,
-) => {
-  const filesFiltered = files.filter((file) => file?.data_category);
-  if (!filesFiltered?.length) {
+interface IGetFilesInfoByType {
+  allTypes: string[];
+  files: IFileEntity[];
+  callbackFilter: (file: IFileEntity, type: string) => boolean;
+  participantId?: string;
+}
+
+export const getFilesInfoByType = ({
+  files,
+  allTypes,
+  callbackFilter,
+  participantId,
+}: IGetFilesInfoByType) => {
+  if (!files?.length || !allTypes?.length) {
     return [];
   }
 
-  const allDataCategories = dataCategories?.map((dataCategory) => dataCategory.key);
-  const filesInfoData = allDataCategories?.reduce(
-    (dataCategories: IFileInfoByType[], dataCategory: string) => {
-      const filesWithGivenCategory = filesFiltered.filter(
-        (file) => file.data_category === dataCategory,
-      );
-      return [
-        ...dataCategories,
-        {
-          key: dataCategory,
-          value: dataCategory,
-          nb_files: filesWithGivenCategory.length,
-          proportion_of_files: (filesWithGivenCategory.length / filesFiltered.length) * 100,
-          participant_id: participant_id || '',
-        },
-      ];
-    },
-    [],
-  );
-  return filesInfoData || [];
-};
-
-export const getFileCountByExperimentalStrategy = (
-  files: IFileEntity[],
-  expStrategies?: [{ key: string }],
-  participant_id?: string,
-) => {
-  const filesFiltered = files.filter((file) => file?.sequencing_experiment);
-  if (!filesFiltered?.length) {
-    return [];
-  }
-
-  const strategies = expStrategies?.map((x) => x.key);
-
-  const filesInfoData = strategies?.reduce((ss: IFileInfoByType[], s: string) => {
-    const filesWithGivenStrategy = filesFiltered.filter((file) =>
-      file.sequencing_experiment.hits.edges.some((e) => e.node.experiment_strategy === s),
-    );
+  const filesInfoData = allTypes.reduce((result: IFileInfoByType[], type: string) => {
+    const filesWithGivenType = files.filter((file) => callbackFilter(file, type));
     return [
-      ...ss,
+      ...result,
       {
-        key: s,
-        value: s,
-        nb_files: filesWithGivenStrategy.length,
-        proportion_of_files: (filesWithGivenStrategy.length / filesFiltered.length) * 100,
-        participant_id: participant_id || '',
+        key: type,
+        value: type,
+        nb_files: filesWithGivenType.length,
+        proportion_of_files: (filesWithGivenType.length / files.length) * 100,
+        participant_id: participantId || '',
       },
     ];
   }, []);

--- a/src/views/ParticipantEntity/utils/files.tsx
+++ b/src/views/ParticipantEntity/utils/files.tsx
@@ -31,31 +31,31 @@ export const getDataCategoryInfo = (
   participant_id?: string,
   dataCategories?: [{ key: string }],
 ) => {
-  if (!files?.length) {
+  const filesFiltered = files.filter((file) => file?.data_category);
+  if (!filesFiltered?.length) {
     return [];
   }
+  const filesInfoData: IFileInfoByType[] = [];
 
-  const filesInfosData: IFileInfoByType[] = [];
+  for (const file of filesFiltered) {
+    if (!filesInfoData.find((f) => f.value === file.data_category)) {
+      const filesFound = filesFiltered.filter(
+        ({ data_category }) => data_category === file.data_category,
+      );
 
-  for (const file of files) {
-    if (!file.data_category) {
-      continue;
-    }
-    const filesFound = files.filter(({ data_category }) => data_category === file.data_category);
-    if (!filesInfosData.find((f) => f.value === file.data_category)) {
-      filesInfosData.push({
+      filesInfoData.push({
         key: file.data_category,
         value: file.data_category,
         nb_files: filesFound.length,
-        proportion_of_files: (filesFound.length / files.length) * 100,
+        proportion_of_files: (filesFound.length / filesFiltered.length) * 100,
         participant_id: participant_id || '',
       });
     }
   }
 
   dataCategories?.forEach((dataCategory) => {
-    if (!filesInfosData.find((f) => f.value === dataCategory.key)) {
-      filesInfosData.push({
+    if (!filesInfoData.find((f) => f.value === dataCategory.key)) {
+      filesInfoData.push({
         key: dataCategory.key,
         value: dataCategory.key,
         nb_files: 0,
@@ -65,24 +65,25 @@ export const getDataCategoryInfo = (
     }
   });
 
-  return filesInfosData;
+  return filesInfoData;
 };
 
 export const getFileCountByExperimentalStrategy = (
   files: IFileEntity[],
   participant_id?: string,
-  dataCategories?: [{ key: string }],
+  expStrategies?: [{ key: string }],
 ) => {
-  if (!files?.length) {
+  const filesFiltered = files.filter((file) => file?.sequencing_experiment);
+  if (!filesFiltered?.length) {
     return [];
   }
 
   const experimentalStrategy: { [key: string]: number } = {};
-  dataCategories?.forEach((dataCategory) => {
-    experimentalStrategy[dataCategory.key] = 0;
+  expStrategies?.forEach((expStrategy) => {
+    experimentalStrategy[expStrategy.key] = 0;
   });
 
-  for (const file of files) {
+  for (const file of filesFiltered) {
     hydrateResults(file.sequencing_experiment?.hits?.edges || []).forEach((node) => {
       if (experimentalStrategy[node.experiment_strategy]) {
         experimentalStrategy[node.experiment_strategy] += 1;
@@ -96,7 +97,7 @@ export const getFileCountByExperimentalStrategy = (
     key,
     value: key,
     nb_files: experimentalStrategy[key],
-    proportion_of_files: (experimentalStrategy[key] / files.length) * 100,
+    proportion_of_files: (experimentalStrategy[key] / filesFiltered.length) * 100,
     participant_id: participant_id || '',
   }));
 };

--- a/src/views/ParticipantEntity/utils/files.tsx
+++ b/src/views/ParticipantEntity/utils/files.tsx
@@ -31,6 +31,10 @@ export const getDataCategoryInfo = (
   participant_id?: string,
   dataCategories?: [{ key: string }],
 ) => {
+  if (!files?.length) {
+    return [];
+  }
+
   const filesInfosData: IFileInfoByType[] = [];
 
   for (const file of files) {
@@ -69,6 +73,10 @@ export const getFileCountByExperimentalStrategy = (
   participant_id?: string,
   dataCategories?: [{ key: string }],
 ) => {
+  if (!files?.length) {
+    return [];
+  }
+
   const experimentalStrategy: { [key: string]: number } = {};
   dataCategories?.forEach((dataCategory) => {
     experimentalStrategy[dataCategory.key] = 0;

--- a/src/views/ParticipantEntity/utils/files.tsx
+++ b/src/views/ParticipantEntity/utils/files.tsx
@@ -42,7 +42,7 @@ export const getFilesInfoByType = ({
     return [];
   }
 
-  const filesInfoData = allTypes.reduce((result: IFileInfoByType[], type: string) => {
+  return allTypes.reduce((result: IFileInfoByType[], type: string) => {
     const filesWithGivenType = files.filter((file) => callbackFilter(file, type));
     return [
       ...result,
@@ -55,7 +55,6 @@ export const getFilesInfoByType = ({
       },
     ];
   }, []);
-  return filesInfoData || [];
 };
 
 export const getExperimentalStrategyColumns = (fileCount: number): ProColumnType<any>[] => [


### PR DESCRIPTION
# FIX: data category display in participant entity

- closes [SJIP-471](https://d3b.atlassian.net/browse/SJIP-471)

## Description
In participant entity, category in file table doesn't display all data categories present in the app.
Fix progress bar display.

Same for exprimental strategy (not in the ticket but same place and behavior)

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
- Without file
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/7f1cf981-4ed4-4799-a01c-8ab41f7daa78)

- With file in each data category
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/2a6a7b72-359e-4cc2-9888-3892ec0ba914)

- With file not in all data category
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/e9084b8d-d7e2-4139-8b0f-957a3e3a282c)

### After

- Without file
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/0aee01ed-b0cd-46e1-a816-d76b8e33785f)

- With file in each data category
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/48d4b10e-1011-4e5b-8270-327c3ca288e0)

- With file not in all data category
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/94dcdaf5-ff4b-4d54-90a6-992fbdbea09c)
