### PR TITLE
fix: SJIP-498 eliminate unwanted mondo roots

### DIFF
--- a/src/views/DataExploration/utils/OntologyTree.tsx
+++ b/src/views/DataExploration/utils/OntologyTree.tsx
@@ -1,5 +1,7 @@
 import { IPhenotypeSource } from 'graphql/summary/models';
 
+import { EXCLUDED_MONDO_ROOTS } from './constant';
+
 export type TreeNode = {
   title: string;
   key: string;
@@ -18,15 +20,13 @@ export type TreeNode = {
 
 export type TTitleFormatter = (title: string) => React.ReactElement | string;
 
-export const lightTreeNodeConstructor = (key: string, children: TreeNode[] = []): TreeNode => {
-  return {
-    title: key,
-    key: key,
-    children,
-    valueText: 0,
-    name: key,
-  };
-};
+export const lightTreeNodeConstructor = (key: string, children: TreeNode[] = []): TreeNode => ({
+  title: key,
+  key: key,
+  children,
+  valueText: 0,
+  name: key,
+});
 
 const termRegex = new RegExp('[^-]+$');
 
@@ -59,8 +59,8 @@ export const searchTree = (element: TreeNode, matchingTitle: string): TreeNode |
   if (element.title === matchingTitle) {
     return element;
   } else if (element.children != null) {
-    var i;
-    var result = null;
+    let i;
+    let result = null;
     for (i = 0; result == null && i < element.children.length; i++) {
       result = searchTree(element.children[i], matchingTitle);
     }
@@ -125,7 +125,10 @@ export default class OntologyTree {
     workingPhenotypes.forEach((sourcePhenotype) => {
       let phenotype: TreeNode;
       // start from root and then look for each element inhereting from that node
-      if (!sourcePhenotype.top_hits.parents.length || workingPhenotypes.length === 1) {
+      if (
+        (!sourcePhenotype.top_hits.parents.length || workingPhenotypes.length === 1) &&
+        !EXCLUDED_MONDO_ROOTS.find((s) => sourcePhenotype.key.includes(s))
+      ) {
         const children = this.populateNodeChild({
           source: sourcePhenotype,
           field,

--- a/src/views/DataExploration/utils/OntologyTree.tsx
+++ b/src/views/DataExploration/utils/OntologyTree.tsx
@@ -59,9 +59,8 @@ export const searchTree = (element: TreeNode, matchingTitle: string): TreeNode |
   if (element.title === matchingTitle) {
     return element;
   } else if (element.children != null) {
-    let i;
     let result = null;
-    for (i = 0; result == null && i < element.children.length; i++) {
+    for (let i = 0; result == null && i < element.children.length; i++) {
       result = searchTree(element.children[i], matchingTitle);
     }
     return result;

--- a/src/views/DataExploration/utils/constant.ts
+++ b/src/views/DataExploration/utils/constant.ts
@@ -10,6 +10,8 @@ export const DATA_EXPLORATION_QB_ID = 'data-exploration-repo-key';
 export const DEFAULT_PAGE_INDEX = 1;
 export const DEFAULT_PAGE_SIZE = 20;
 
+export const EXCLUDED_MONDO_ROOTS = ['MONDO:0042489'];
+
 export const CAVATICA_FILE_BATCH_SIZE = 10000;
 
 export const DATA_EPLORATION_FILTER_TAG = 'data-exploration';


### PR DESCRIPTION
# FIX  : Remove Unwanted second root node

- closes # [SJIP-498](https://d3b.atlassian.net/browse/SJIP-498)

## Description

![image](https://github.com/include-dcc/include-portal-ui/assets/29788342/330c9f8a-b355-48a3-ac45-20e17225cb63)

We have to remove other top roots as both the tree and sunburst cannot support them.  

Acceptance Criterias

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
![image](https://github.com/include-dcc/include-portal-ui/assets/29788342/7ae28958-5338-4415-9d67-4372a8826484)


### After
![image](https://github.com/include-dcc/include-portal-ui/assets/29788342/3f7f7742-bd13-495f-a544-eedf10d1d883)

## QA

Steps to validate
Url (storybook, ...)
...

## Mention

@kstonge @luclemo

