### PR TITLE
fix(variant): SJIP-502 add colon after label

### DIFF
--- a/src/views/VariantEntity/FerlabComponent/EntityGeneConsequenceSubtitle.tsx
+++ b/src/views/VariantEntity/FerlabComponent/EntityGeneConsequenceSubtitle.tsx
@@ -27,7 +27,7 @@ const EntityGeneConsequenceSubtitle = ({
 }: IEntityGeneConsequenceSubtitle): React.ReactElement => (
   <div className={styles.wrapper}>
     <span>
-      <span className={styles.bold}>{dictionary.gene}</span>
+      <span className={styles.bold}>{dictionary.gene}:</span>
       <ExternalLink
         className={styles.link}
         href={`https://useast.ensembl.org/Homo_sapiens/Gene/Summary?g=${gene?.node?.symbol}`}
@@ -38,7 +38,7 @@ const EntityGeneConsequenceSubtitle = ({
     {gene?.node?.omim_gene_id && (
       <span>
         <span className={styles.separator}>|</span>
-        <span className={styles.bold}>{dictionary.omim}</span>
+        <span className={styles.bold}>{dictionary.omim}:</span>
         <ExternalLink
           className={styles.link}
           href={`https://omim.org/entry/${gene.node.omim_gene_id}`}
@@ -54,21 +54,21 @@ const EntityGeneConsequenceSubtitle = ({
     {gene?.node?.spliceai?.ds && (
       <span>
         <span className={styles.separator}>|</span>
-        <span className={styles.bold}>{dictionary.spliceai}</span>
+        <span className={styles.bold}>{dictionary.spliceai}:</span>
         <span>{gene.node.spliceai.ds}</span>
       </span>
     )}
     {gene?.node?.gnomad?.pli && (
       <span>
         <span className={styles.separator}>|</span>
-        <span className={styles.bold}>{dictionary.gnomad_pli}</span>
+        <span className={styles.bold}>{dictionary.gnomad_pli}:</span>
         <span>{gene.node.gnomad.pli}</span>
       </span>
     )}
     {gene?.node?.gnomad?.loeuf && (
       <span>
         <span className={styles.separator}>|</span>
-        <span className={styles.bold}>{dictionary.gnomad_loeuf}</span>
+        <span className={styles.bold}>{dictionary.gnomad_loeuf}:</span>
         <span>{gene.node.gnomad.loeuf}</span>
       </span>
     )}


### PR DESCRIPTION
# FIX : Consequence subtitle add colon adter label

- closes #354 

## Description

[SJIP-502](https://d3b.atlassian.net/browse/SJIP-502)
Add colon after label in subtitle.

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/ac75bcc3-15b0-4f64-a1dc-5cdb653b036f)

### After
![Screenshot from 2023-06-27 08-14-07](https://github.com/include-dcc/include-portal-ui/assets/133775440/f38038b0-a260-404c-aabc-3c90db80e9cf)
