### PR TITLE
fix(participant entity): SJIP-493 fix biospecimen menu tool

### DIFF
--- a/src/views/ParticipantEntity/BiospecimenTable/index.tsx
+++ b/src/views/ParticipantEntity/BiospecimenTable/index.tsx
@@ -85,7 +85,18 @@ const BiospecimenTable = ({ participant, loading }: OwnProps) => {
         enableColumnSort: true,
         onColumnSortChange: (newState) =>
           dispatch(
-            updateUserConfig({ participants: { tables: { biospecimens: { columns: newState } } } }),
+            updateUserConfig({
+              participants: {
+                tables: {
+                  biospecimens: {
+                    columns: newState.map((column) => ({
+                      ...column,
+                      key: `${COLUMNS_PREFIX}${column.key}`,
+                    })),
+                  },
+                },
+              },
+            }),
           ),
         onTableExportClick: () =>
           dispatch(


### PR DESCRIPTION
# FIX : Menu tool is not working for biospecimens table in Participant entity page

- closes [SJIP-493](https://d3b.atlassian.net/browse/SJIP-493)

## Description

Fix menu tool in participant entity page for biospecimens table.

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
See attached video in ticket

### After
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/824c6a53-a3fc-408d-83d0-664cfce2d9ed)
