### PR TITLE
fix(data exploration): SJIP-482 add trio+ family unit

### DIFF
--- a/src/graphql/participants/models.ts
+++ b/src/graphql/participants/models.ts
@@ -116,6 +116,7 @@ export enum FamilyType {
   PROBAND = 'proband-only',
   DUO = 'duo',
   TRIO = 'trio',
+  TRIO_PLUS = 'trio+',
   OTHER = 'other',
 }
 

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1041,6 +1041,7 @@ const en = {
       sex: 'Sex',
       source_text: 'Condition (Source Text)',
       trio: 'Trio',
+      trio_plus: ' Trio+',
       trisomy: 'T21: "Trisomy 21"',
     },
     study: {

--- a/src/views/DataExploration/components/PageContent/tabs/Participants/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Participants/index.tsx
@@ -171,7 +171,9 @@ const defaultColumns: ProColumnType<any>[] = [
       multiple: 1,
     },
     render: (family_type: FamilyType) =>
-      family_type ? familyTypeText[family_type] : TABLE_EMPTY_PLACE_HOLDER,
+      family_type && familyTypeText[family_type]
+        ? familyTypeText[family_type]
+        : TABLE_EMPTY_PLACE_HOLDER,
   },
   {
     key: 'diagnosis.source_text',

--- a/src/views/ParticipantEntity/utils/summary.tsx
+++ b/src/views/ParticipantEntity/utils/summary.tsx
@@ -12,6 +12,7 @@ export const familyTypeText = {
   [FamilyType.PROBAND]: intl.get('entities.participant.proband_only'),
   [FamilyType.DUO]: intl.get('entities.participant.duo'),
   [FamilyType.TRIO]: intl.get('entities.participant.trio'),
+  [FamilyType.TRIO_PLUS]: intl.get('entities.participant.trio_plus'),
   [FamilyType.OTHER]: intl.get('entities.participant.other'),
 };
 


### PR DESCRIPTION
# FIX : Add trio+ mapping for Family unit

- closes [SJIP-482](https://d3b.atlassian.net/browse/SJIP-482)

## Description

It's missing the trio+ mapping into FamilyType to display the right label in the paticipant table.

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/d73cb237-4c7b-4822-a039-624ee79db9b7)

### After
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/377d7fe7-78a5-43ec-8f97-2a49eb43aea1)