### PR TITLE
style(tooltip): SJIP-499 update white space

### DIFF
--- a/src/style/themes/include/antd/tooltips.less
+++ b/src/style/themes/include/antd/tooltips.less
@@ -3,6 +3,6 @@
 
 .@{tooltip-prefix-cls} {
   &-inner {
-    white-space: pre;
+    white-space: pre-line;
   }
 }


### PR DESCRIPTION
# FIX : long tooltip display

- closes [SJIP-499](https://d3b.atlassian.net/browse/SJIP-499)

## Description

Long tooltip go out of the box.

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/caa0b2cf-89a6-4e85-b64b-e0d93282ca99)

### After
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/13c04ffd-bf95-4294-8fd3-5a9ce8bc8aa4)
