### PR TITLE
feat(ft): SJIP-512 add feature toggle for variant

### DIFF
--- a/src/components/Layout/Header/index.tsx
+++ b/src/components/Layout/Header/index.tsx
@@ -41,6 +41,9 @@ const Header = () => {
   const currentPathName = history.location.pathname;
   const tokenParsed = keycloak.tokenParsed as IncludeKeycloakTokenParsed;
 
+  // TODO: to remove after indexaction
+  const ft_variant = getFTEnvVarByKey('VARIANT');
+
   return (
     <>
       <NotificationBanner
@@ -82,13 +85,16 @@ const Header = () => {
               icon={<FileSearchOutlined />}
               title={intl.get('layout.main.menu.explore')}
             />
-            <HeaderLink
-              key="variant-data"
-              currentPathName={currentPathName}
-              to={[STATIC_ROUTES.VARIANTS]}
-              icon={<LineStyleIcon />}
-              title={intl.get('layout.main.menu.variants')}
-            />
+
+            {ft_variant === 'true' && (
+              <HeaderLink
+                key="variant-data"
+                currentPathName={currentPathName}
+                to={[STATIC_ROUTES.VARIANTS]}
+                icon={<LineStyleIcon />}
+                title={intl.get('layout.main.menu.variants')}
+              />
+            )}
           </nav>
         }
         extra={[


### PR DESCRIPTION
# FEAT

- closes #[512](https://d3b.atlassian.net/browse/SJIP-512)

## Description
Set the Variant Exploration page with a toggle parameter. This will allow us to see what the page looks like while it is in PRD environment without letting the user access it. 


## Screenshot
![image](https://github.com/include-dcc/include-portal-ui/assets/65532894/666a71a6-9b98-449f-a2d1-9792f19ad3ab)


