### PR TITLE
fix(saved filters): SJIP-479 add scroll in widget

### DIFF
--- a/src/views/Dashboard/components/DashboardCards/SavedFilters/index.module.scss
+++ b/src/views/Dashboard/components/DashboardCards/SavedFilters/index.module.scss
@@ -1,15 +1,15 @@
 .savedFiltersList {
-    height: 100%;
-    overflow: auto;
-    min-height: 200px;
+  height: 100%;
+  overflow: auto;
+  min-height: 200px;
 
-    div[class$="-item-meta"] {
-        margin-bottom: 0;
-    }
+  div[class$='-item-meta'] {
+    margin-bottom: 0;
+  }
 
-    *[class$="-item-meta-description"] {
-        font-size: 12px;
-    }
+  *[class$='-item-meta-description'] {
+    font-size: 12px;
+  }
 }
 
 .setTabs {
@@ -17,6 +17,7 @@
 
   :global(.ant-tabs-content) {
     height: 100%;
+    overflow: auto;
   }
 
   :global(.ant-tabs-tab) {


### PR DESCRIPTION
# FIX : Add scroll in saved filters tab

- closes [SJIP-479](https://d3b.atlassian.net/browse/SJIP-479)

## Description

When we have lots of saved filters we need to scroll in the list.

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/3431153f-2be2-4da3-8f12-d397f48e4234)

### After
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/b3ddab1b-d1e9-4afc-8623-40e43bb06a03)
