### PR TITLE
fix: SJIP-475 download biospecimen using _id and specimen_id

### DIFF
--- a/src/views/DataExploration/components/PageContent/tabs/Biospecimens/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Biospecimens/index.tsx
@@ -257,7 +257,7 @@ const BioSpecimenTab = ({ sqon }: OwnProps) => {
   const getCurrentSqon = (): any =>
     selectedAllResults || !selectedKeys.length
       ? sqon
-      : generateSelectionSqon(TAB_IDS.BIOSPECIMENS, selectedKeys);
+      : generateSelectionSqon(TAB_IDS.BIOSPECIMENS, selectedKeys, '_id');
 
   useEffect(() => {
     if (selectedKeys.length) {

--- a/src/views/DataExploration/utils/selectionSqon.ts
+++ b/src/views/DataExploration/utils/selectionSqon.ts
@@ -2,12 +2,16 @@ import { Key } from 'react';
 import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/utils';
 import { TAB_IDS } from 'views/DataExploration/utils/constant';
 
-export const generateSelectionSqon = (type: Omit<TAB_IDS, TAB_IDS.SUMMARY>, ids: Key[]) => {
+export const generateSelectionSqon = (
+  type: Omit<TAB_IDS, TAB_IDS.SUMMARY>,
+  ids: Key[],
+  sampleField: string = '',
+) => {
   let field;
 
   switch (type) {
     case TAB_IDS.BIOSPECIMENS:
-      field = 'sample_id';
+      field = sampleField || 'sample_id';
       break;
     case TAB_IDS.DATA_FILES:
       field = 'file_id';


### PR DESCRIPTION
# FIX: Export/Download not working

- closes #[SJIP-475](https://d3b.atlassian.net/browse/SJIP-475)

## Description

The biospecimen download report in `Data Exploration` and `Particpant Entity page `have different fields they need to query on.

1. Data Exploration: Query on the keys ot the table, which corresponds to the ES id. (`sample_id` cannot be use as key as it would not be unique)
2. Participant Entity Page: we use the `sample_id` in this case (it is fine in this case)

See related issue: [SJIP-435](https://d3b.atlassian.net/browse/SJIP-435) for more history on this issue.

Acceptance Criterias

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before

### After

## QA

Steps to validate
Url (storybook, ...)
...

## Mention

@kstonge @luclemo

