### PR TITLE
feat(file entity): SJIP-478 remove manifest button

### DIFF
--- a/src/views/FileEntity/Title/index.tsx
+++ b/src/views/FileEntity/Title/index.tsx
@@ -1,7 +1,7 @@
 import intl from 'react-intl-universal';
 import { FileImageOutlined, LockOutlined, UnlockFilled } from '@ant-design/icons';
 import { EntityTitle } from '@ferlab/ui/core/pages/EntityPage';
-import { Button, Popover, Space } from 'antd';
+import { Popover, Space } from 'antd';
 import { IFileEntity } from 'graphql/files/models';
 
 import { FENCE_CONNECTION_STATUSES } from 'common/fenceTypes';
@@ -60,12 +60,7 @@ const FileEntityTitle: React.FC<OwnProps> = ({ file, loading }) => {
         <LockOutlined className={styles.locked} />
       </Popover>
     ),
-    extra: (
-      <Space>
-        <Button type="primary">{intl.get('entities.file.manifest')}</Button>
-        {file && <CavaticaAnalyzeButton fileIds={[file.file_id]} />}
-      </Space>
-    ),
+    extra: <Space>{file && <CavaticaAnalyzeButton fileIds={[file.file_id]} />}</Space>,
   };
 
   return <EntityTitle {...title} loading={loading} />;


### PR DESCRIPTION
# FEAT : remove manifest button

- closes [SJIP-478](https://d3b.atlassian.net/browse/SJIP-478)

## Description

Remove manifest button in file entity page.

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/8c30e31d-7eb2-470c-beef-a5c3a1759106)

### After
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/36a3d3c7-ce61-4b89-ad7c-39e2cc2181ce)
