### PR TITLE
feat(explo variants): SJIP-502 add fields in subtilte consequence section

### DIFF
--- a/src/graphql/variants/models.ts
+++ b/src/graphql/variants/models.ts
@@ -171,9 +171,8 @@ export interface IGeneEntity {
   omim: IArrangerResultsTree<IGeneOmim>;
   orphanet: IArrangerResultsTree<IGeneOrphanet>;
   spliceai: {
-    score: number;
     ds: number;
-    type: string;
+    type: string[];
   };
 }
 

--- a/src/graphql/variants/queries.ts
+++ b/src/graphql/variants/queries.ts
@@ -435,6 +435,10 @@ export const GET_VARIANT_ENTITY = gql`
                         }
                       }
                     }
+                    spliceai {
+                      ds
+                      type
+                    }
                     symbol
                   }
                 }

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -913,7 +913,7 @@ const en = {
         vep_impact: 'VEP',
         predictions: {
           cadd_score: 'CADD Raw',
-          cadd_phred: 'CADD Phred',
+          cadd_phred: 'CADD phred',
           dann_score: 'DANN',
           fathmm_pred: 'FATHMM',
           lrt_pred: 'LRT',

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -913,7 +913,7 @@ const en = {
         vep_impact: 'VEP',
         predictions: {
           cadd_score: 'CADD Raw',
-          cadd_phred: 'CADD phred',
+          cadd_phred: 'CADD Phred',
           dann_score: 'DANN',
           fathmm_pred: 'FATHMM',
           lrt_pred: 'LRT',

--- a/src/utils/translation.ts
+++ b/src/utils/translation.ts
@@ -320,7 +320,7 @@ export const getFacetsDictionary = () => ({
       vep_impact: 'VEP',
       predictions: {
         cadd_score: 'CADD',
-        cadd_phred: 'CADD prhed',
+        cadd_phred: 'CADD (Phred)',
         dann_score: 'DANN',
         fathmm_pred: 'FATHMM',
         lrt_pred: 'LRT',

--- a/src/views/VariantEntity/FerlabComponent/EntityGeneConsequence.tsx
+++ b/src/views/VariantEntity/FerlabComponent/EntityGeneConsequence.tsx
@@ -40,16 +40,17 @@ export const EntityGeneConsequences = ({
     tables={
       genes?.map((gene) => ({
         columns,
-        data: hydrateResults(gene.node.consequences.hits.edges),
+        data: hydrateResults(gene?.node?.consequences?.hits?.edges || []),
         subTitle: (
           <EntityGeneConsequenceSubtitle
             gene={gene}
             dictionary={{
               gene: 'Gene',
               omim: 'Omim',
+              spliceai: 'SpliceAI',
+              gnomad_pli: 'gnomAD pLI',
+              gnomad_loeuf: 'gnomAD LOEUF',
             }}
-            omim={gene.node.omim_gene_id}
-            symbol={gene.node.symbol}
           />
         ),
       })) || []

--- a/src/views/VariantEntity/FerlabComponent/EntityGeneConsequenceSubtitle.tsx
+++ b/src/views/VariantEntity/FerlabComponent/EntityGeneConsequenceSubtitle.tsx
@@ -8,8 +8,6 @@ import styles from '@ferlab/ui/core/pages/EntityPage/EntityGeneConsequence/Entit
 
 export interface IGeneConsquenceTableGroup {
   gene: IArrangerEdge<IGeneEntity>;
-  omim: string;
-  symbol: string;
   ensembleGeneId: string;
 }
 
@@ -17,38 +15,63 @@ interface IEntityGeneConsequenceSubtitle extends Omit<IGeneConsquenceTableGroup,
   dictionary: {
     gene: string;
     omim: string;
+    spliceai: string;
+    gnomad_pli: string;
+    gnomad_loeuf: string;
   };
 }
 
 const EntityGeneConsequenceSubtitle = ({
   gene,
   dictionary,
-  omim,
-  symbol,
 }: IEntityGeneConsequenceSubtitle): React.ReactElement => (
   <div className={styles.wrapper}>
     <span>
       <span className={styles.bold}>{dictionary.gene}</span>
       <ExternalLink
         className={styles.link}
-        href={`https://useast.ensembl.org/Homo_sapiens/Gene/Summary?g=${symbol}`}
+        href={`https://useast.ensembl.org/Homo_sapiens/Gene/Summary?g=${gene?.node?.symbol}`}
       >
-        {symbol}
+        {gene?.node?.symbol}
       </ExternalLink>
     </span>
-    {omim && (
+    {gene?.node?.omim_gene_id && (
       <span>
         <span className={styles.separator}>|</span>
         <span className={styles.bold}>{dictionary.omim}</span>
-        <ExternalLink className={styles.link} href={`https://omim.org/entry/${omim}`}>
-          {omim}
+        <ExternalLink
+          className={styles.link}
+          href={`https://omim.org/entry/${gene.node.omim_gene_id}`}
+        >
+          {gene.node.omim_gene_id}
         </ExternalLink>
       </span>
     )}
     <span className={styles.bold}>
       <span className={styles.separator}>|</span>
-      {removeUnderscoreAndCapitalize(gene.node.biotype)}
+      {removeUnderscoreAndCapitalize(gene?.node?.biotype)}
     </span>
+    {gene?.node?.spliceai?.ds && (
+      <span>
+        <span className={styles.separator}>|</span>
+        <span className={styles.bold}>{dictionary.spliceai}</span>
+        <span>{gene.node.spliceai.ds}</span>
+      </span>
+    )}
+    {gene?.node?.gnomad?.pli && (
+      <span>
+        <span className={styles.separator}>|</span>
+        <span className={styles.bold}>{dictionary.gnomad_pli}</span>
+        <span>{gene.node.gnomad.pli}</span>
+      </span>
+    )}
+    {gene?.node?.gnomad?.loeuf && (
+      <span>
+        <span className={styles.separator}>|</span>
+        <span className={styles.bold}>{dictionary.gnomad_loeuf}</span>
+        <span>{gene.node.gnomad.loeuf}</span>
+      </span>
+    )}
   </div>
 );
 


### PR DESCRIPTION
# FEAT : Add fields in consequence subtitle

- closes [SJIP-502](https://d3b.atlassian.net/browse/SJIP-502)

## Description

Add fields in the consequence subtitle:

- biotype
- spliceAI ds
- gnomAD pLI
- gnomAD LOEUF

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/cab0298c-8e8c-4ae7-843a-3c0eb4ba2ebc)

### After
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/9c408767-83a6-4197-b65a-639174665563)
