### PR TITLE
:construction: Adding support for variants v2

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,7 +40,11 @@ const CommunityMember = loadable(() => import('views/Community/Member'), loadabl
 const Studies = loadable(() => import('views/Studies'), loadableProps);
 const DataExploration = loadable(() => import('views/DataExploration'), loadableProps);
 const Variants = loadable(() => import('views/Variants'), loadableProps);
+//fixme variantsV2
+const VariantsV2 = loadable(() => import('views/VariantsV2'), loadableProps);
 const VariantEntity = loadable(() => import('views/VariantEntity'), loadableProps);
+//fixme variantsV2
+const VariantEntityV2 = loadable(() => import('views/VariantEntityV2'), loadableProps);
 const FileEntity = loadable(() => import('views/FileEntity'), loadableProps);
 const ParticipantEntity = loadable(() => import('views/ParticipantEntity'), loadableProps);
 const ProfileSettings = loadable(() => import('views/ProfileSettings'), loadableProps);
@@ -107,8 +111,16 @@ const App = () => {
                   <ProtectedRoute exact path={STATIC_ROUTES.VARIANTS} layout={PageLayout}>
                     <Variants />
                   </ProtectedRoute>
+                  {/* fixme variantsV2 */}
+                  <ProtectedRoute exact path={STATIC_ROUTES.VARIANTS_V2} layout={PageLayout}>
+                    <VariantsV2 />
+                  </ProtectedRoute>
                   <ProtectedRoute exact path={DYNAMIC_ROUTES.VARIANT_ENTITY} layout={PageLayout}>
                     <VariantEntity />
+                  </ProtectedRoute>
+                  {/* fixme variantsV2 */}
+                  <ProtectedRoute exact path={DYNAMIC_ROUTES.VARIANT_ENTITY_V2} layout={PageLayout}>
+                    <VariantEntityV2 />
                   </ProtectedRoute>
                   <ProtectedRoute exact path={DYNAMIC_ROUTES.FILE_ENTITY} layout={PageLayout}>
                     <FileEntity />

--- a/src/graphql/constants.ts
+++ b/src/graphql/constants.ts
@@ -5,5 +5,7 @@ export enum INDEXES {
   BIOSPECIMEN = 'biospecimen',
   SETS = 'sets',
   VARIANTS = 'variants',
+  //fixme variantsV2
+  VARIANTS_V2 = 'variantsV2',
   GENES = 'genes',
 }

--- a/src/graphql/variantsv2/actions.ts
+++ b/src/graphql/variantsv2/actions.ts
@@ -1,0 +1,60 @@
+import {
+  IQueryOperationsConfig,
+  IQueryResults,
+  IQueryVariable,
+} from '@ferlab/ui/core/graphql/types';
+import { computeSearchAfter, hydrateResults } from '@ferlab/ui/core/graphql/utils';
+import { IVariantEntity as IVariantEntityFerlab } from '@ferlab/ui/core/pages/EntityPage/type';
+import { INDEXES } from 'graphql/constants';
+
+import useLazyResultQuery from 'hooks/graphql/useLazyResultQuery';
+
+import { IVariantEntity, IVariantEntityResultTree, IVariantResultTree } from './models';
+import { GET_VARIANT_ENTITY_V2, SEARCH_VARIANT_QUERY_V2 } from './queries';
+
+export const useVariant = (
+  variables?: IQueryVariable,
+  operations?: IQueryOperationsConfig,
+): IQueryResults<IVariantEntity[]> => {
+  const { loading, result } = useLazyResultQuery<IVariantResultTree>(SEARCH_VARIANT_QUERY_V2, {
+    variables,
+  });
+
+  return {
+    loading,
+    data: hydrateResults(result?.variants?.hits?.edges || [], operations?.previous),
+    total: result?.variants?.hits?.total || 0,
+    searchAfter: computeSearchAfter(result?.variants?.hits?.edges || [], operations),
+  };
+};
+
+interface IUseVariantEntityProps {
+  field: string;
+  values: string[];
+}
+
+interface IUseVariantEntityReturn {
+  loading: boolean;
+  data?: IVariantEntityFerlab;
+}
+
+export const useVariantEntity = ({
+  field,
+  values,
+}: IUseVariantEntityProps): IUseVariantEntityReturn => {
+  const sqon = {
+    content: [{ content: { field, value: values, index: INDEXES.VARIANTS_V2 }, op: 'in' }],
+    op: 'and',
+  };
+
+  const { loading, result } = useLazyResultQuery<IVariantEntityResultTree>(GET_VARIANT_ENTITY_V2, {
+    variables: { sqon },
+  });
+
+  const data = result?.variants?.hits?.edges[0].node;
+
+  return {
+    loading,
+    data,
+  };
+};

--- a/src/graphql/variantsv2/models.ts
+++ b/src/graphql/variantsv2/models.ts
@@ -1,0 +1,219 @@
+import { IArrangerResultsTree } from '@ferlab/ui/core/graphql/types';
+import { IVariantEntity as IVariantEntityFerlab } from '@ferlab/ui/core/pages/EntityPage/type';
+
+export interface IVariantResultTree {
+  variants: IArrangerResultsTree<IVariantEntity>;
+}
+
+export interface IVariantEntityResultTree {
+  variants: IArrangerResultsTree<IVariantEntityFerlab>;
+}
+
+export enum Impact {
+  High = 'HIGH',
+  Moderate = 'MODERATE',
+  Low = 'LOW',
+  Modifier = 'MODIFIER',
+}
+
+export interface IConservationsEntity {
+  phyloP100way_vertebrate: number;
+  phyloP17way_primate: number;
+}
+
+export interface IBoundType {
+  ac?: number;
+  af?: number;
+  an?: number;
+  pn?: number;
+  pc?: number;
+  pf?: number;
+  het?: number;
+  hom?: number;
+}
+
+export interface IVariantInternalFrequencies {
+  total: IBoundType;
+}
+
+export interface IExternalFrequenciesEntity {
+  gnomad_exomes_2_1_1: IBoundType;
+  gnomad_genomes_2_1_1: IBoundType;
+  gnomad_genomes_3: IBoundType;
+  thousand_genomes: IBoundType;
+  topmed_bravo: IBoundType;
+}
+
+export interface IConsequenceNode {
+  node: IConsequenceEntity;
+}
+export interface IPredictionEntity {
+  cadd_phred: number;
+  cadd_score: number;
+  dann_score: number;
+  fathmm_pred: string;
+  fathmm_score: number;
+  lrt_pred: string;
+  lrt_score: number;
+  polyphen2_hvar_pred: string;
+  polyphen2_hvar_score: number;
+  revel_score: number;
+  sift_pred: string;
+  sift_score: number;
+}
+
+export interface IConsequenceEntity {
+  id: string;
+  score: number;
+  aa_change: string | undefined | null;
+  canonical: boolean;
+  cdna_position: string;
+  cds_position: string;
+  consequence: string[];
+  ensembl_feature_id: string;
+  ensembl_transcript_id: string;
+  feature_type: string;
+  hgvsc: string;
+  hgvsp: string;
+  impact_score: number;
+  mane_plus: boolean;
+  mane_select: boolean;
+  picked: boolean;
+  protein_position: string;
+  refseq_mrna_id: string[];
+  strand: string;
+  uniprot_id: string;
+  vep_impact: Impact;
+  amino_acids: {
+    reference: string;
+    variant: string;
+  };
+  codons: {
+    reference: string;
+    variant: string;
+  };
+  conservations: IConservationsEntity;
+  exon: {
+    rank: number;
+    total: number;
+  };
+  intron: {
+    rank: number;
+    total: number;
+  };
+  predictions: IPredictionEntity;
+}
+
+export interface IClinVar {
+  clinvar_id: string | undefined;
+  inheritance: string[];
+  conditions: string[];
+  clin_sig: string[];
+  interpretations: string[];
+}
+
+interface IGeneCosmic {
+  id: any;
+  score: number;
+  tumour_types_germline: string[];
+}
+
+interface IGeneDdd {
+  id: any;
+  score: number;
+  disease_name: string;
+}
+
+interface IGeneHpo {
+  id: any;
+  score: number;
+  hpo_term_id: string;
+  hpo_term_label: string;
+  hpo_term_name: string;
+}
+
+interface IGeneOmim {
+  id: any;
+  score: number;
+  inheritance: string[];
+  inheritance_code: string[];
+  name: string;
+  omim_id: string;
+}
+
+interface IGeneOrphanet {
+  id: any;
+  score: number;
+  inheritance: string;
+  disorder_id: number;
+  panel: string;
+}
+
+export interface IGeneEntity {
+  id: any;
+  score: number;
+  alias: string[];
+  biotype: string;
+  ensembl_gene_id: string;
+  entrez_gene_id: string;
+  hgnc: string;
+  location: string;
+  name: string;
+  omim_gene_id: string;
+  symbol: string;
+  consequences: IArrangerResultsTree<IConsequenceEntity>;
+  cosmic: IArrangerResultsTree<IGeneCosmic>;
+  ddd: IArrangerResultsTree<IGeneDdd>;
+  gnomad: {
+    loeuf: string;
+    pli: number;
+  };
+  hpo: IArrangerResultsTree<IGeneHpo>;
+  omim: IArrangerResultsTree<IGeneOmim>;
+  orphanet: IArrangerResultsTree<IGeneOrphanet>;
+  spliceai: {
+    score: number;
+    ds: number;
+    type: string;
+  };
+}
+
+export interface IVariantEntity {
+  id: string;
+  score: number;
+  alternate: string;
+  assembly_version: string;
+  chromosome: string;
+  dna_change: string;
+  end: number;
+  gene_external_reference: string[];
+  hash: string;
+  hgvsg: string;
+  locus: string;
+  max_impact_score: number;
+  reference: string;
+  rsnumber: string;
+  start: number;
+  variant_class: string;
+  variant_external_reference: string;
+  clinvar: IClinVar;
+  external_frequencies: IExternalFrequenciesEntity;
+  genes: IArrangerResultsTree<IGeneEntity>;
+  internal_frequencies: IVariantInternalFrequencies;
+  studies: IArrangerResultsTree<IVariantStudyEntity>;
+}
+
+export interface IVariantStudyEntity {
+  id: string;
+  score: number | null;
+  participant_ids: string[];
+  study_code: string;
+  study_id: string;
+  transmissions: string[];
+  zygosity: string[];
+  total: IBoundType;
+}
+
+export type ITableVariantEntity = IVariantEntity & {
+  key: string;
+};

--- a/src/graphql/variantsv2/queries.ts
+++ b/src/graphql/variantsv2/queries.ts
@@ -1,0 +1,504 @@
+import { gql } from '@apollo/client';
+
+export const SEARCH_VARIANT_QUERY_V2 = gql`
+  query searchVariant($sqon: JSON, $first: Int, $offset: Int, $sort: [Sort], $searchAfter: JSON) {
+    variants: variantsV2 {
+      hits(filters: $sqon, first: $first, offset: $offset, sort: $sort, searchAfter: $searchAfter) {
+        total
+        edges {
+          node {
+            alternate
+            assembly_version
+            chromosome
+            clinvar {
+              clin_sig
+              clinvar_id
+              conditions
+              inheritance
+              interpretations
+            }
+            dna_change
+            end
+            external_frequencies {
+              topmed_bravo {
+                ac
+                af
+                an
+                hom
+                het
+              }
+              gnomad_exomes_2_1_1 {
+                ac
+                af
+                an
+                hom
+              }
+              gnomad_genomes_2_1_1 {
+                ac
+                af
+                an
+                hom
+              }
+              gnomad_genomes_3 {
+                ac
+                af
+                an
+                hom
+              }
+              thousand_genomes {
+                ac
+                af
+                an
+              }
+            }
+            gene_external_reference
+            genes {
+              hits {
+                total
+                edges {
+                  node {
+                    alias
+                    biotype
+                    consequences {
+                      hits {
+                        total
+                        edges {
+                          node {
+                            aa_change
+                            amino_acids {
+                              reference
+                              variant
+                            }
+                            canonical
+                            cdna_position
+                            cds_position
+                            coding_dna_change
+                            codons {
+                              reference
+                              variant
+                            }
+                            consequence
+                            conservations {
+                              phyloP100way_vertebrate
+                              phyloP17way_primate
+                            }
+                            ensembl_feature_id
+                            ensembl_transcript_id
+                            exon {
+                              rank
+                              total
+                            }
+                            feature_type
+                            hgvsc
+                            hgvsp
+                            impact_score
+                            intron {
+                              rank
+                              total
+                            }
+                            mane_plus
+                            mane_select
+                            picked
+                            predictions {
+                              cadd_phred
+                              cadd_score
+                              dann_score
+                              fathmm_pred
+                              fathmm_score
+                              lrt_pred
+                              lrt_score
+                              polyphen2_hvar_pred
+                              polyphen2_hvar_score
+                              revel_score
+                              sift_pred
+                              sift_score
+                            }
+                            protein_position
+                            refseq_mrna_id
+                            strand
+                            uniprot_id
+                            vep_impact
+                          }
+                        }
+                      }
+                    }
+                    cosmic {
+                      hits {
+                        total
+                        edges {
+                          node {
+                            tumour_types_germline
+                          }
+                        }
+                      }
+                    }
+                    ddd {
+                      hits {
+                        total
+                        edges {
+                          node {
+                            disease_name
+                          }
+                        }
+                      }
+                    }
+                    ensembl_gene_id
+                    entrez_gene_id
+                    gnomad {
+                      loeuf
+                      pli
+                    }
+                    hgnc
+                    hpo {
+                      hits {
+                        total
+                        edges {
+                          node {
+                            hpo_term_id
+                            hpo_term_label
+                            hpo_term_name
+                          }
+                        }
+                      }
+                    }
+                    location
+                    name
+                    omim {
+                      hits {
+                        total
+                        edges {
+                          node {
+                            inheritance
+                            inheritance_code
+                            name
+                            omim_id
+                          }
+                        }
+                      }
+                    }
+                    omim_gene_id
+                    orphanet {
+                      hits {
+                        total
+                        edges {
+                          node {
+                            disorder_id
+                            panel
+                            inheritance
+                          }
+                        }
+                      }
+                    }
+                    # spliceai FIXME nested must be removed from mapping
+                    symbol
+                  }
+                }
+              }
+            }
+            hash
+            hgvsg
+            id
+            internal_frequencies {
+              total {
+                ac
+                pc
+                hom
+                pn
+                an
+                af
+                pf
+              }
+            }
+            locus
+            max_impact_score
+            reference
+            rsnumber
+            start
+            studies {
+              hits {
+                total
+                edges {
+                  node {
+                    score
+                    study_code
+                    study_id
+                    total {
+                      ac
+                      pc
+                      hom
+                      pn
+                      an
+                      af
+                      pf
+                    }
+                    transmission
+                    participant_ids
+                    zygosity
+                  }
+                }
+              }
+            }
+            variant_class
+            variant_id: id
+          }
+        }
+      }
+    }
+  }
+`;
+
+export const GET_VARIANT_ENTITY_V2 = gql`
+  query getVariantEntity($sqon: JSON) {
+    variants: variantsV2 {
+      hits(filters: $sqon) {
+        edges {
+          node {
+            alternate
+            assembly_version
+            chromosome
+            clinvar {
+              clin_sig
+              clinvar_id
+              conditions
+              inheritance
+              interpretations
+            }
+            dna_change
+            end
+            external_frequencies {
+              topmed_bravo {
+                ac
+                af
+                an
+                hom
+                het
+              }
+              gnomad_exomes_2_1_1 {
+                ac
+                af
+                an
+                hom
+              }
+              gnomad_genomes_2_1_1 {
+                ac
+                af
+                an
+                hom
+              }
+              gnomad_genomes_3 {
+                ac
+                af
+                an
+                hom
+              }
+              thousand_genomes {
+                ac
+                af
+                an
+              }
+            }
+            gene_external_reference
+            genes {
+              hits {
+                total
+                edges {
+                  node {
+                    alias
+                    biotype
+                    consequences {
+                      hits {
+                        total
+                        edges {
+                          node {
+                            aa_change
+                            amino_acids {
+                              reference
+                              variant
+                            }
+                            canonical
+                            cdna_position
+                            cds_position
+                            coding_dna_change
+                            codons {
+                              reference
+                              variant
+                            }
+                            consequence
+                            conservations {
+                              phyloP100way_vertebrate
+                              phyloP17way_primate
+                            }
+                            ensembl_feature_id
+                            ensembl_transcript_id
+                            exon {
+                              rank
+                              total
+                            }
+                            feature_type
+                            hgvsc
+                            hgvsp
+                            impact_score
+                            intron {
+                              rank
+                              total
+                            }
+                            mane_plus
+                            mane_select
+                            picked
+                            predictions {
+                              cadd_phred
+                              cadd_score
+                              dann_score
+                              fathmm_pred
+                              fathmm_score
+                              lrt_pred
+                              lrt_score
+                              polyphen2_hvar_pred
+                              polyphen2_hvar_score
+                              revel_score
+                              sift_pred
+                              sift_score
+                            }
+                            protein_position
+                            refseq_mrna_id
+                            strand
+                            uniprot_id
+                            vep_impact
+                          }
+                        }
+                      }
+                    }
+                    cosmic {
+                      hits {
+                        total
+                        edges {
+                          node {
+                            tumour_types_germline
+                          }
+                        }
+                      }
+                    }
+                    ddd {
+                      hits {
+                        total
+                        edges {
+                          node {
+                            disease_name
+                          }
+                        }
+                      }
+                    }
+                    ensembl_gene_id
+                    entrez_gene_id
+                    gnomad {
+                      loeuf
+                      pli
+                    }
+                    hgnc
+                    hpo {
+                      hits {
+                        total
+                        edges {
+                          node {
+                            hpo_term_id
+                            hpo_term_label
+                            hpo_term_name
+                          }
+                        }
+                      }
+                    }
+                    location
+                    name
+                    omim {
+                      hits {
+                        total
+                        edges {
+                          node {
+                            inheritance
+                            inheritance_code
+                            name
+                            omim_id
+                          }
+                        }
+                      }
+                    }
+                    omim_gene_id
+                    orphanet {
+                      hits {
+                        total
+                        edges {
+                          node {
+                            disorder_id
+                            panel
+                            inheritance
+                          }
+                        }
+                      }
+                    }
+                    # spliceai FIXME nested must be removed from mapping
+                    symbol
+                  }
+                }
+              }
+            }
+            hash
+            hgvsg
+            id
+            internal_frequencies {
+              total {
+                ac
+                pc
+                hom
+                pn
+                an
+                af
+                pf
+              }
+            }
+            locus
+            max_impact_score
+            reference
+            rsnumber
+            start
+            studies {
+              hits {
+                total
+                edges {
+                  node {
+                    score
+                    study_code
+                    study_id
+                    total {
+                      ac
+                      pc
+                      hom
+                      pn
+                      an
+                      af
+                      pf
+                    }
+                    transmission
+                    zygosity
+                    participant_ids
+                  }
+                }
+              }
+            }
+            variant_class
+            variant_id: id
+          }
+        }
+      }
+    }
+  }
+`;
+
+export const GET_VARIANT_COUNT_V2 = gql`
+  query getVariantsCount($sqon: JSON) {
+    variants: variantsV2 {
+      hits(filters: $sqon) {
+        total
+      }
+    }
+  }
+`;

--- a/src/utils/routes.ts
+++ b/src/utils/routes.ts
@@ -15,6 +15,8 @@ export enum STATIC_ROUTES {
   DATA_EXPLORATION_DATAFILES = '/data-exploration/datafiles',
 
   VARIANTS = '/variants',
+  //fixme variantsV2
+  VARIANTS_V2 = '/variants_v2',
 
   FILES = '/files',
   PARTICIPANTS = '/participants',
@@ -26,6 +28,8 @@ export enum STATIC_ROUTES {
 export enum DYNAMIC_ROUTES {
   DATA_EXPLORATION = '/data-exploration/:tab?',
   VARIANT_ENTITY = '/variants/:locus?',
+  //fixme variantsV2
+  VARIANT_ENTITY_V2 = '/variants_v2/:locus?',
   FILE_ENTITY = '/files/:file_id?',
   PARTICIPANT_ENTITY = '/participants/:participant_id?',
   ERROR = '/error/:status?',

--- a/src/views/DataExploration/components/SetsManagementDropdown/index.tsx
+++ b/src/views/DataExploration/components/SetsManagementDropdown/index.tsx
@@ -14,7 +14,9 @@ import { IBiospecimenEntity } from 'graphql/biospecimens/models';
 import { IFileEntity } from 'graphql/files/models';
 import { IQueryResults } from 'graphql/models';
 import { IParticipantEntity } from 'graphql/participants/models';
+//fixme variantsV2
 import { IVariantEntity } from 'graphql/variants/models';
+import { IVariantEntity as IVariantEntityV2 } from 'graphql/variantsv2/models';
 import { MenuClickEventHandler, MenuInfo } from 'rc-menu/lib/interface';
 import CreateEditModal from 'views/Dashboard/components/DashboardCards/SavedSets/CreateEditModal';
 
@@ -32,7 +34,11 @@ import styles from './index.module.scss';
 type Props = {
   idField: string;
   results: IQueryResults<
-    IParticipantEntity[] | IFileEntity[] | IBiospecimenEntity[] | IVariantEntity[]
+    | IParticipantEntity[]
+    | IFileEntity[]
+    | IBiospecimenEntity[]
+    | IVariantEntity[]
+    | IVariantEntityV2[] //fixme variantsV2
   >;
   sqon?: ISqonGroupFilter;
   selectedAllResults: boolean;

--- a/src/views/VariantEntityV2/SummaryHeader/index.module.scss
+++ b/src/views/VariantEntityV2/SummaryHeader/index.module.scss
@@ -1,0 +1,60 @@
+@import 'src/style/themes/include/colors';
+@import 'src/style/themes/include/theme.template';
+
+.container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 20px;
+  gap: 24px;
+}
+
+.link {
+  display: flex;
+  padding: 8px 16px;
+  border: 1px solid $gray-5;
+  width: 100%;
+  align-items: center;
+  justify-content: center;
+
+  &:hover {
+    background: $gray-2;
+  }
+}
+
+.participantDisabled {
+  display: flex;
+  height: 54px;
+  padding: 8px 16px;
+  border: 1px solid $gray-5;
+  width: 100%;
+  align-items: center;
+  justify-content: center;
+
+  &:hover {
+    background-color: $gray-1;
+  }
+}
+
+.icon,
+.entityCount {
+  color: $gray-9;
+}
+
+.icon {
+  font-size: 20px;
+  margin-bottom: 3px;
+}
+
+.entityCount {
+  font-size: 24px;
+  line-height: 32px;
+  font-weight: 600;
+  margin: 0 4px 0 8px;
+}
+
+.text {
+  color: $gray-7;
+  line-height: 32px;
+  margin-top: 4px;
+}

--- a/src/views/VariantEntityV2/SummaryHeader/index.tsx
+++ b/src/views/VariantEntityV2/SummaryHeader/index.tsx
@@ -1,0 +1,111 @@
+import intl from 'react-intl-universal';
+import { Link } from 'react-router-dom';
+import { ReadOutlined, UserOutlined } from '@ant-design/icons';
+import { addQuery } from '@ferlab/ui/core/components/QueryBuilder/utils/useQueryBuilderState';
+import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/utils';
+import { IVariantEntity } from '@ferlab/ui/core/pages/EntityPage/type';
+import { numberWithCommas } from '@ferlab/ui/core/utils/numberUtils';
+import { Tooltip } from 'antd';
+import { INDEXES } from 'graphql/constants';
+import { DATA_EXPLORATION_QB_ID } from 'views/DataExploration/utils/constant';
+
+import { STATIC_ROUTES } from 'utils/routes';
+
+import { IVariantStudyEntity } from '../../../graphql/variants/models';
+
+import styles from './index.module.scss';
+
+const PARTICIPANT_SAFE_GUARD = 10;
+
+interface OwnProps {
+  variant?: IVariantEntity;
+}
+
+const SummaryHeader = ({ variant }: OwnProps) => {
+  const studyCount = variant?.studies.hits.total || 0;
+  const participantCount = variant?.participant_number || 0;
+  const studyCodes =
+    variant?.studies.hits.edges.map((e) => (e.node as IVariantStudyEntity).study_code) || [];
+
+  const showParticipantsLink = participantCount >= PARTICIPANT_SAFE_GUARD;
+  const participantsIdsFromAllStudies = showParticipantsLink
+    ? variant?.studies.hits.edges.reduce((xs: string[], x) => {
+        if (x.node.participant_ids?.length) {
+          return [...xs, ...x.node.participant_ids];
+        }
+        return xs;
+      }, [])
+    : [];
+  const uniqueParticipantsFromAllStudies = [...new Set(participantsIdsFromAllStudies)];
+  return (
+    <div className={styles.container}>
+      <Link
+        to={STATIC_ROUTES.DATA_EXPLORATION_PARTICIPANTS}
+        className={styles.link}
+        onClick={() =>
+          addQuery({
+            queryBuilderId: DATA_EXPLORATION_QB_ID,
+            query: generateQuery({
+              newFilters: [
+                generateValueFilter({
+                  field: 'study.study_code',
+                  value: studyCodes,
+                  index: '',
+                }),
+              ],
+            }),
+            setAsActive: true,
+          })
+        }
+      >
+        <ReadOutlined className={styles.icon} />
+        <span className={styles.entityCount}>{numberWithCommas(studyCount)}</span>
+        <span className={styles.text}>
+          {intl.get('entities.study.count', { count: studyCount })}
+        </span>
+      </Link>
+
+      {showParticipantsLink ? (
+        <Link
+          to={STATIC_ROUTES.DATA_EXPLORATION_PARTICIPANTS}
+          className={styles.link}
+          onClick={() =>
+            addQuery({
+              queryBuilderId: DATA_EXPLORATION_QB_ID,
+              query: generateQuery({
+                newFilters: [
+                  generateValueFilter({
+                    field: 'participant_id',
+                    value: uniqueParticipantsFromAllStudies,
+                    index: INDEXES.PARTICIPANT,
+                  }),
+                ],
+              }),
+              setAsActive: true,
+            })
+          }
+        >
+          <UserOutlined className={styles.icon} />
+          <span className={styles.entityCount}>{numberWithCommas(participantCount)}</span>
+          <span className={styles.text}>
+            {intl.get('entities.variant.participant', {
+              count: participantCount,
+            })}
+          </span>
+        </Link>
+      ) : (
+        <Tooltip placement="top" title={intl.get('screen.variants.summary.participantsTooltip')}>
+          <div className={styles.participantDisabled}>
+            <UserOutlined className={styles.icon} />
+            <span className={styles.entityCount}>{numberWithCommas(participantCount)}</span>
+            <span className={styles.text}>
+              {intl.get('entities.variant.participant', { count: participantCount })}
+            </span>
+          </div>
+        </Tooltip>
+      )}
+    </div>
+  );
+};
+
+export default SummaryHeader;

--- a/src/views/VariantEntityV2/index.module.scss
+++ b/src/views/VariantEntityV2/index.module.scss
@@ -1,0 +1,32 @@
+@import 'src/style/themes/include/theme.template';
+
+.predictionLabel {
+  margin-right: 4px;
+}
+
+.canonicalIcon {
+  color: $canonical-icon-color;
+}
+
+.dotted {
+  border-bottom: 1px dotted;
+}
+
+.variantTag {
+  color: $variant-tag-color;
+  background-color: $variant-tag-bg-color;
+}
+
+.titleIcon {
+  font-size: 24px;
+}
+
+.geneExternalLink {
+  &:not(&:first-child) {
+    &::before {
+      content: ',';
+      margin-right: 4px;
+      color: $body-1;
+    }
+  }
+}

--- a/src/views/VariantEntityV2/index.tsx
+++ b/src/views/VariantEntityV2/index.tsx
@@ -1,0 +1,158 @@
+import intl from 'react-intl-universal';
+import { useParams } from 'react-router-dom';
+import { IAnchorLink } from '@ferlab/ui/core/components/AnchorMenu';
+import ExternalLink from '@ferlab/ui/core/components/ExternalLink';
+import { hydrateResults } from '@ferlab/ui/core/graphql/utils';
+import EntityPageWrapper, {
+  EntityGeneConsequences,
+  EntityPublicCohortTable,
+  EntitySummary,
+  EntityTable,
+  EntityTitle,
+} from '@ferlab/ui/core/pages/EntityPage';
+import {
+  makeClinvarRows,
+  makeGenesOrderedRow,
+} from '@ferlab/ui/core/pages/EntityPage/utils/pathogenicity';
+import { Space, Tag } from 'antd';
+import { useVariantEntity } from 'graphql/variants/actions';
+
+import LineStyleIcon from 'components/Icons/LineStyleIcon';
+import { getEntityExpandableTableMultiple } from 'utils/translation';
+
+import { getConsequencesProColumn } from './utils/consequences';
+import {
+  getFrequenciesItems,
+  getFrequenciesTableSummaryColumns,
+  getPublicCohorts,
+} from './utils/frequencies';
+import { getClinvarColumns, getGenePhenotypeColumns } from './utils/pathogenicity';
+import { getSummaryItems } from './utils/summary';
+import SummaryHeader from './SummaryHeader';
+
+import styles from './index.module.scss';
+
+enum SectionId {
+  SUMMARY = 'summary',
+  CONSEQUENCE = 'consequence',
+  FREQUENCIES = 'frequencies',
+  PATHOGENICITY = 'pathogenicity',
+}
+
+export default function VariantEntity() {
+  const { locus } = useParams<{ locus: string }>();
+
+  const links: IAnchorLink[] = [
+    { href: `#${SectionId.SUMMARY}`, title: intl.get('screen.variants.summary.summary') },
+    {
+      href: `#${SectionId.CONSEQUENCE}`,
+      title: intl.get('screen.variants.consequences.consequence'),
+    },
+    { href: `#${SectionId.FREQUENCIES}`, title: intl.get('screen.variants.frequencies.frequency') },
+    {
+      href: `#${SectionId.PATHOGENICITY}`,
+      title: intl.get('screen.variants.pathogenicity.pathogenicity'),
+    },
+  ];
+
+  const { data, loading } = useVariantEntity({
+    field: 'locus',
+    values: [locus],
+  });
+
+  const variantStudies = hydrateResults(data?.studies.hits.edges || []).map(
+    (e: any, index: number) => ({
+      ...e,
+      key: index,
+      participant_total_number: data?.participant_total_number || 0,
+    }),
+  );
+
+  return (
+    <EntityPageWrapper
+      pageId="variant-entity-page"
+      links={links}
+      data={data}
+      loading={loading}
+      emptyText={intl.get('no.data.available')}
+    >
+      <>
+        <EntityTitle
+          text={data?.hgvsg}
+          icon={<LineStyleIcon className={styles.titleIcon} />}
+          loading={loading}
+          tag={<Tag className={styles.variantTag}>Germline</Tag>}
+        />
+
+        <EntitySummary
+          id={SectionId.SUMMARY}
+          title={intl.get('screen.variants.summary.summary')}
+          header={<SummaryHeader variant={data} />}
+          data={getSummaryItems(data)}
+          loading={loading}
+        />
+
+        <EntityGeneConsequences
+          id={SectionId.CONSEQUENCE}
+          dictionary={getEntityExpandableTableMultiple()}
+          loading={loading}
+          title={intl.get('screen.variants.consequences.consequence')}
+          header={intl.get('screen.variants.consequences.geneConsequence')}
+          columns={getConsequencesProColumn()}
+          genes={data?.genes.hits.edges}
+          consequences={data?.consequences.hits.edges}
+        />
+
+        <EntityTable
+          id={SectionId.FREQUENCIES}
+          columns={getFrequenciesItems()}
+          data={variantStudies}
+          title={intl.get('screen.variants.frequencies.frequency')}
+          header={intl.get('screen.variants.frequencies.includeStudies')}
+          loading={loading}
+          summaryColumns={getFrequenciesTableSummaryColumns(data, variantStudies)}
+        />
+
+        <EntityPublicCohortTable
+          columns={getPublicCohorts()}
+          frequencies={data?.frequencies}
+          locus={data?.locus}
+          header={intl.get('screen.variants.frequencies.publicCohorts')}
+          id=""
+          loading={loading}
+          emptyMessage={intl.get('screen.variants.frequencies.noDataAvailable')}
+        />
+
+        <EntityTable
+          id={SectionId.PATHOGENICITY}
+          loading={loading}
+          title={intl.get('screen.variants.pathogenicity.pathogenicity')}
+          header={
+            <Space size={4}>
+              {intl.get('screen.variants.pathogenicity.clinVar')}
+              {data?.clinvar?.clinvar_id && (
+                <ExternalLink
+                  hasIcon
+                  href={`https://www.ncbi.nlm.nih.gov/clinvar/variation/${data?.clinvar.clinvar_id}`}
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  {data?.clinvar?.clinvar_id}
+                </ExternalLink>
+              )}
+            </Space>
+          }
+          data={makeClinvarRows(data?.clinvar)}
+          columns={getClinvarColumns()}
+        />
+
+        <EntityTable
+          id=""
+          loading={loading}
+          header={intl.get('screen.variants.pathogenicity.genePhenotype')}
+          data={makeGenesOrderedRow(data?.genes)}
+          columns={getGenePhenotypeColumns()}
+        />
+      </>
+    </EntityPageWrapper>
+  );
+}

--- a/src/views/VariantEntityV2/utils/consequences.tsx
+++ b/src/views/VariantEntityV2/utils/consequences.tsx
@@ -1,0 +1,163 @@
+import intl from 'react-intl-universal';
+import ExternalLink from '@ferlab/ui/core/components/ExternalLink';
+import CanonicalIcon from '@ferlab/ui/core/components/Icons/CanonicalIcon';
+import { ProColumnType } from '@ferlab/ui/core/components/ProTable/types';
+import ExpandableCell from '@ferlab/ui/core/components/tables/ExpandableCell';
+import StackLayout from '@ferlab/ui/core/layout/StackLayout';
+import {
+  getLongPredictionLabelIfKnown,
+  getPredictionScore,
+  getVepImpactTag,
+  INDEX_IMPACT_PREDICTION_FIELD,
+  INDEX_IMPACT_PREDICTION_SHORT_LABEL,
+  INDEX_IMPACT_SCORE,
+} from '@ferlab/ui/core/pages/EntityPage/utils/consequences';
+import { removeUnderscoreAndCapitalize } from '@ferlab/ui/core/utils/stringUtils';
+import { Space, Tooltip, Typography } from 'antd';
+import { IConsequenceEntity, Impact } from 'graphql/variants/models';
+import { capitalize } from 'lodash';
+
+import { TABLE_EMPTY_PLACE_HOLDER } from 'common/constants';
+import { getEntityConsequenceDictionary } from 'utils/translation';
+const { Text } = Typography;
+
+import styles from '../index.module.scss';
+
+export const getConsequencesProColumn = (): ProColumnType[] => [
+  {
+    title: intl.get('screen.variants.consequences.aaColumn'),
+    tooltip: intl.get('screen.variants.consequences.aaColumnTooltip'),
+    key: 'consequence',
+    render: (consequence: IConsequenceEntity) =>
+      consequence.hgvsp?.split(':')[1] || TABLE_EMPTY_PLACE_HOLDER,
+    width: '10%',
+  },
+  {
+    title: intl.get('screen.variants.consequences.consequence'),
+    dataIndex: 'consequences',
+    key: 'consequences',
+    render: (consequences) => {
+      if (!consequences.length) return TABLE_EMPTY_PLACE_HOLDER;
+      return (
+        <ExpandableCell
+          dataSource={consequences}
+          renderItem={(item: any, id) => (
+            <StackLayout horizontal key={id}>
+              <Text>{removeUnderscoreAndCapitalize(item)}</Text>
+            </StackLayout>
+          )}
+        />
+      );
+    },
+    width: '15%',
+  },
+  {
+    title: intl.get('screen.variants.consequences.cdnaChangeColumn'),
+    key: 'consequence',
+    render: (consequence: IConsequenceEntity) =>
+      consequence.hgvsc?.split(':')[1] || TABLE_EMPTY_PLACE_HOLDER,
+    width: '15%',
+  },
+  {
+    title: intl.get('screen.variants.consequences.strand'),
+    dataIndex: 'strand',
+    key: 'consequences',
+    render: (strand: string) => strand || TABLE_EMPTY_PLACE_HOLDER,
+    width: '5%',
+  },
+  {
+    title: intl.get('screen.variants.consequences.vep'),
+    dataIndex: 'vep_impact',
+    key: 'consequences',
+    render: (vep: Impact) =>
+      getVepImpactTag(vep?.toLowerCase(), getEntityConsequenceDictionary().impactTag) ||
+      TABLE_EMPTY_PLACE_HOLDER,
+    width: '5%',
+  },
+  {
+    title: intl.get('screen.variants.consequences.predictions.predictions'),
+    key: 'consequences',
+    render: (consequences) => {
+      const impact = getPredictionScore(
+        consequences.predictions,
+        getEntityConsequenceDictionary().predictions,
+      );
+      if (!impact?.length) return TABLE_EMPTY_PLACE_HOLDER;
+      return (
+        <ExpandableCell
+          dataSource={impact}
+          dictionnary={{
+            'see.less': intl.get('see.less'),
+            'see.more': intl.get('see.more'),
+          }}
+          nOfElementsWhenCollapsed={2}
+          renderItem={(item: any, id) => {
+            const predictionField = item[INDEX_IMPACT_PREDICTION_FIELD];
+            const score = item[INDEX_IMPACT_SCORE];
+            const predictionShortLabel = item[INDEX_IMPACT_PREDICTION_SHORT_LABEL];
+            const predictionLongLabel = getLongPredictionLabelIfKnown(
+              predictionField,
+              predictionShortLabel,
+            );
+            const label = predictionLongLabel || predictionShortLabel;
+            const description = label ? `${capitalize(label)} - ${score}` : score;
+            return (
+              <StackLayout className={styles.cellList} horizontal key={id}>
+                <Text className={styles.predictionLabel} type={'secondary'}>
+                  {predictionField}:
+                </Text>
+                <Text>{description}</Text>
+              </StackLayout>
+            );
+          }}
+        />
+      );
+    },
+    width: '15%',
+  },
+  {
+    title: intl.get('screen.variants.consequences.conservationColumn'),
+    dataIndex: 'conservations',
+    key: 'consequences',
+    render: (conservations) =>
+      conservations?.phylo_p17way_primate_rankscore || TABLE_EMPTY_PLACE_HOLDER,
+
+    width: '10%',
+  },
+  {
+    title: intl.get('screen.variants.consequences.transcript'),
+    key: 'consequences',
+    render: (consequence: IConsequenceEntity) => {
+      const { ensembl_transcript_id, canonical } = consequence;
+      return (
+        <Space>
+          <ExternalLink href={`https://www.ensembl.org/id/${ensembl_transcript_id}`}>
+            {ensembl_transcript_id}
+          </ExternalLink>
+          {canonical && (
+            <Tooltip title={intl.get('screen.variants.consequences.canonical')}>
+              <div>
+                <CanonicalIcon className={styles.canonicalIcon} height={14} width={14} />
+              </div>
+            </Tooltip>
+          )}
+        </Space>
+      );
+    },
+    width: '15%',
+  },
+  {
+    title: intl.get('screen.variants.consequences.refSeq'),
+    dataIndex: 'refseq_mrna_id',
+    key: 'consequences',
+    render: (refseq_mrna_id: string) =>
+      refseq_mrna_id ? (
+        <ExternalLink href={`https://www.ncbi.nlm.nih.gov/nuccore/${refseq_mrna_id}?report=graph`}>
+          {refseq_mrna_id}
+        </ExternalLink>
+      ) : (
+        TABLE_EMPTY_PLACE_HOLDER
+      ),
+    width: '10%',
+  },
+];

--- a/src/views/VariantEntityV2/utils/frequencies.tsx
+++ b/src/views/VariantEntityV2/utils/frequencies.tsx
@@ -1,0 +1,233 @@
+import intl from 'react-intl-universal';
+import { InfoCircleOutlined } from '@ant-design/icons';
+import { ProColumnType, TProTableSummary } from '@ferlab/ui/core/components/ProTable/types';
+import { updateActiveQueryField } from '@ferlab/ui/core/components/QueryBuilder/utils/useQueryBuilderState';
+import {
+  IVariantEntity,
+  IVariantFrequencies,
+  IVariantStudyEntity,
+  IVariantStudyFrequencies,
+} from '@ferlab/ui/core/pages//EntityPage/type';
+import {
+  formatQuotientOrElse,
+  formatQuotientToExponentialOrElse,
+  numberWithCommas,
+} from '@ferlab/ui/core/utils/numberUtils';
+import { Button, Space, Tooltip } from 'antd';
+import { INDEXES } from 'graphql/constants';
+import { DATA_EXPLORATION_QB_ID } from 'views/DataExploration/utils/constant';
+
+import { TABLE_EMPTY_PLACE_HOLDER } from 'common/constants';
+import { STATIC_ROUTES } from 'utils/routes';
+
+export const MIN_N_OF_PARTICIPANTS_FOR_LINK = 10;
+
+import styles from '../index.module.scss';
+
+type TInternalRow = {
+  frequencies: IVariantFrequencies;
+  key: string;
+  participant_total_number: number;
+  participant_ids: null | string[];
+  participant_number: number;
+  study_id: string;
+};
+
+export const getFrequenciesItems = (): ProColumnType[] => [
+  {
+    dataIndex: 'study_code',
+    key: 'study_code',
+    title: intl.get('screen.variants.frequencies.studies'),
+  },
+  {
+    title: intl.get('screen.variants.frequencies.participants'),
+    iconTitle: (
+      <Space>
+        <Tooltip
+          className={styles.dotted}
+          title={intl.get('screen.variants.frequencies.participantsTooltip')}
+        >
+          {intl.get('screen.variants.frequencies.participants')}
+        </Tooltip>
+        <Tooltip title={intl.get('screen.variants.frequencies.participantsInfoIconTooltip')}>
+          <InfoCircleOutlined />
+        </Tooltip>
+      </Space>
+    ),
+    key: 'participants',
+    render: (row: TInternalRow) =>
+      row?.participant_number >= MIN_N_OF_PARTICIPANTS_FOR_LINK ? (
+        <>
+          <Button
+            type="link"
+            href={STATIC_ROUTES.DATA_EXPLORATION}
+            onClick={() => {
+              updateActiveQueryField({
+                field: 'participant_id',
+                index: INDEXES.PARTICIPANT,
+                queryBuilderId: DATA_EXPLORATION_QB_ID,
+                value: row.participant_ids || [],
+              });
+            }}
+          >
+            {numberWithCommas(row.participant_number)}
+          </Button>
+          {row.participant_total_number
+            ? ` / ${numberWithCommas(row.participant_total_number)}`
+            : ''}
+        </>
+      ) : (
+        formatQuotientOrElse(row.participant_number, row.participant_total_number)
+      ),
+  },
+  {
+    title: intl.get('screen.variants.frequencies.frequency'),
+    tooltip: intl.get('screen.variants.frequencies.frequencyTooltip'),
+    key: 'frequency',
+    render: (row: TInternalRow) =>
+      formatQuotientToExponentialOrElse(row.participant_number, row.participant_total_number),
+  },
+  {
+    title: intl.get('screen.variants.frequencies.altAlleles'),
+    tooltip: intl.get('screen.variants.frequencies.altAllelesTooltip'),
+    dataIndex: 'frequencies',
+    key: 'upper_bound_kf_ac',
+    render: (frequencies: IVariantStudyFrequencies) =>
+      frequencies?.upper_bound_kf?.ac ? numberWithCommas(frequencies.upper_bound_kf.ac) : 0,
+    width: '14%',
+  },
+  {
+    title: intl.get('screen.variants.frequencies.homozygotes'),
+    tooltip: intl.get('screen.variants.frequencies.homozygotesTooltip'),
+    dataIndex: 'frequencies',
+    key: 'upper_bound_kf_homozygotes',
+    render: (frequencies: IVariantStudyFrequencies) =>
+      frequencies?.upper_bound_kf?.homozygotes
+        ? numberWithCommas(frequencies.upper_bound_kf.homozygotes)
+        : 0,
+    width: '14%',
+  },
+];
+
+export const getFrequenciesTableSummaryColumns = (
+  variant?: IVariantEntity,
+  studies?: IVariantStudyEntity[],
+): TProTableSummary[] => {
+  const hasparticipantlink: boolean =
+    studies?.some(
+      (s: IVariantStudyEntity) => s.participant_number >= MIN_N_OF_PARTICIPANTS_FOR_LINK,
+    ) || false;
+
+  return [
+    {
+      index: 0,
+      value: intl.get('screen.variants.frequencies.total'),
+    },
+    {
+      index: 1,
+      value: hasparticipantlink ? (
+        <>
+          <Button
+            type="link"
+            href={STATIC_ROUTES.DATA_EXPLORATION}
+            onClick={() => {
+              updateActiveQueryField({
+                field: 'participant_id',
+                index: INDEXES.PARTICIPANT,
+                queryBuilderId: DATA_EXPLORATION_QB_ID,
+                value: (studies || []).map((s) => s.participant_ids || []).flat(),
+              });
+            }}
+          >
+            {numberWithCommas(variant?.participant_number || 0)}
+          </Button>
+          {variant?.participant_total_number
+            ? ` / ${numberWithCommas(variant.participant_total_number)}`
+            : ''}
+        </>
+      ) : (
+        formatQuotientOrElse(
+          variant?.participant_number || 0,
+          variant?.participant_total_number || 0,
+        )
+      ),
+    },
+    {
+      index: 2,
+      value: formatQuotientToExponentialOrElse(
+        variant?.participant_number || 0,
+        variant?.participant_total_number || 0,
+      ),
+    },
+    {
+      index: 3,
+      value: variant?.frequencies?.internal?.upper_bound_kf.ac
+        ? numberWithCommas(variant.frequencies?.internal.upper_bound_kf.ac)
+        : 0,
+    },
+    {
+      index: 4,
+      value: variant?.frequencies?.internal?.upper_bound_kf.homozygotes
+        ? numberWithCommas(variant.frequencies.internal.upper_bound_kf.homozygotes)
+        : 0,
+    },
+  ];
+};
+
+export const getPublicCohorts = (): ProColumnType[] => [
+  {
+    dataIndex: 'cohort',
+    key: 'cohort',
+    render: (cohort: { cohortName: string; link?: string }) =>
+      cohort.link ? (
+        <a href={cohort.link} rel="noopener noreferrer" target="_blank">
+          {cohort.cohortName}
+        </a>
+      ) : (
+        cohort.cohortName
+      ),
+    title: intl.get('screen.variants.frequencies.cohort'),
+  },
+  {
+    dataIndex: 'alt',
+    key: 'alt',
+    render: (alt: string | number | null) => {
+      if (!alt) {
+        return TABLE_EMPTY_PLACE_HOLDER;
+      }
+      return typeof alt === 'number' ? numberWithCommas(alt) : alt;
+    },
+    title: intl.get('screen.variants.frequencies.altAlleles'),
+    tooltip: intl.get('screen.variants.frequencies.altAllelesTooltip'),
+  },
+  {
+    dataIndex: 'altRef',
+    key: 'altRef',
+    render: (altRef: string | number | null) => {
+      if (!altRef) {
+        return TABLE_EMPTY_PLACE_HOLDER;
+      }
+      return typeof altRef === 'number' ? numberWithCommas(altRef) : altRef;
+    },
+    title: intl.get('screen.variants.frequencies.altRef'),
+    tooltip: intl.get('screen.variants.frequencies.altRefTooltip'),
+  },
+  {
+    dataIndex: 'homozygotes',
+    key: 'homozygotes',
+    render: (homozygotes: string | number | null) => {
+      if (!homozygotes) {
+        return TABLE_EMPTY_PLACE_HOLDER;
+      }
+      return typeof homozygotes === 'number' ? numberWithCommas(homozygotes) : homozygotes;
+    },
+    title: intl.get('screen.variants.frequencies.homozygotes'),
+    tooltip: intl.get('screen.variants.frequencies.homozygotesTooltip'),
+  },
+  {
+    dataIndex: 'frequency',
+    key: 'frequency',
+    render: (frequency: string) => frequency || TABLE_EMPTY_PLACE_HOLDER,
+    title: intl.get('screen.variants.frequencies.frequency'),
+  },
+];

--- a/src/views/VariantEntityV2/utils/pathogenicity.tsx
+++ b/src/views/VariantEntityV2/utils/pathogenicity.tsx
@@ -1,0 +1,133 @@
+import intl from 'react-intl-universal';
+import ExternalLink from '@ferlab/ui/core/components/ExternalLink';
+import { ProColumnType } from '@ferlab/ui/core/components/ProTable/types';
+import StackLayout from '@ferlab/ui/core/layout/StackLayout';
+import {
+  CosmicConditionCell,
+  DddConditionCell,
+  HpoConditionCell,
+  OmimConditionCell,
+  OrphanetConditionCell,
+} from '@ferlab/ui/core/pages/EntityPage';
+import {
+  ClinicalGenesTableSource,
+  Conditions,
+  CosmicConditions,
+  DddConditions,
+  HpoConditions,
+  IGeneRecord,
+  Inheritance,
+  OmimConditions,
+  OmimGene,
+  OmimInheritance,
+  OrphanetConditions,
+  OrphanetInheritance,
+  SingleValuedInheritance,
+} from '@ferlab/ui/core/pages/EntityPage/type';
+import { Typography } from 'antd';
+
+import { TABLE_EMPTY_PLACE_HOLDER } from 'common/constants';
+
+export const getClinvarColumns = (): ProColumnType[] => [
+  {
+    key: 'interpretation',
+    dataIndex: 'interpretation',
+    title: intl.get('screen.variants.pathogenicity.interpretation'),
+  },
+  {
+    key: 'condition',
+    dataIndex: 'condition',
+    title: intl.get('screen.variants.pathogenicity.condition'),
+    width: '33%',
+  },
+  {
+    key: 'inheritance',
+    dataIndex: 'inheritance',
+    title: intl.get('screen.variants.pathogenicity.inheritance'),
+    width: '33%',
+  },
+];
+
+export const getGenePhenotypeColumns = (): ProColumnType[] => [
+  {
+    key: 'source',
+    dataIndex: 'source',
+    title: intl.get('screen.variants.pathogenicity.source'),
+  },
+  {
+    key: 'gene',
+    dataIndex: 'gene',
+    title: intl.get('screen.variants.pathogenicity.gene'),
+    render: (text: Conditions, record: IGeneRecord) => {
+      const { source } = record;
+      if (source === ClinicalGenesTableSource.omim) {
+        const [geneName, omimId] = record.gene as OmimGene;
+        return (
+          <>
+            {`${geneName} (MIM:`}
+            <ExternalLink href={`https://www.omim.org/entry/${omimId}`}>{omimId}</ExternalLink>)
+          </>
+        );
+      }
+      return record.gene;
+    },
+  },
+  {
+    key: 'conditions',
+    dataIndex: 'conditions',
+    render: (text: Conditions, record: IGeneRecord) => {
+      switch (record.source) {
+        case ClinicalGenesTableSource.omim:
+          return <OmimConditionCell conditions={record.conditions as OmimConditions} />;
+        case ClinicalGenesTableSource.orphanet:
+          return <OrphanetConditionCell conditions={record.conditions as OrphanetConditions} />;
+        case ClinicalGenesTableSource.hpo:
+          return <HpoConditionCell conditions={record.conditions as HpoConditions} />;
+        case ClinicalGenesTableSource.ddd:
+          return <DddConditionCell conditions={record.conditions as DddConditions} />;
+        default:
+          return <CosmicConditionCell conditions={record.conditions as CosmicConditions} />;
+      }
+    },
+    title: intl.get('screen.variants.pathogenicity.condition'),
+    width: '33%',
+  },
+  {
+    key: 'inheritance',
+    dataIndex: 'inheritance',
+    render: (text: Inheritance, record: IGeneRecord) => {
+      const { source } = record;
+      if (source === ClinicalGenesTableSource.orphanet) {
+        const orphanetInheritance = (record.inheritance || []) as OrphanetInheritance;
+        return (
+          <>
+            {orphanetInheritance.map((inheritance: string[], index: number) => (
+              <StackLayout key={index}>
+                <Typography.Text>
+                  {inheritance ? inheritance.join(', ') : TABLE_EMPTY_PLACE_HOLDER}
+                </Typography.Text>
+              </StackLayout>
+            ))}
+          </>
+        );
+      } else if (source === ClinicalGenesTableSource.omim) {
+        const omimInheritance = record.inheritance as OmimInheritance;
+        return (
+          <>
+            {omimInheritance.map((inheritance: string[], index: number) => (
+              <StackLayout key={index}>
+                <Typography.Text>
+                  {inheritance ? inheritance.join(', ') : TABLE_EMPTY_PLACE_HOLDER}
+                </Typography.Text>
+              </StackLayout>
+            ))}
+          </>
+        );
+      }
+      const inheritance = record.inheritance as SingleValuedInheritance;
+      return inheritance || TABLE_EMPTY_PLACE_HOLDER;
+    },
+    title: intl.get('screen.variants.pathogenicity.inheritance'),
+    width: '33%',
+  },
+];

--- a/src/views/VariantEntityV2/utils/summary.tsx
+++ b/src/views/VariantEntityV2/utils/summary.tsx
@@ -1,0 +1,147 @@
+import intl from 'react-intl-universal';
+import ExternalLink from '@ferlab/ui/core/components/ExternalLink';
+import { IVariantEntity } from '@ferlab/ui/core/pages//EntityPage/type';
+import { IEntitySummaryColumns } from '@ferlab/ui/core/pages/EntityPage/EntitySummary';
+import { numberWithCommas, toExponentialNotation } from '@ferlab/ui/core/utils/numberUtils';
+import { removeUnderscoreAndCapitalize } from '@ferlab/ui/core/utils/stringUtils';
+
+import { TABLE_EMPTY_PLACE_HOLDER } from 'common/constants';
+
+import styles from '../index.module.scss';
+
+export const getSummaryItems = (variant?: IVariantEntity): IEntitySummaryColumns[] => [
+  {
+    column: {
+      lg: 12,
+      md: 24,
+      xs: 24,
+    },
+    rows: [
+      {
+        title: '',
+        data: [
+          {
+            label: intl.get('screen.variants.summary.variant'),
+            value: variant?.hgvsg || TABLE_EMPTY_PLACE_HOLDER,
+          },
+          {
+            label: intl.get('screen.variants.summary.type'),
+            value: variant?.variant_class || TABLE_EMPTY_PLACE_HOLDER,
+          },
+          {
+            label: intl.get('screen.variants.summary.cytoband'),
+            value: variant?.genes?.hits?.edges[0]
+              ? variant.genes.hits.edges[0].node.location
+              : TABLE_EMPTY_PLACE_HOLDER,
+          },
+          {
+            label: intl.get('screen.variants.summary.referenceGenome'),
+            value: variant?.genome_build || TABLE_EMPTY_PLACE_HOLDER,
+          },
+          {
+            label: intl.get('screen.variants.summary.genes'),
+            value: variant?.genes?.hits?.edges?.length
+              ? variant.genes.hits.edges.map((gene) => {
+                  if (!gene?.node?.symbol) {
+                    return;
+                  }
+                  return (
+                    <ExternalLink
+                      key={gene.node.symbol}
+                      className={styles.geneExternalLink}
+                      href={`https://useast.ensembl.org/Homo_sapiens/Gene/Summary?g=${gene.node.symbol}`}
+                    >
+                      {gene.node.symbol}
+                    </ExternalLink>
+                  );
+                })
+              : TABLE_EMPTY_PLACE_HOLDER,
+          },
+          {
+            label: intl.get('screen.variants.summary.omim'),
+            value: variant?.genes?.hits?.edges?.length
+              ? variant.genes.hits.edges.map((gene) => {
+                  if (!gene?.node?.omim_gene_id) {
+                    return;
+                  }
+                  return (
+                    <ExternalLink
+                      key={gene.node.omim_gene_id}
+                      className={styles.geneExternalLink}
+                      href={`https://omim.org/entry/${gene.node.omim_gene_id}`}
+                    >
+                      {gene.node.omim_gene_id}
+                    </ExternalLink>
+                  );
+                })
+              : TABLE_EMPTY_PLACE_HOLDER,
+          },
+          {
+            label: intl.get('screen.variants.summary.clinVar'),
+            value:
+              removeUnderscoreAndCapitalize(
+                variant?.clinvar?.clin_sig.join(', ') || TABLE_EMPTY_PLACE_HOLDER,
+              ) || TABLE_EMPTY_PLACE_HOLDER,
+          },
+          {
+            label: intl.get('screen.variants.summary.participants'),
+            value: variant?.participant_number
+              ? numberWithCommas(variant.participant_number)
+              : TABLE_EMPTY_PLACE_HOLDER,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    column: {
+      lg: 12,
+      md: 24,
+      xs: 24,
+    },
+    rows: [
+      {
+        title: 'Frequencies',
+        data: [
+          {
+            label: intl.get('screen.variants.summary.gnomadGenome311'),
+            value:
+              toExponentialNotation(variant?.frequencies?.gnomad_genomes_3_1_1?.af) ||
+              TABLE_EMPTY_PLACE_HOLDER,
+          },
+          {
+            label: intl.get('screen.variants.summary.studies'),
+            value: variant?.studies?.hits?.edges?.length || TABLE_EMPTY_PLACE_HOLDER,
+          },
+        ],
+      },
+      {
+        title: 'External Reference',
+        data: [
+          {
+            label: intl.get('screen.variants.summary.clinVar'),
+            value: variant?.clinvar?.clinvar_id ? (
+              <ExternalLink
+                href={`https://www.ncbi.nlm.nih.gov/clinvar/variation/${variant.clinvar.clinvar_id}`}
+              >
+                {variant?.clinvar?.clinvar_id}
+              </ExternalLink>
+            ) : (
+              TABLE_EMPTY_PLACE_HOLDER
+            ),
+          },
+          {
+            label: intl.get('screen.variants.summary.dbSNP'),
+            value: variant?.rsnumber ? (
+              <ExternalLink href={`https://www.ncbi.nlm.nih.gov/snp/${variant?.rsnumber}`}>
+                {variant?.rsnumber}
+              </ExternalLink>
+            ) : (
+              TABLE_EMPTY_PLACE_HOLDER
+            ),
+          },
+        ],
+      },
+    ],
+  },
+];

--- a/src/views/VariantsV2/components/ConsequencesCell/consequences.ts
+++ b/src/views/VariantsV2/components/ConsequencesCell/consequences.ts
@@ -1,0 +1,70 @@
+import { IArrangerEdge } from '@ferlab/ui/core/graphql/types';
+import { IConsequenceEntity } from 'graphql/variantsv2/models';
+
+const keyNoSymbol = 'noSymbol_';
+
+/*
+ * Algorithm:
+ *   Input: consequences
+ *   #=====#
+ *   - IF consequence has NO gene (symbol) then keep it;
+ *   - IF consequence has multiple symbols, then keep one consequence per symbol.
+ *   - IF consequence has a symbol filter accordingly to these rules:
+ *      for a given symbol,
+ *        find consequence with highest score s
+ *        IF multiple consequences with same score s then find the one that is canonical
+ *          IF canonical does not exist then grab whatever consequence with score s.
+ *   #=====#
+ *   Output: filtered consequences.
+ * */
+export const filterThanSortConsequencesByImpact = (
+  consequences: IArrangerEdge<IConsequenceEntity>[],
+) => {
+  if (!consequences || consequences.length === 0) {
+    return [];
+  }
+  return consequences
+    .filter((c) => c.node?.impact_score !== null)
+    .map((c) => ({ ...c }))
+    .sort(
+      (a, b) =>
+        b.node.impact_score! - a.node.impact_score! || +b.node.canonical! - +a.node.canonical!,
+    );
+};
+type SymbolToConsequences = {
+  [key: string]: IArrangerEdge<IConsequenceEntity>[];
+};
+
+export const generateConsequencesDataLines = (
+  rawConsequences: IArrangerEdge<IConsequenceEntity>[] | null,
+): IArrangerEdge<IConsequenceEntity>[] => {
+  if (!rawConsequences || rawConsequences.length === 0) {
+    return [];
+  }
+
+  const ensemblTranscriptIdToConsequences: SymbolToConsequences =
+    rawConsequences.reduce<SymbolToConsequences>(
+      (dict: SymbolToConsequences, consequence: IArrangerEdge<IConsequenceEntity>) => {
+        const keyForCurrentConsequence = consequence.node?.ensembl_transcript_id || keyNoSymbol;
+        const oldConsequences = dict[keyForCurrentConsequence] || [];
+        return {
+          ...dict,
+          [keyForCurrentConsequence]: [...oldConsequences, { ...consequence }],
+        };
+      },
+      {},
+    );
+
+  return Object.entries(ensemblTranscriptIdToConsequences).reduce(
+    (acc: IArrangerEdge<IConsequenceEntity>[], [key, consequences]) => {
+      // no gene then show
+      if (key === keyNoSymbol) {
+        return [...acc, ...consequences];
+      }
+
+      const highestRanked = filterThanSortConsequencesByImpact(consequences)[0] || {};
+      return [...acc, { ...highestRanked }];
+    },
+    [],
+  );
+};

--- a/src/views/VariantsV2/components/ConsequencesCell/index.module.scss
+++ b/src/views/VariantsV2/components/ConsequencesCell/index.module.scss
@@ -1,0 +1,40 @@
+@import 'src/style/themes/include/colors';
+
+.stackLayout {
+  min-width: 375px;
+}
+
+.consequenceUl {
+  list-style: none;
+  padding: 0;
+}
+
+.highImpact {
+  fill: $red-5;
+}
+
+.lowImpact {
+  fill: $green-6;
+}
+
+.moderateImpact {
+  fill: $orange-5;
+}
+
+.modifierImpact {
+  fill: $gray-6;
+}
+
+.detail {
+  padding-right: 12px;
+}
+
+.bullet {
+  margin-right: 8px;
+  min-width: 10px;
+  min-height: 10px;
+}
+
+.symbol {
+  padding-right: 8px;
+}

--- a/src/views/VariantsV2/components/ConsequencesCell/index.tsx
+++ b/src/views/VariantsV2/components/ConsequencesCell/index.tsx
@@ -1,0 +1,67 @@
+import ExternalLink from '@ferlab/ui/core/components/ExternalLink';
+import { IArrangerEdge } from '@ferlab/ui/core/graphql/types';
+import StackLayout from '@ferlab/ui/core/layout/StackLayout';
+import { removeUnderscoreAndCapitalize } from '@ferlab/ui/core/utils/stringUtils';
+import { IConsequenceEntity, Impact } from 'graphql/variantsv2/models';
+
+import HighBadgeIcon from 'components/Icons/VariantBadgeIcons/HighBadgeIcon';
+import LowBadgeIcon from 'components/Icons/VariantBadgeIcons/LowBadgeIcon';
+import ModerateBadgeIcon from 'components/Icons/VariantBadgeIcons/ModerateBadgeIcon';
+import ModifierBadgeIcon from 'components/Icons/VariantBadgeIcons/ModifierBadgeIcon';
+import { toKebabCase } from 'utils/helper';
+
+import { generateConsequencesDataLines } from './consequences';
+
+import style from './index.module.scss';
+
+const impactToColorClassName = Object.freeze({
+  [Impact.High]: <HighBadgeIcon svgClass={`${style.bullet} ${style.highImpact}`} />,
+  [Impact.Low]: <LowBadgeIcon svgClass={`${style.bullet} ${style.lowImpact}`} />,
+  [Impact.Moderate]: <ModerateBadgeIcon svgClass={`${style.bullet} ${style.moderateImpact}`} />,
+  [Impact.Modifier]: <ModifierBadgeIcon svgClass={`${style.bullet} ${style.modifierImpact}`} />,
+});
+
+const pickImpactBadge = (impact: Impact) => impactToColorClassName[impact];
+
+const ConsequencesCell = ({
+  consequences,
+  symbol,
+}: {
+  consequences: IArrangerEdge<IConsequenceEntity>[];
+  symbol: string;
+}) => {
+  const lines = generateConsequencesDataLines(consequences);
+  return (
+    <>
+      {lines.map((consequence, index) => {
+        /* Note: index can be used as key since the list is readonly */
+        const node = consequence.node;
+
+        if (node.consequence) {
+          return (
+            <StackLayout className={style.stackLayout} center key={index}>
+              {pickImpactBadge(node.vep_impact)}
+              <span key={index} className={style.detail}>
+                {removeUnderscoreAndCapitalize(node.consequence[0])}
+              </span>
+              {symbol && (
+                <span key={toKebabCase(symbol)} className={style.symbol}>
+                  <ExternalLink
+                    href={`https://useast.ensembl.org/Homo_sapiens/Gene/Summary?g=${symbol}`}
+                  >
+                    {symbol}
+                  </ExternalLink>
+                </span>
+              )}
+              {node.hgvsp && <span>{node.hgvsp.split(':')[1]}</span>}
+            </StackLayout>
+          );
+        }
+
+        return null;
+      })}
+    </>
+  );
+};
+
+export default ConsequencesCell;

--- a/src/views/VariantsV2/components/GeneUploadIds/index.module.scss
+++ b/src/views/VariantsV2/components/GeneUploadIds/index.module.scss
@@ -1,0 +1,11 @@
+.geneUploadIdsPopover {
+    max-width: 400px;
+
+    :global(.ant-descriptions-item) {
+        padding-bottom: 0;
+    }
+
+    :global(.ant-descriptions-item-label) {
+        font-weight: 500;
+    }
+}

--- a/src/views/VariantsV2/components/GeneUploadIds/index.tsx
+++ b/src/views/VariantsV2/components/GeneUploadIds/index.tsx
@@ -1,0 +1,137 @@
+import intl from 'react-intl-universal';
+import { updateActiveQueryField } from '@ferlab/ui/core/components/QueryBuilder/utils/useQueryBuilderState';
+import UploadIds from '@ferlab/ui/core/components/UploadIds';
+import { MatchTableItem } from '@ferlab/ui/core/components/UploadIds/types';
+import { BooleanOperators } from '@ferlab/ui/core/data/sqon/operators';
+import { MERGE_VALUES_STRATEGIES } from '@ferlab/ui/core/data/sqon/types';
+import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/utils';
+import { hydrateResults } from '@ferlab/ui/core/graphql/utils';
+import { numberWithCommas } from '@ferlab/ui/core/utils/numberUtils';
+import { Descriptions } from 'antd';
+import { INDEXES } from 'graphql/constants';
+import { CHECK_GENE_MATCH_QUERY } from 'graphql/genes/queries';
+import { IGeneEntity } from 'graphql/variants/models';
+
+import { ArrangerApi } from 'services/api/arranger';
+
+import styles from './index.module.scss';
+
+interface OwnProps {
+  queryBuilderId: string;
+}
+
+const GenesUploadIds = ({ queryBuilderId }: OwnProps) => (
+  <UploadIds
+    dictionary={{
+      modalTitle: intl.get('upload.gene.ids.modal.title'),
+      submittedColTitle: intl.get('upload.gene.ids.modal.submittedColTitle'),
+      uploadBtnText: intl.get('upload.gene.ids.modal.uploadBtnText'),
+      modalUploadBtnText: intl.get('upload.gene.ids.modal.upload.file.btn'),
+      mappedTo: intl.get('upload.gene.ids.modal.mappedTo'),
+      clear: intl.get('upload.gene.ids.modal.clear.btn'),
+      emptyTableDescription: intl.get('upload.gene.ids.modal.empty.table'),
+      modalOkText: intl.get('upload.gene.ids.modal.upload.btn'),
+      modalCancelText: intl.get('upload.gene.ids.modal.cancel.btn'),
+      collapseTitle: (matchCount, unMatchCount) =>
+        intl.get('upload.gene.ids.modal.collapseTitle', {
+          matchCount: numberWithCommas(matchCount),
+          unMatchCount: numberWithCommas(unMatchCount),
+        }),
+      matchTabTitle: (matchCount) =>
+        intl.get('upload.gene.ids.modal.match', { count: numberWithCommas(matchCount) }),
+      unmatchTabTitle: (unmatchcount) =>
+        intl.get('upload.gene.ids.modal.unmatch', { count: numberWithCommas(unmatchcount) }),
+      tablesMessage: (submittedCount, mappedCount) =>
+        intl.get('upload.gene.ids.modal.table.message', {
+          submittedCount: numberWithCommas(submittedCount),
+          mappedCount: numberWithCommas(mappedCount),
+        }),
+      inputLabel: intl.get('upload.gene.ids.modal.input.label'),
+      matchTable: {
+        idColTitle: intl.get('upload.gene.ids.modal.match.table.idcol.title'),
+        matchToFieldColTitle: intl.get('upload.gene.ids.modal.match.table.matchcol.title'),
+        mappedToFieldColTitle: intl.get('upload.gene.ids.modal.match.table.mappedcol.title'),
+      },
+    }}
+    popoverProps={{
+      title: intl.get('components.uploadIds.modal.popover.title'),
+      overlayClassName: styles.geneUploadIdsPopover,
+      content: (
+        <Descriptions column={1}>
+          <Descriptions.Item label={intl.get('components.uploadIds.modal.popover.identifiers')}>
+            {intl.get('upload.gene.ids.modal.identifiers')}
+          </Descriptions.Item>
+          <Descriptions.Item
+            label={intl.get('components.uploadIds.modal.popover.separatedBy.title')}
+          >
+            {intl.get('components.uploadIds.modal.popover.separatedBy.values')}
+          </Descriptions.Item>
+          <Descriptions.Item
+            label={intl.get('components.uploadIds.modal.popover.uploadFileFormats')}
+          >
+            {intl.get('components.uploadIds.modal.popover.fileFormats')}
+          </Descriptions.Item>
+        </Descriptions>
+      ),
+    }}
+    placeHolder="ex. ENSG00000157764, TP53"
+    fetchMatch={async (ids: string[]) => {
+      const response = await ArrangerApi.graphqlRequest({
+        query: CHECK_GENE_MATCH_QUERY.loc?.source.body,
+        variables: {
+          first: 1000,
+          offset: 0,
+          sqon: generateQuery({
+            operator: BooleanOperators.or,
+            newFilters: ['symbol', 'ensembl_gene_id', 'alias'].map((field) =>
+              generateValueFilter({
+                field,
+                value: ids,
+                index: INDEXES.GENES,
+              }),
+            ),
+          }),
+        },
+      });
+
+      const genes: IGeneEntity[] = hydrateResults(response.data?.data?.genes?.hits?.edges || []);
+
+      return genes?.flatMap((gene) => {
+        const matchedIds: string[] = ids.filter((id: string) => {
+          const lowerCaseId = id.toLocaleLowerCase();
+          const lowerCaseAliases = (gene.alias || []).map((alias) => alias.toLocaleLowerCase());
+
+          return (
+            gene.symbol?.toLocaleLowerCase() === lowerCaseId ||
+            gene.ensembl_gene_id?.toLocaleLowerCase() === lowerCaseId ||
+            lowerCaseAliases.includes(lowerCaseId)
+          );
+        });
+
+        return matchedIds.map((id, index) => ({
+          key: `${gene.omim_gene_id}:${index}`,
+          submittedId: id,
+          mappedTo: gene.symbol,
+          matchTo: gene.ensembl_gene_id,
+        }));
+      });
+    }}
+    onUpload={(matches: MatchTableItem[]) => {
+      const uniqueMatches = matches.filter(
+        (match, index, currentMatch) =>
+          index === currentMatch.findIndex((m) => m.mappedTo === match.mappedTo),
+      );
+
+      return updateActiveQueryField({
+        queryBuilderId,
+        field: 'consequences.symbol',
+        value: uniqueMatches.map((match) => match.mappedTo),
+        index: INDEXES.VARIANTS,
+        merge_strategy: MERGE_VALUES_STRATEGIES.APPEND_VALUES,
+        isUploadedList: true,
+      });
+    }}
+  />
+);
+
+export default GenesUploadIds;

--- a/src/views/VariantsV2/components/PageContent/VariantsTable/index.module.scss
+++ b/src/views/VariantsV2/components/PageContent/VariantsTable/index.module.scss
@@ -1,0 +1,16 @@
+.variantTabWrapper {
+  display: flex;
+
+  :global(.ant-pagination) {
+    margin-bottom: 0;
+  }
+}
+
+.variantTableCellElipsis {
+  max-width: 200px;
+  width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  overflow-wrap: unset;
+  white-space: nowrap;
+}

--- a/src/views/VariantsV2/components/PageContent/VariantsTable/index.tsx
+++ b/src/views/VariantsV2/components/PageContent/VariantsTable/index.tsx
@@ -1,0 +1,365 @@
+// variant table
+
+import { useEffect, useState } from 'react';
+import intl from 'react-intl-universal';
+import { useDispatch } from 'react-redux';
+import { Link } from 'react-router-dom';
+import ExternalLink from '@ferlab/ui/core/components/ExternalLink';
+import ProTable from '@ferlab/ui/core/components/ProTable';
+import { PaginationViewPerQuery } from '@ferlab/ui/core/components/ProTable/Pagination/constants';
+import { ProColumnType } from '@ferlab/ui/core/components/ProTable/types';
+import { addQuery } from '@ferlab/ui/core/components/QueryBuilder/utils/useQueryBuilderState';
+import { useFilters } from '@ferlab/ui/core/data/filters/utils';
+import { ISqonGroupFilter, ISyntheticSqon } from '@ferlab/ui/core/data/sqon/types';
+import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/utils';
+import {
+  IArrangerResultsTree,
+  IQueryConfig,
+  IQueryResults,
+  TQueryConfigCb,
+} from '@ferlab/ui/core/graphql/types';
+import { numberWithCommas, toExponentialNotation } from '@ferlab/ui/core/utils/numberUtils';
+import { removeUnderscoreAndCapitalize } from '@ferlab/ui/core/utils/stringUtils';
+import GridCard from '@ferlab/ui/core/view/v2/GridCard';
+import { Tooltip } from 'antd';
+import cx from 'classnames';
+import { INDEXES } from 'graphql/constants';
+import {
+  IClinVar,
+  IExternalFrequenciesEntity,
+  IGeneEntity,
+  ITableVariantEntity,
+  IVariantEntity,
+  IVariantInternalFrequencies,
+  IVariantStudyEntity,
+} from 'graphql/variantsv2/models';
+import SetsManagementDropdown from 'views/DataExploration/components/SetsManagementDropdown';
+import { DATA_EXPLORATION_QB_ID, DEFAULT_PAGE_INDEX } from 'views/DataExploration/utils/constant';
+import { SCROLL_WRAPPER_ID, VARIANT_SAVED_SETS_FIELD } from 'views/Variants/utils/constants';
+import ConsequencesCell from 'views/VariantsV2/components/ConsequencesCell';
+
+import { TABLE_EMPTY_PLACE_HOLDER } from 'common/constants';
+import { SetType } from 'services/api/savedSet/models';
+import { useUser } from 'store/user';
+import { updateUserConfig } from 'store/user/thunks';
+import { formatQuerySortList, scrollToTop } from 'utils/helper';
+import { STATIC_ROUTES } from 'utils/routes';
+import { truncateString } from 'utils/string';
+import { getProTableDictionary } from 'utils/translation';
+
+import styles from './index.module.scss';
+
+interface OwnProps {
+  pageIndex: number;
+  sqon?: ISqonGroupFilter;
+  setPageIndex: (value: number) => void;
+  results: IQueryResults<IVariantEntity[]>;
+  setQueryConfig: TQueryConfigCb;
+  queryConfig: IQueryConfig;
+}
+
+const isNumber = (n: number) => n && !Number.isNaN(n);
+
+const defaultColumns: ProColumnType[] = [
+  {
+    title: intl.get('screen.variants.table.variant'),
+    key: 'hgvsg',
+    dataIndex: 'hgvsg',
+    className: cx(styles.variantTableCell, styles.variantTableCellElipsis),
+    sorter: {
+      multiple: 1,
+    },
+    render: (hgvsg: string, entity: IVariantEntity) =>
+      hgvsg ? (
+        <Tooltip placement="topLeft" title={hgvsg}>
+          <Link to={`${STATIC_ROUTES.VARIANTS_V2}/${entity?.locus}`}>{hgvsg}</Link>
+        </Tooltip>
+      ) : (
+        TABLE_EMPTY_PLACE_HOLDER
+      ),
+  },
+  {
+    key: 'variant_class',
+    title: 'Type',
+    dataIndex: 'variant_class',
+    sorter: {
+      multiple: 1,
+    },
+    render: (variant_class: string) => variant_class || TABLE_EMPTY_PLACE_HOLDER,
+  },
+  {
+    key: 'rsnumber',
+    title: intl.get('screen.variants.table.dbsnp'),
+    dataIndex: 'rsnumber',
+    className: styles.dbSnpTableCell,
+    sorter: {
+      multiple: 1,
+    },
+    render: (rsNumber: string) =>
+      rsNumber ? (
+        <ExternalLink href={`https://www.ncbi.nlm.nih.gov/snp/${rsNumber}`}>
+          {rsNumber}
+        </ExternalLink>
+      ) : (
+        TABLE_EMPTY_PLACE_HOLDER
+      ),
+  },
+  {
+    key: 'consequences',
+    title: intl.get('screen.variants.table.consequences.title'),
+    dataIndex: 'genes',
+    tooltip: intl.get('screen.variants.table.consequences.tooltip'),
+    render: (genes: IArrangerResultsTree<IGeneEntity>) => {
+      const geneWithPickedConsequence = genes?.hits?.edges?.find((e) =>
+        (e.node.consequences || [])?.hits?.edges?.some((e) => e.node?.picked),
+      )?.node;
+      if (!geneWithPickedConsequence) {
+        //must never happen or it is a bug
+        return TABLE_EMPTY_PLACE_HOLDER;
+      }
+
+      //fixme sort in such a way that "picked === true" is first element
+      const consequences = geneWithPickedConsequence.consequences?.hits?.edges;
+      return (
+        <ConsequencesCell
+          //TODO !!picked or first
+          consequences={consequences}
+          symbol={geneWithPickedConsequence.symbol}
+        />
+      );
+    },
+  },
+  {
+    key: 'clinvar',
+    title: intl.get('screen.variants.table.clinvar'),
+    dataIndex: 'clinvar',
+    className: cx(styles.variantTableCell, styles.variantTableCellElipsis),
+    render: (clinVar: IClinVar) =>
+      clinVar?.clin_sig && clinVar.clinvar_id ? (
+        <Tooltip
+          placement="topLeft"
+          title={removeUnderscoreAndCapitalize(clinVar.clin_sig.join(', '))}
+        >
+          <ExternalLink
+            href={`https://www.ncbi.nlm.nih.gov/clinvar/variation/${clinVar.clinvar_id}`}
+          >
+            {truncateString(removeUnderscoreAndCapitalize(clinVar.clin_sig.join(', ')), 29)}
+          </ExternalLink>
+        </Tooltip>
+      ) : (
+        TABLE_EMPTY_PLACE_HOLDER
+      ),
+  },
+  {
+    key: 'gnomad_genomes_3.af',
+    title: intl.get('screen.variants.table.gnomAD.title'),
+    tooltip: intl.get('screen.variants.table.gnomAD.tooltip'),
+    dataIndex: 'external_frequencies',
+    render: (externalFrequencies: IExternalFrequenciesEntity) =>
+      externalFrequencies?.gnomad_genomes_3?.af
+        ? toExponentialNotation(externalFrequencies?.gnomad_genomes_3.af)
+        : TABLE_EMPTY_PLACE_HOLDER,
+  },
+  {
+    title: 'Studies',
+    dataIndex: 'studies',
+    key: 'studies',
+    render: (studies: IArrangerResultsTree<IVariantStudyEntity>) =>
+      studies?.hits?.total ? numberWithCommas(studies.hits.total) : 0,
+  },
+  {
+    title: intl.get('screen.variants.table.participant.title'),
+    tooltip: intl.get('screen.variants.table.participant.tooltip'),
+    dataIndex: 'studies',
+    key: 'studies_participant',
+    render: (studies: IArrangerResultsTree<IVariantStudyEntity>) => {
+      const participantIds = studies?.hits?.edges
+        ?.map((study) => study.node.participant_ids || [])
+        .flat();
+      const nOfParticipants = participantIds.length;
+      if (nOfParticipants <= 10) {
+        return nOfParticipants;
+      }
+      return (
+        <Link
+          to={STATIC_ROUTES.DATA_EXPLORATION_PARTICIPANTS}
+          onClick={() => {
+            addQuery({
+              queryBuilderId: DATA_EXPLORATION_QB_ID,
+              query: generateQuery({
+                newFilters: [
+                  generateValueFilter({
+                    field: 'participant_id',
+                    value: participantIds,
+                    index: INDEXES.PARTICIPANT,
+                  }),
+                ],
+              }),
+              setAsActive: true,
+            });
+          }}
+        >
+          {numberWithCommas(nOfParticipants)}
+        </Link>
+      );
+    },
+  },
+  {
+    title: intl.get('screen.variants.table.frequence.title'),
+    tooltip: intl.get('screen.variants.table.frequence.tooltip'),
+    dataIndex: 'internal_frequencies',
+    key: 'internal_frequencies',
+    sorter: {
+      multiple: 1,
+    },
+    render: (internalFrequencies: IVariantInternalFrequencies) =>
+      internalFrequencies?.total?.af && isNumber(internalFrequencies.total.af)
+        ? toExponentialNotation(internalFrequencies?.total?.af)
+        : TABLE_EMPTY_PLACE_HOLDER,
+  },
+  {
+    title: intl.get('screen.variants.table.alt.title'),
+    tooltip: intl.get('screen.variants.table.alt.tooltip'),
+    dataIndex: 'alternate',
+    key: 'alternate',
+    render: (alternate: string) => alternate || TABLE_EMPTY_PLACE_HOLDER,
+  },
+  {
+    title: intl.get('screen.variants.table.homozygotes.title'),
+    tooltip: intl.get('screen.variants.table.homozygotes.tooltip'),
+    dataIndex: 'internal_frequencies',
+    key: 'homozygotes',
+    render: (internalFrequencies: IVariantInternalFrequencies) =>
+      internalFrequencies.total.hom ? numberWithCommas(internalFrequencies.total.hom) : 0,
+  },
+];
+
+const VariantsTable = ({
+  results,
+  sqon,
+  setQueryConfig,
+  queryConfig,
+  pageIndex,
+  setPageIndex,
+}: OwnProps) => {
+  const dispatch = useDispatch();
+  const { filters }: { filters: ISyntheticSqon } = useFilters();
+  const { userInfo } = useUser();
+  const [selectedKeys, setSelectedKeys] = useState<string[]>([]);
+  const [selectedRows, setSelectedRows] = useState<IVariantEntity[]>([]);
+  const [selectedAllResults, setSelectedAllResults] = useState(false);
+
+  const getCurrentSqon = (): any =>
+    selectedAllResults || !selectedKeys.length
+      ? sqon
+      : generateQuery({
+          newFilters: [
+            generateValueFilter({
+              field: 'locus',
+              index: INDEXES.VARIANTS_V2,
+              value: selectedRows.map((row) => row.locus),
+            }),
+          ],
+        });
+
+  useEffect(() => {
+    if (selectedKeys.length) {
+      setSelectedKeys([]);
+      setSelectedRows([]);
+    }
+    // eslint-disable-next-line
+  }, [JSON.stringify(filters)]);
+
+  return (
+    <GridCard
+      content={
+        <ProTable<ITableVariantEntity>
+          tableId="variants_table"
+          columns={defaultColumns}
+          enableRowSelection
+          initialColumnState={userInfo?.config.variants?.tables?.variants?.columns}
+          wrapperClassName={styles.variantTabWrapper}
+          loading={results.loading}
+          initialSelectedKey={selectedKeys}
+          showSorterTooltip={false}
+          // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
+          onChange={({ current }, _, sorter) => {
+            setPageIndex(DEFAULT_PAGE_INDEX);
+            setQueryConfig({
+              pageIndex: DEFAULT_PAGE_INDEX,
+              size: queryConfig.size!,
+              sort: formatQuerySortList(sorter),
+            });
+          }}
+          headerConfig={{
+            itemCount: {
+              pageIndex: pageIndex,
+              pageSize: queryConfig.size,
+              total: results.total,
+            },
+            enableColumnSort: true,
+            onColumnSortChange: (newState) =>
+              dispatch(
+                updateUserConfig({
+                  variants: {
+                    tables: {
+                      variants: {
+                        columns: newState,
+                      },
+                    },
+                  },
+                }),
+              ),
+            onSelectAllResultsChange: setSelectedAllResults,
+            onSelectedRowsChange: (keys, selectedRows) => {
+              setSelectedKeys(keys);
+              setSelectedRows(selectedRows);
+            },
+            extra: [
+              <SetsManagementDropdown
+                idField={VARIANT_SAVED_SETS_FIELD}
+                results={results}
+                selectedKeys={selectedKeys}
+                selectedAllResults={selectedAllResults}
+                sqon={getCurrentSqon()}
+                type={SetType.VARIANT}
+                key="variants-set-management"
+              />,
+            ],
+          }}
+          bordered
+          size="small"
+          pagination={{
+            current: pageIndex,
+            queryConfig,
+            setQueryConfig,
+            onChange: (page: number) => {
+              scrollToTop(SCROLL_WRAPPER_ID);
+              setPageIndex(page);
+            },
+            searchAfter: results.searchAfter,
+            onViewQueryChange: (viewPerQuery: PaginationViewPerQuery) => {
+              dispatch(
+                updateUserConfig({
+                  variants: {
+                    tables: {
+                      variants: {
+                        ...userInfo?.config.variants?.tables?.variants,
+                        viewPerQuery,
+                      },
+                    },
+                  },
+                }),
+              );
+            },
+            defaultViewPerQuery: queryConfig.size,
+          }}
+          dataSource={results.data.map((i) => ({ ...i, key: i.id }))}
+          dictionary={getProTableDictionary()}
+        />
+      }
+    />
+  );
+};
+
+export default VariantsTable;

--- a/src/views/VariantsV2/components/PageContent/index.module.scss
+++ b/src/views/VariantsV2/components/PageContent/index.module.scss
@@ -1,0 +1,36 @@
+@import 'src/style/themes/include/colors';
+
+.pageHeader {
+  display: flex;
+  align-items: center;
+
+  .pageHeaderTitle {
+    display: flex;
+    margin: 0;
+    font-size: 20px;
+    line-height: 28px;
+    margin-right: 1.2rem;
+  }
+
+  .dataReleaseTag {
+    color: $cyan-7;
+    display: flex;
+    align-items: center;
+    font-size: 12px;
+    height: 20px;
+
+    &:hover {
+      cursor: pointer;
+    }
+
+    span {
+      margin-right: 0.5rem;
+    }
+  }
+}
+
+.variantsPageContent {
+  width: 100%;
+  display: flex;
+  position: relative;
+}

--- a/src/views/VariantsV2/components/PageContent/index.tsx
+++ b/src/views/VariantsV2/components/PageContent/index.tsx
@@ -1,0 +1,218 @@
+import { ReactElement, useEffect, useState } from 'react';
+import intl from 'react-intl-universal';
+import { useDispatch } from 'react-redux';
+import { TExtendedMapping } from '@ferlab/ui/core/components/filters/types';
+import { resetSearchAfterQueryConfig, tieBreaker } from '@ferlab/ui/core/components/ProTable/utils';
+import QueryBuilder from '@ferlab/ui/core/components/QueryBuilder';
+import { ISavedFilter } from '@ferlab/ui/core/components/QueryBuilder/types';
+import { dotToUnderscore } from '@ferlab/ui/core/data/arranger/formatting';
+import { isEmptySqon, resolveSyntheticSqon } from '@ferlab/ui/core/data/sqon/utils';
+import { SortDirection } from '@ferlab/ui/core/graphql/constants';
+import { IExtendedMappingResults } from '@ferlab/ui/core/graphql/types';
+import { Space, Typography } from 'antd';
+import copy from 'copy-to-clipboard';
+import { useVariant } from 'graphql/variantsv2/actions';
+import { IVariantResultTree } from 'graphql/variantsv2/models';
+import { GET_VARIANT_COUNT_V2 } from 'graphql/variantsv2/queries';
+import {
+  DEFAULT_OFFSET,
+  DEFAULT_PAGE_INDEX,
+  DEFAULT_PAGE_SIZE,
+  DEFAULT_QUERY_CONFIG,
+  DEFAULT_SORT_QUERY,
+  VARIANT_REPO_QB_ID,
+} from 'views/Variants/utils/constants';
+
+import { SHARED_FILTER_ID_QUERY_PARAM_KEY } from 'common/constants';
+import LineStyleIcon from 'components/Icons/LineStyleIcon';
+import GenericFilters from 'components/uiKit/FilterList/GenericFilters';
+import useQBStateWithSavedFilters from 'hooks/useQBStateWithSavedFilters';
+import { ArrangerApi } from 'services/api/arranger';
+import { SavedFilterTag } from 'services/api/savedFilter/models';
+import { globalActions } from 'store/global';
+import {
+  createSavedFilter,
+  deleteSavedFilter,
+  setSavedFilterAsDefault,
+  updateSavedFilter,
+} from 'store/savedFilter/thunks';
+import { useSavedSet } from 'store/savedSet';
+import { useUser } from 'store/user';
+import { combineExtendedMappings } from 'utils/fieldMapper';
+import { getCurrentUrl } from 'utils/helper';
+import { getQueryBuilderDictionary } from 'utils/translation';
+
+import VariantsTable from './VariantsTable';
+
+import styles from './index.module.scss';
+
+type OwnProps = {
+  variantMapping: IExtendedMappingResults;
+};
+
+const addTagToFilter = (filter: ISavedFilter) => ({
+  ...filter,
+  tag: SavedFilterTag.VariantsExplorationPage,
+});
+
+const PageContent = ({ variantMapping }: OwnProps) => {
+  const dispatch = useDispatch();
+  const { userInfo } = useUser();
+  const { savedSets } = useSavedSet();
+  const { queryList, activeQuery, selectedSavedFilter, savedFilterList } =
+    useQBStateWithSavedFilters(VARIANT_REPO_QB_ID, SavedFilterTag.VariantsExplorationPage);
+  const [queryConfig, setQueryConfig] = useState({
+    ...DEFAULT_QUERY_CONFIG,
+    size: userInfo?.config.variants?.tables?.variants?.viewPerQuery || DEFAULT_PAGE_SIZE,
+  });
+  const [selectedFilterContent, setSelectedFilterContent] = useState<ReactElement | undefined>(
+    undefined,
+  );
+  const [pageIndex, setPageIndex] = useState(DEFAULT_PAGE_INDEX);
+
+  const variantResolvedSqon = resolveSyntheticSqon(queryList, activeQuery);
+
+  const results = useVariant(
+    {
+      first: queryConfig.size,
+      offset: DEFAULT_OFFSET,
+      searchAfter: queryConfig.searchAfter,
+      sqon: variantResolvedSqon,
+      sort: tieBreaker({
+        sort: queryConfig.sort,
+        defaultSort: DEFAULT_SORT_QUERY,
+        field: 'locus',
+        order: queryConfig.operations?.previous ? SortDirection.Desc : SortDirection.Asc,
+      }),
+    },
+    queryConfig.operations,
+  );
+
+  useEffect(() => {
+    if (queryConfig.firstPageFlag !== undefined || queryConfig.searchAfter === undefined) {
+      return;
+    }
+
+    setQueryConfig({
+      ...queryConfig,
+      firstPageFlag: queryConfig.searchAfter,
+    });
+  }, [queryConfig]);
+
+  useEffect(() => {
+    resetSearchAfterQueryConfig(
+      {
+        ...DEFAULT_QUERY_CONFIG,
+        size: userInfo?.config.variants?.tables?.variants?.viewPerQuery || DEFAULT_PAGE_SIZE,
+      },
+      setQueryConfig,
+    );
+    setPageIndex(DEFAULT_PAGE_INDEX);
+    // eslint-disable-next-line
+  }, [JSON.stringify(activeQuery)]);
+
+  const facetTransResolver = (key: string) => {
+    const title = intl.get(`facets.${key}`);
+    return title
+      ? title
+      : combineExtendedMappings([variantMapping])?.data?.find(
+          (mapping: TExtendedMapping) => key === mapping.field,
+        )?.displayName || key;
+  };
+
+  const handleOnUpdateFilter = (filter: ISavedFilter) => dispatch(updateSavedFilter(filter));
+  const handleOnSaveFilter = (filter: ISavedFilter) =>
+    dispatch(createSavedFilter(addTagToFilter(filter)));
+  const handleOnDeleteFilter = (id: string) => dispatch(deleteSavedFilter(id));
+  const handleOnSaveAsFavorite = (filter: ISavedFilter) =>
+    dispatch(setSavedFilterAsDefault(addTagToFilter(filter)));
+  const handleOnShareFilter = (filter: ISavedFilter) => {
+    copy(`${getCurrentUrl()}?${SHARED_FILTER_ID_QUERY_PARAM_KEY}=${filter.id}`);
+    dispatch(
+      globalActions.displayMessage({
+        content: 'Copied share url',
+        type: 'success',
+      }),
+    );
+  };
+
+  return (
+    <Space direction="vertical" size={24} className={styles.variantsPageContent}>
+      <div className={styles.pageHeader}>
+        <Typography.Title className={styles.pageHeaderTitle} level={1}>
+          {intl.get('screen.variants.title')}
+        </Typography.Title>
+      </div>
+
+      <QueryBuilder
+        id={VARIANT_REPO_QB_ID}
+        className="variants-repo__query-builder"
+        headerConfig={{
+          showHeader: true,
+          showTools: true,
+          defaultTitle: intl.get('components.querybuilder.defaultTitle'),
+          options: {
+            enableEditTitle: true,
+            enableDuplicate: true,
+            enableFavoriteFilter: false,
+            enableShare: true,
+            enableUndoChanges: true,
+          },
+          selectedSavedFilter: selectedSavedFilter,
+          savedFilters: savedFilterList,
+          onShareFilter: handleOnShareFilter,
+          onUpdateFilter: handleOnUpdateFilter,
+          onSaveFilter: handleOnSaveFilter,
+          onDeleteFilter: handleOnDeleteFilter,
+          onSetAsFavorite: handleOnSaveAsFavorite,
+        }}
+        facetFilterConfig={{
+          enable: true,
+          onFacetClick: (filter) => {
+            const index = filter.content.index!;
+            const field = filter.content.field;
+
+            setSelectedFilterContent(
+              <GenericFilters
+                queryBuilderId={VARIANT_REPO_QB_ID}
+                index={index}
+                field={dotToUnderscore(field)}
+                sqon={variantResolvedSqon}
+                extendedMappingResults={variantMapping}
+              />,
+            );
+          },
+          selectedFilterContent: selectedFilterContent,
+          blacklistedFacets: ['consequences.symbol', 'consequences.symbol_id_1', 'locus'],
+        }}
+        enableCombine
+        enableShowHideLabels
+        IconTotal={<LineStyleIcon width={18} height={18} />}
+        currentQuery={isEmptySqon(activeQuery) ? {} : activeQuery}
+        total={results.total}
+        dictionary={getQueryBuilderDictionary(facetTransResolver, savedSets)}
+        getResolvedQueryForCount={(sqon) => resolveSyntheticSqon(queryList, sqon)}
+        fetchQueryCount={async (sqon) => {
+          const { data } = await ArrangerApi.graphqlRequest<{ data: IVariantResultTree }>({
+            query: GET_VARIANT_COUNT_V2.loc?.source.body,
+            variables: {
+              sqon: resolveSyntheticSqon(queryList, sqon),
+            },
+          });
+
+          return data?.data?.variants.hits.total ?? 0;
+        }}
+      />
+      <VariantsTable
+        pageIndex={pageIndex}
+        sqon={variantResolvedSqon}
+        setPageIndex={setPageIndex}
+        results={results}
+        setQueryConfig={setQueryConfig}
+        queryConfig={queryConfig}
+      />
+    </Space>
+  );
+};
+
+export default PageContent;

--- a/src/views/VariantsV2/components/VariantGeneSearch/OptionItem/index.module.scss
+++ b/src/views/VariantsV2/components/VariantGeneSearch/OptionItem/index.module.scss
@@ -1,0 +1,15 @@
+@import 'src/style/themes/include/colors';
+
+.searchLabel {
+  &.variants {
+    background-color: $purple-2;
+  }
+
+  &.genes {
+    background-color: $geekblue-2;
+  }
+}
+
+.variantSearchLocus {
+  font-weight: 500;
+}

--- a/src/views/VariantsV2/components/VariantGeneSearch/OptionItem/index.tsx
+++ b/src/views/VariantsV2/components/VariantGeneSearch/OptionItem/index.tsx
@@ -1,0 +1,34 @@
+import { Space, Typography } from 'antd';
+import cx from 'classnames';
+
+import SquareLabel from 'components/uiKit/search/GlobalSearch/SquareLabel';
+import { Suggestion, SuggestionType } from 'services/api/arranger/models';
+
+import styles from './index.module.scss';
+
+interface OwnProps {
+  type: SuggestionType;
+  suggestion: Suggestion;
+  value: string;
+}
+
+enum OptionLabel {
+  VARIANT = 'VR',
+  GENE = 'GN',
+}
+
+const OptionItem = ({ type, suggestion, value }: OwnProps) => {
+  const label = type === SuggestionType.GENES ? OptionLabel.GENE : OptionLabel.VARIANT;
+
+  return (
+    <Space size={12}>
+      <SquareLabel label={label} className={cx(styles.searchLabel, styles[type])} />
+      <Space direction="vertical" size={0}>
+        <Typography.Text className={styles.variantSearchLocus}>{value}</Typography.Text>
+        {suggestion.rsnumber || suggestion.ensembl_gene_id || '--'}
+      </Space>
+    </Space>
+  );
+};
+
+export default OptionItem;

--- a/src/views/VariantsV2/components/VariantGeneSearch/index.tsx
+++ b/src/views/VariantsV2/components/VariantGeneSearch/index.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import intl from 'react-intl-universal';
+import useQueryBuilderState, {
+  updateActiveQueryField,
+} from '@ferlab/ui/core/components/QueryBuilder/utils/useQueryBuilderState';
+import { ISqonGroupFilter, MERGE_VALUES_STRATEGIES } from '@ferlab/ui/core/data/sqon/types';
+import { findSqonValueByField } from '@ferlab/ui/core/data/sqon/utils';
+import { INDEXES } from 'graphql/constants';
+import { VARIANT_REPO_QB_ID } from 'views/Variants/utils/constants';
+
+import { ICustomSearchProps } from 'components/uiKit/search/GlobalSearch';
+import SearchAutocomplete, {
+  OptionsType,
+} from 'components/uiKit/search/GlobalSearch/Search/SearchAutocomplete';
+import { ArrangerApi } from 'services/api/arranger';
+import { Suggestion, SuggestionType } from 'services/api/arranger/models';
+
+import OptionItem from './OptionItem';
+
+type OwnProps = ICustomSearchProps & {
+  type: SuggestionType;
+};
+
+const getValue = (type: SuggestionType, option: Suggestion) =>
+  (type === SuggestionType.GENES ? option.symbol : option.locus) ?? '';
+
+const VariantGeneSearch = ({ queryBuilderId, type }: OwnProps) => {
+  const [options, setOptions] = useState<OptionsType[]>([]);
+  const { activeQuery } = useQueryBuilderState(VARIANT_REPO_QB_ID);
+  const field = type === SuggestionType.VARIANTS ? 'locus' : 'consequences.symbol';
+
+  const handleSearch = async (searchText: string) => {
+    const { data } = await ArrangerApi.searchSuggestions(type, searchText);
+    setOptions(
+      data?.suggestions?.map((s) => ({
+        label: <OptionItem type={type} suggestion={s} value={getValue(type, s)} />,
+        value: getValue(type, s),
+      })) ?? [],
+    );
+    return;
+  };
+
+  return (
+    <SearchAutocomplete
+      onSearch={(value) => handleSearch(value)}
+      onSelect={(values) =>
+        updateActiveQueryField({
+          queryBuilderId,
+          field,
+          value: values,
+          index: INDEXES.VARIANTS,
+          merge_strategy: MERGE_VALUES_STRATEGIES.OVERRIDE_VALUES,
+        })
+      }
+      placeHolder={intl.get(`global.search.${type}.placeholder`)}
+      options={options}
+      selectedItems={
+        (findSqonValueByField(field, activeQuery as ISqonGroupFilter) as string[]) ?? []
+      }
+      title={intl.get(`global.search.${type}.title`)}
+      emptyDescription={intl.get(`global.search.${type}.emptyText`)}
+      tooltipText={intl.get(`global.search.${type}.tooltip`)}
+    />
+  );
+};
+
+export default VariantGeneSearch;

--- a/src/views/VariantsV2/index.module.scss
+++ b/src/views/VariantsV2/index.module.scss
@@ -1,0 +1,32 @@
+@import 'src/style/themes/include/layout';
+
+.variantsLayout {
+  display: flex;
+  height: calc(100vh - #{$main-header-height});
+
+  .filterLoader {
+    padding: 24px;
+    width: 100%;
+  }
+
+  .sideMenu {
+    li[role='menuitem'] {
+      color: white;
+
+      span[class$='-title-content'] {
+        margin-left: 0 !important;
+      }
+    }
+  }
+
+  span[role='img'].sideMenuIcon {
+    font-size: 20px !important;
+    display: flex;
+    justify-content: center;
+  }
+
+  .scrollContent {
+    width: 100%;
+    padding: $default-page-content-padding;
+  }
+}

--- a/src/views/VariantsV2/index.tsx
+++ b/src/views/VariantsV2/index.tsx
@@ -1,0 +1,240 @@
+import intl from 'react-intl-universal';
+import { UserOutlined } from '@ant-design/icons';
+import SidebarMenu, { ISidebarMenuItem } from '@ferlab/ui/core/components/SidebarMenu';
+import ScrollContent from '@ferlab/ui/core/layout/ScrollContent';
+import { INDEXES } from 'graphql/constants';
+import GenesUploadIds from 'views/Variants/components/GeneUploadIds';
+import VariantGeneSearch from 'views/Variants/components/VariantGeneSearch';
+import { VARIANT_REPO_QB_ID } from 'views/Variants/utils/constants';
+
+import DiseaseIcon from 'components/Icons/DiseaseIcon';
+import FrequencyIcon from 'components/Icons/FrequencyIcon';
+import GeneIcon from 'components/Icons/GeneIcon';
+import LineStyleIcon from 'components/Icons/LineStyleIcon';
+import FilterList from 'components/uiKit/FilterList';
+import { FilterInfo } from 'components/uiKit/FilterList/types';
+import useGetExtendedMappings from 'hooks/graphql/useGetExtendedMappings';
+import { SuggestionType } from 'services/api/arranger/models';
+
+import PageContent from './components/PageContent';
+import { SCROLL_WRAPPER_ID } from './utils/constants';
+
+import styles from 'views/Variants/index.module.scss';
+
+enum FilterTypes {
+  Participant,
+  Variant,
+  Gene,
+  Frequency,
+  Pathogenicity,
+}
+
+enum FilterKeys {
+  PARTICIPANT = 'participant',
+  VARIANTS = 'variants',
+  GENES = 'genes',
+  PATHOGENICITY = 'pathogenicity',
+  FREQUENCY = 'frequency',
+}
+
+const filterGroups: {
+  [type: string]: FilterInfo;
+} = {
+  [FilterTypes.Participant]: {
+    groups: [
+      {
+        facets: ['studies__study_code'],
+      },
+    ],
+  },
+  [FilterTypes.Variant]: {
+    customSearches: [
+      <VariantGeneSearch
+        key="variants"
+        type={SuggestionType.VARIANTS}
+        queryBuilderId={VARIANT_REPO_QB_ID}
+      />,
+    ],
+    groups: [
+      {
+        facets: [
+          'variant_class',
+          'genes__consequences__consequence',
+          'variant_external_reference',
+          'chromosome',
+          'start',
+          'studies__zygosity',
+          'studies__transmission',
+        ],
+      },
+    ],
+  },
+  [FilterTypes.Gene]: {
+    customSearches: [
+      <VariantGeneSearch
+        key="genes"
+        type={SuggestionType.GENES}
+        queryBuilderId={VARIANT_REPO_QB_ID}
+      />,
+      <GenesUploadIds key="genes_upload_ids" queryBuilderId={VARIANT_REPO_QB_ID} />,
+    ],
+    groups: [
+      {
+        facets: ['genes__biotype', 'gene_external_reference'],
+      },
+      {
+        title: intl.get('facets.genePanels'),
+        facets: [
+          'genes__hpo__hpo_term_label',
+          'genes__orphanet__panel',
+          'genes__omim__name',
+          'genes__ddd__disease_name',
+          'genes__cosmic__tumour_types_germline',
+        ],
+        tooltips: [
+          'genes__hpo__hpo_term_label',
+          'genes__omim__name',
+          'genes__ddd__disease_name',
+          'genes__cosmic__tumour_types_germline',
+        ],
+      },
+    ],
+  },
+  [FilterTypes.Pathogenicity]: {
+    groups: [
+      {
+        facets: ['clinvar__clin_sig', 'genes__consequences__vep_impact'],
+        tooltips: ['genes__consequences__vep_impact'],
+      },
+      {
+        title: 'Predictions',
+        facets: [
+          'genes__consequences__predictions__cadd_score',
+          'genes__consequences__predictions__dann_score',
+          'genes__consequences__predictions__fathmm_pred',
+          'genes__consequences__predictions__lrt_pred',
+          'genes__consequences__predictions__polyphen2_hvar_pred',
+          'genes__consequences__predictions__revel_score',
+          'genes__consequences__predictions__sift_pred',
+        ],
+        tooltips: [
+          'genes__consequences__predictions__cadd_score',
+          'genes__consequences__predictions__dann_score',
+          'genes__consequences__predictions__fathmm_pred',
+          'genes__consequences__predictions__lrt_pred',
+          'genes__consequences__predictions__polyphen2_hvar_pred',
+          'genes__consequences__predictions__revel_score',
+          'genes__consequences__predictions__sift_pred',
+        ],
+      },
+    ],
+  },
+  [FilterTypes.Frequency]: {
+    groups: [
+      {
+        facets: [
+          'internal_frequencies__total__af',
+          'external_frequencies__gnomad_genomes_2_1_1__af',
+          'external_frequencies__gnomad_genomes_3__af',
+          'external_frequencies__gnomad_genomes_3__af',
+          'external_frequencies__gnomad_exomes_2_1_1__af',
+          'external_frequencies__topmed_bravo__af',
+          'external_frequencies__thousand_genomes__af',
+        ],
+      },
+    ],
+  },
+};
+
+const Variants = () => {
+  const participantMappingResults = useGetExtendedMappings(INDEXES.PARTICIPANT);
+  const variantMappingResults = useGetExtendedMappings(INDEXES.VARIANTS_V2);
+  const menuItems: ISidebarMenuItem[] = [
+    {
+      key: '1',
+      title: intl.get('screen.variants.sidemenu.participant'),
+      icon: <UserOutlined />,
+      panelContent: (
+        <FilterList
+          loading={participantMappingResults.loading}
+          key={FilterKeys.VARIANTS}
+          index={INDEXES.VARIANTS_V2}
+          queryBuilderId={VARIANT_REPO_QB_ID}
+          extendedMappingResults={variantMappingResults}
+          filterInfo={filterGroups[FilterTypes.Participant]}
+        />
+      ),
+    },
+    {
+      key: '2',
+      title: intl.get('screen.variants.sidemenu.variant'),
+      icon: <LineStyleIcon />,
+      panelContent: (
+        <FilterList
+          loading={variantMappingResults.loading}
+          key={FilterKeys.VARIANTS}
+          index={INDEXES.VARIANTS_V2}
+          queryBuilderId={VARIANT_REPO_QB_ID}
+          extendedMappingResults={variantMappingResults}
+          filterInfo={filterGroups[FilterTypes.Variant]}
+        />
+      ),
+    },
+    {
+      key: '3',
+      title: intl.get('screen.variants.sidemenu.gene'),
+      icon: <GeneIcon />,
+      panelContent: (
+        <FilterList
+          loading={variantMappingResults.loading}
+          key={FilterKeys.GENES}
+          index={INDEXES.VARIANTS_V2}
+          queryBuilderId={VARIANT_REPO_QB_ID}
+          extendedMappingResults={variantMappingResults}
+          filterInfo={filterGroups[FilterTypes.Gene]}
+        />
+      ),
+    },
+    {
+      key: '4',
+      title: intl.get('screen.variants.sidemenu.pathogenicity'),
+      icon: <DiseaseIcon />,
+      panelContent: (
+        <FilterList
+          loading={variantMappingResults.loading}
+          key={FilterKeys.PATHOGENICITY}
+          index={INDEXES.VARIANTS_V2}
+          queryBuilderId={VARIANT_REPO_QB_ID}
+          extendedMappingResults={variantMappingResults}
+          filterInfo={filterGroups[FilterTypes.Pathogenicity]}
+        />
+      ),
+    },
+    {
+      key: '5',
+      title: intl.get('screen.variants.sidemenu.frequency'),
+      icon: <FrequencyIcon />,
+      panelContent: (
+        <FilterList
+          loading={variantMappingResults.loading}
+          key={FilterKeys.FREQUENCY}
+          index={INDEXES.VARIANTS_V2}
+          queryBuilderId={VARIANT_REPO_QB_ID}
+          extendedMappingResults={variantMappingResults}
+          filterInfo={filterGroups[FilterTypes.Frequency]}
+        />
+      ),
+    },
+  ];
+
+  return (
+    <div className={styles.variantsLayout}>
+      <SidebarMenu className={styles.sideMenu} menuItems={menuItems} />
+      <ScrollContent id={SCROLL_WRAPPER_ID} className={styles.scrollContent}>
+        <PageContent variantMapping={variantMappingResults} />
+      </ScrollContent>
+    </div>
+  );
+};
+
+export default Variants;

--- a/src/views/VariantsV2/utils/constants.ts
+++ b/src/views/VariantsV2/utils/constants.ts
@@ -1,0 +1,33 @@
+import { SortDirection } from '@ferlab/ui/core/graphql/constants';
+import { IQueryConfig, ISort } from '@ferlab/ui/core/graphql/types';
+
+export const VARIANT_SAVED_SETS_FIELD = 'locus';
+
+export const SCROLL_WRAPPER_ID = 'variants-scroll-wrapper';
+
+export const VARIANT_REPO_QB_ID = 'variant-repo-key';
+
+export const VARIANT_FILTER_TAG = 'variants';
+
+export const DEFAULT_OFFSET = 0;
+export const DEFAULT_PAGE_INDEX = 1;
+export const DEFAULT_PAGE_SIZE = 20;
+
+export const DEFAULT_SORT_QUERY = [
+  { field: 'max_impact_score', order: SortDirection.Desc },
+  { field: 'hgvsg', order: SortDirection.Asc },
+] as ISort[];
+
+export enum TAB_IDS {
+  SUMMARY = 'summary',
+  VARIANTS = 'variants',
+}
+
+export const DEFAULT_QUERY_CONFIG: IQueryConfig = {
+  pageIndex: DEFAULT_OFFSET,
+  size: DEFAULT_PAGE_SIZE,
+  sort: DEFAULT_SORT_QUERY,
+  searchAfter: undefined,
+  firstPageFlag: undefined,
+  operations: undefined,
+};


### PR DESCRIPTION
WORK IN PROGRESS

adding stuff for new variants

Variant exploration page and variant entity page were duplicated in folders names were appended with `V2`. Same thing for queries.

exploration page for new variants can be accessed .../variants`_v2`/

![image](https://github.com/include-dcc/include-portal-ui/assets/54366437/4c20811e-f35c-446f-87fc-a18f7bf09f7a)
