### PR TITLE
feat(participant): SJIP-497 mask family table and id in summary

### DIFF
--- a/src/views/ParticipantEntity/index.tsx
+++ b/src/views/ParticipantEntity/index.tsx
@@ -8,7 +8,6 @@ import getProfileItems from './utils/getProfileItems';
 import { getSummaryItems } from './utils/summary';
 import BiospecimenTable from './BiospecimenTable';
 import DiagnosisTable from './DiagnosisTable';
-import FamilyTable from './FamilyTable';
 import FileTable from './FileTable';
 import PhenotypeTable from './PhenotypeTable';
 import SummaryHeader from './SummaryHeader';
@@ -22,13 +21,14 @@ const ParticipantEntity = () => {
     value: participant_id,
   });
 
-  const showFamilyTable = Boolean(
-    participant?.family?.family_id && participant?.family?.family_relations?.hits?.edges?.length,
-  );
+  // SJIP-497 / SJIP-458 back end fix needed
+  // const showFamilyTable = Boolean(
+  //   participant?.family?.family_id && participant?.family?.family_relations?.hits?.edges?.length,
+  // );
 
   return (
     <EntityPage
-      links={getLinks(showFamilyTable)}
+      links={getLinks()}
       pageId={'participant-entity-page'}
       data={participant}
       loading={loading}
@@ -52,7 +52,8 @@ const ParticipantEntity = () => {
         header={intl.get('entities.participant.profile')}
       />
 
-      {showFamilyTable && <FamilyTable participant={participant!} loading={loading} />}
+      {/* SJIP-497 / SJIP-458 back end fix needed */}
+      {/* {showFamilyTable && <FamilyTable participant={participant!} loading={loading} />} */}
 
       <DiagnosisTable participant={participant} loading={loading} />
 

--- a/src/views/ParticipantEntity/utils/anchorLinks.tsx
+++ b/src/views/ParticipantEntity/utils/anchorLinks.tsx
@@ -11,7 +11,7 @@ export enum SectionId {
   FILES = 'files',
 }
 
-export const getLinks = (showFamilyTable: boolean): IAnchorLink[] => {
+export const getLinks = (): IAnchorLink[] => {
   const links = [
     { href: `#${SectionId.SUMMARY}`, title: intl.get('entities.global.summary') },
     { href: `#${SectionId.PROFILE}`, title: intl.get('entities.participant.profile') },
@@ -24,12 +24,13 @@ export const getLinks = (showFamilyTable: boolean): IAnchorLink[] => {
     { href: `#${SectionId.FILES}`, title: intl.get('entities.file.file') },
   ];
 
-  if (showFamilyTable) {
-    links.splice(2, 0, {
-      href: `#${SectionId.FAMILY}`,
-      title: intl.get('entities.participant.family'),
-    });
-  }
+  // SJIP-497 / SJIP-458 back end fix needed
+  // if (showFamilyTable) {
+  //   links.splice(2, 0, {
+  //     href: `#${SectionId.FAMILY}`,
+  //     title: intl.get('entities.participant.family'),
+  //   });
+  // }
 
   return links;
 };

--- a/src/views/ParticipantEntity/utils/summary.tsx
+++ b/src/views/ParticipantEntity/utils/summary.tsx
@@ -6,6 +6,8 @@ import { FamilyType, IParticipantEntity } from 'graphql/participants/models';
 
 import { TABLE_EMPTY_PLACE_HOLDER } from 'common/constants';
 
+import FamilyIdLink from '../FamilyTable/FamilyIdLink';
+
 import styles from '../styles/styles.module.scss';
 
 export const familyTypeText = {
@@ -54,6 +56,14 @@ export const getSummaryItems = (participant?: IParticipantEntity): IEntityDescri
     label: intl.get('entities.participant.family_unit'),
     value: participant?.family_type ? (
       <Tag color="cyan">{familyTypeText[participant.family_type]}</Tag>
+    ) : (
+      TABLE_EMPTY_PLACE_HOLDER
+    ),
+  },
+  {
+    label: intl.get('entities.participant.family_id'),
+    value: participant?.family?.family_id ? (
+      <FamilyIdLink familyId={participant.family.family_id} />
     ) : (
       TABLE_EMPTY_PLACE_HOLDER
     ),


### PR DESCRIPTION
# FEAT : Mask Family table and add id in summary in participant entity page

- closes [SJIP-497](https://d3b.atlassian.net/browse/SJIP-497)

## Description

Waiting a back end fix for family data, we need to : 

- mask family table
- mak the associated entry in the anchor menu
- add family id and a link to data exploration in the summary table

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/f3a3fcf1-96f6-461e-b1b2-dada57d7aa7d)

### After
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/9a03f26f-a04a-4877-b86b-bca43b8905d3)
