### PR TITLE
fix(variant explo v2): SJIP-506 add pill translations

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -813,6 +813,8 @@ const en = {
     },
     studies: {
       study_code: 'Study Code',
+      transmission: 'Transmission',
+      zygosity: 'Zygosity',
     },
     is_proband: 'Proband',
     study_id: 'Study Code',
@@ -901,6 +903,28 @@ const en = {
       },
     },
     genes: {
+      consequences: {
+        consequence: 'Consequence',
+        vep_impact: 'VEP',
+        predictions: {
+          cadd_score: 'CADD Raw',
+          cadd_phred: 'CADD Phred',
+          dann_score: 'DANN',
+          fathmm_pred: 'FATHMM',
+          lrt_pred: 'LRT',
+          polyphen2_hvar_pred: 'PolyPhen-2 HVAR',
+          revel_score: 'REVEL',
+          sift_pred: 'SIFT',
+        },
+      },
+      biotype: 'Gene Type',
+      gnomad: {
+        pli: 'gnomAD pLI',
+        loeuf: 'gnomAD LOEUF',
+      },
+      spliceai: {
+        ds: 'SpliceAI',
+      },
       hpo: {
         hpo_term_label: 'HPO',
       },
@@ -919,6 +943,28 @@ const en = {
     },
     clinvar: {
       clin_sig: 'ClinVar',
+    },
+    external_frequencies: {
+      gnomad_genomes_2_1_1: {
+        af: 'gnomAD Genome 2.1.1',
+      },
+      gnomad_genomes_3: {
+        af: 'gnomAD Genome 3',
+      },
+      gnomad_exomes_2_1_1: {
+        af: 'gnomAD Exome 2.1.1',
+      },
+      topmed_bravo: {
+        af: 'TopMed',
+      },
+      thousand_genomes: {
+        af: '1000 Genomes',
+      },
+    },
+    internal_frequencies: {
+      total: {
+        af: 'INCLUDE Allele Frequency',
+      },
     },
     frequencies: {
       internal: {


### PR DESCRIPTION
# FIX : add pill translations

- closes [SJIP-506](https://d3b.atlassian.net/browse/SJIP-506)

## Description

Translation missing for pills in variant ecploration V2.

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/f171e4bf-6a04-40ac-8f04-b492a8dd6a47)

### After
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/6406d4cc-bb7c-4dd5-a382-ce5fb11bcfa2)
