### PR TITLE
fix(study): SJIP-526 improve max study size per query

### DIFF
--- a/src/views/Studies/index.tsx
+++ b/src/views/Studies/index.tsx
@@ -20,6 +20,8 @@ import { getProTableDictionary } from 'utils/translation';
 
 import StudyPopoverRedirect from '../DataExploration/components/StudyPopoverRedirect';
 
+import { DEFAULT_PAGE_SIZE } from './utils/constants';
+
 import styles from './index.module.scss';
 
 const { Title } = Typography;
@@ -187,6 +189,7 @@ const columns: ProColumnType<any>[] = [
 
 const Studies = () => {
   const { loading, data, total } = useStudies({
+    first: DEFAULT_PAGE_SIZE,
     sort: [
       {
         field: 'study_code',

--- a/src/views/Studies/utils/constants.ts
+++ b/src/views/Studies/utils/constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_PAGE_SIZE = 100;


### PR DESCRIPTION
# FIX |

- closes #[526](https://d3b.atlassian.net/browse/SJIP-526)

## Description
add “first“ (set to 100 - arbitrary number) variable to the payload query in order to display all the studies

{"operationName":"getStudy","variables":{"sort":[{"field":"study_code","order":"asc"}]},"query":"query getStudy($sqon: JSON, $first: Int, $offset: Int, $sort: [Sort]) {\n study {\n hits(filters: $sqon, first: $first, offset: $offset, sort: $sort) {\n total\n edges {\n node {\n id\n study_id\n study_code\n study_name\n program\n external_id\n participant_count\n family_count\n biospecimen_count\n attribution\n data_category\n website\n }\n }\n }\n }\n}"}


## Screenshot
![image](https://github.com/include-dcc/include-portal-ui/assets/65532894/29246e2e-e9c2-469f-8459-9474ca37cff1)


