### PR TITLE
fix(saved set): SJIP-488 update icons

### DIFF
--- a/src/views/DataExploration/components/SetsManagementDropdown/UserSetForm/index.tsx
+++ b/src/views/DataExploration/components/SetsManagementDropdown/UserSetForm/index.tsx
@@ -1,8 +1,10 @@
+import { ExperimentOutlined, FileTextOutlined, UserOutlined } from '@ant-design/icons';
 import { Col, Form, Row, Select } from 'antd';
-import { Store } from 'antd/lib/form/interface';
 import { FormInstance } from 'antd/lib/form';
+import { Store } from 'antd/lib/form/interface';
+
+import LineStyleIcon from 'components/Icons/LineStyleIcon';
 import { IUserSetOutput, SetType } from 'services/api/savedSet/models';
-import { UserOutlined } from '@ant-design/icons';
 
 import styles from './index.module.scss';
 
@@ -13,6 +15,22 @@ type OwnProps = {
   onSelectionChange: (values: string) => void;
   form: FormInstance;
   type: SetType;
+};
+
+const getIcon = (setType: SetType) => {
+  switch (setType) {
+    case SetType.PARTICIPANT:
+      return <UserOutlined />;
+    case SetType.BIOSPECIMEN:
+      return <ExperimentOutlined />;
+    case SetType.FILE:
+      return <FileTextOutlined />;
+    case SetType.VARIANT:
+      return <LineStyleIcon />;
+
+    default:
+      break;
+  }
 };
 
 const UserSetsForm = ({
@@ -34,9 +52,7 @@ const UserSetsForm = ({
           <Select.Option key={s.id} value={s.id}>
             <Row>
               <Col className={styles.setDropdownName}>{s.tag}</Col>
-              <Col style={{ paddingRight: 2 }}>
-                <UserOutlined />
-              </Col>
+              <Col style={{ paddingRight: 2 }}>{getIcon(s.setType)}</Col>
               <Col>
                 <div className={'secondary-text-color'}>{s.size}</div>
               </Col>

--- a/src/views/DataExploration/components/SetsManagementDropdown/UserSetForm/index.tsx
+++ b/src/views/DataExploration/components/SetsManagementDropdown/UserSetForm/index.tsx
@@ -19,17 +19,15 @@ type OwnProps = {
 
 const getIcon = (setType: SetType) => {
   switch (setType) {
-    case SetType.PARTICIPANT:
-      return <UserOutlined />;
     case SetType.BIOSPECIMEN:
       return <ExperimentOutlined />;
     case SetType.FILE:
       return <FileTextOutlined />;
     case SetType.VARIANT:
       return <LineStyleIcon />;
-
+    case SetType.PARTICIPANT:
     default:
-      break;
+      return <UserOutlined />;
   }
 };
 


### PR DESCRIPTION
# FIX : Change icon according to type set

- closes [SJIP-488](https://d3b.atlassian.net/browse/SJIP-488)

## Description

Before we have only one icon for each type of set. According to the set type we want a different icon.

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
![Screenshot from 2023-06-20 16-40-24](https://github.com/include-dcc/include-portal-ui/assets/133775440/5cbfddde-8c68-4272-8b56-3c8cff219372)
![Screenshot from 2023-06-20 16-40-38](https://github.com/include-dcc/include-portal-ui/assets/133775440/838a6a13-5dca-438c-b1f0-b5d5a350dbf5)
![Screenshot from 2023-06-20 16-33-39](https://github.com/include-dcc/include-portal-ui/assets/133775440/e16b7423-58e0-4e9a-9ca2-511f7a511ea6)

### After
![Screenshot from 2023-06-20 16-32-21](https://github.com/include-dcc/include-portal-ui/assets/133775440/a835ac2c-fc1e-43ff-b0ef-f6d12f613836)
![Screenshot from 2023-06-20 16-32-36](https://github.com/include-dcc/include-portal-ui/assets/133775440/da8c5f8f-3f3e-4154-a5ac-d1bbfa1527df)
![Screenshot from 2023-06-20 16-32-50](https://github.com/include-dcc/include-portal-ui/assets/133775440/dce67f10-0a6e-4c8f-84bc-d0db1a9d8568)
![Screenshot from 2023-06-20 16-39-12](https://github.com/include-dcc/include-portal-ui/assets/133775440/f9bdc354-36f8-4127-bad8-3e28c7141df4)
