### PR TITLE
feat(data exploration): SJIP-472 add title and fix style

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -686,6 +686,7 @@ const en = {
       },
     },
     dataExploration: {
+      title: 'Data Exploration',
       sidemenu: {
         participant: 'Participant',
         biospecimen: 'Biospecimen',

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -533,6 +533,7 @@ const fr = {
       },
     },
     dataExploration: {
+      title: 'Data Exploration',
       sidemenu: {
         participant: 'Participant',
         biospecimen: 'Biospecimen',

--- a/src/views/DataExploration/components/PageContent/index.module.scss
+++ b/src/views/DataExploration/components/PageContent/index.module.scss
@@ -1,6 +1,5 @@
-
 .dataExplorePageContent {
-    width: 100%;
-    display: flex;
-    position: relative;
+  width: 100%;
+  display: flex;
+  position: relative;
 }

--- a/src/views/DataExploration/components/PageContent/index.tsx
+++ b/src/views/DataExploration/components/PageContent/index.tsx
@@ -14,7 +14,7 @@ import { ISavedFilter } from '@ferlab/ui/core/components/QueryBuilder/types';
 import { dotToUnderscore } from '@ferlab/ui/core/data/arranger/formatting';
 import { IRemoteComponent, ISyntheticSqon } from '@ferlab/ui/core/data/sqon/types';
 import { isEmptySqon, resolveSyntheticSqon } from '@ferlab/ui/core/data/sqon/utils';
-import { Space, Tabs, Typography } from 'antd';
+import { Space, Tabs } from 'antd';
 import copy from 'copy-to-clipboard';
 import { useTotalBiospecimen } from 'graphql/biospecimens/actions';
 import { INDEXES } from 'graphql/constants';
@@ -151,9 +151,6 @@ const PageContent = ({
 
   return (
     <Space direction="vertical" size={24} className={styles.dataExplorePageContent}>
-      <Typography.Title className={styles.title} level={4}>
-        {intl.get('screen.dataExploration.title')}
-      </Typography.Title>
       <QueryBuilder
         id={DATA_EXPLORATION_QB_ID}
         className="data-exploration-repo__query-builder"

--- a/src/views/DataExploration/index.module.scss
+++ b/src/views/DataExploration/index.module.scss
@@ -1,4 +1,4 @@
-@import "src/style/themes/include/layout";
+@import 'src/style/themes/include/layout';
 
 .dataExplorationLayout {
   display: flex;
@@ -10,16 +10,16 @@
   }
 
   .sideMenu {
-    li[role="menuitem"] {
+    li[role='menuitem'] {
       color: white;
 
-      span[class$="-title-content"] {
+      span[class$='-title-content'] {
         margin-left: 0 !important;
       }
     }
   }
 
-  span[role="img"].sideMenuIcon {
+  span[role='img'].sideMenuIcon {
     font-size: 20px !important;
     display: flex;
     justify-content: center;
@@ -28,5 +28,9 @@
   .scrollContent {
     width: 100%;
     padding: $default-page-content-padding;
+
+    .title {
+      margin-bottom: 16px;
+    }
   }
 }

--- a/src/views/DataExploration/index.tsx
+++ b/src/views/DataExploration/index.tsx
@@ -3,7 +3,7 @@ import { useParams } from 'react-router-dom';
 import { ExperimentOutlined, FileSearchOutlined, UserOutlined } from '@ant-design/icons';
 import SidebarMenu, { ISidebarMenuItem } from '@ferlab/ui/core/components/SidebarMenu';
 import ScrollContent from '@ferlab/ui/core/layout/ScrollContent';
-import { Spin } from 'antd';
+import { Spin, Typography } from 'antd';
 import { INDEXES } from 'graphql/constants';
 import { ExtendedMappingResults } from 'graphql/models';
 import PageContent from 'views/DataExploration/components/PageContent';
@@ -199,6 +199,9 @@ const DataExploration = () => {
         menuItems={menuItems} /* defaultSelectedKey={tab} */
       />
       <ScrollContent id={SCROLL_WRAPPER_ID} className={styles.scrollContent}>
+        <Typography.Title className={styles.title} level={4}>
+          {intl.get('screen.dataExploration.title')}
+        </Typography.Title>
         <PageContent
           fileMapping={fileMappingResults}
           biospecimenMapping={biospecimenMappingResults}

--- a/src/views/Variants/components/PageContent/index.module.scss
+++ b/src/views/Variants/components/PageContent/index.module.scss
@@ -1,34 +1,3 @@
-@import 'src/style/themes/include/colors';
-
-.pageHeader {
-  display: flex;
-  align-items: center;
-
-  .pageHeaderTitle {
-    display: flex;
-    margin: 0;
-    font-size: 20px;
-    line-height: 28px;
-    margin-right: 1.2rem;
-  }
-
-  .dataReleaseTag {
-    color: $cyan-7;
-    display: flex;
-    align-items: center;
-    font-size: 12px;
-    height: 20px;
-
-    &:hover {
-      cursor: pointer;
-    }
-
-    span {
-      margin-right: 0.5rem;
-    }
-  }
-}
-
 .variantsPageContent {
   width: 100%;
   display: flex;

--- a/src/views/Variants/components/PageContent/index.tsx
+++ b/src/views/Variants/components/PageContent/index.tsx
@@ -9,7 +9,7 @@ import { dotToUnderscore } from '@ferlab/ui/core/data/arranger/formatting';
 import { isEmptySqon, resolveSyntheticSqon } from '@ferlab/ui/core/data/sqon/utils';
 import { SortDirection } from '@ferlab/ui/core/graphql/constants';
 import { IExtendedMappingResults } from '@ferlab/ui/core/graphql/types';
-import { Space, Typography } from 'antd';
+import { Space } from 'antd';
 import copy from 'copy-to-clipboard';
 import { useVariant } from 'graphql/variants/actions';
 import { IVariantResultTree } from 'graphql/variants/models';
@@ -138,12 +138,6 @@ const PageContent = ({ variantMapping }: OwnProps) => {
 
   return (
     <Space direction="vertical" size={24} className={styles.variantsPageContent}>
-      <div className={styles.pageHeader}>
-        <Typography.Title className={styles.pageHeaderTitle} level={1}>
-          {intl.get('screen.variants.title')}
-        </Typography.Title>
-      </div>
-
       <QueryBuilder
         id={VARIANT_REPO_QB_ID}
         className="variants-repo__query-builder"

--- a/src/views/Variants/index.module.scss
+++ b/src/views/Variants/index.module.scss
@@ -28,5 +28,9 @@
   .scrollContent {
     width: 100%;
     padding: $default-page-content-padding;
+
+    .title {
+      margin-bottom: 16px;
+    }
   }
 }

--- a/src/views/Variants/index.tsx
+++ b/src/views/Variants/index.tsx
@@ -2,6 +2,7 @@ import intl from 'react-intl-universal';
 import { UserOutlined } from '@ant-design/icons';
 import SidebarMenu, { ISidebarMenuItem } from '@ferlab/ui/core/components/SidebarMenu';
 import ScrollContent from '@ferlab/ui/core/layout/ScrollContent';
+import { Typography } from 'antd';
 import { INDEXES } from 'graphql/constants';
 import GenesUploadIds from 'views/Variants/components/GeneUploadIds';
 import VariantGeneSearch from 'views/Variants/components/VariantGeneSearch';
@@ -231,6 +232,9 @@ const Variants = () => {
     <div className={styles.variantsLayout}>
       <SidebarMenu className={styles.sideMenu} menuItems={menuItems} />
       <ScrollContent id={SCROLL_WRAPPER_ID} className={styles.scrollContent}>
+        <Typography.Title className={styles.title} level={4}>
+          {intl.get('screen.variants.title')}
+        </Typography.Title>
         <PageContent variantMapping={variantMappingResults} />
       </ScrollContent>
     </div>


### PR DESCRIPTION
# FEAT : Add data exploration title

- closes [SJIP-472](https://d3b.atlassian.net/browse/SJIP-472)

## Description

Add title of data exploration page. I have fixed too the style of the title in data exploration and variants pages.

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/4d6564ae-2108-4865-9615-345a87366c37)
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/5b1e7744-2535-4231-9dfe-e7dd5d2ef63c)

### After
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/9755c855-3dc1-443f-a2c2-f86713e89632)
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/d8b1badf-9250-404a-a38a-769ad205f992)
