### PR TITLE
fix(entity): SJIP-520 disable table export

### DIFF
--- a/src/views/FileEntity/BiospecimenTable/index.tsx
+++ b/src/views/FileEntity/BiospecimenTable/index.tsx
@@ -61,7 +61,8 @@ const BiospecimenTable = ({ file, loading }: OwnProps) => {
       columns={getBiospecimenColumns()}
       initialColumnState={userInfo?.config.files?.tables?.biospecimens?.columns}
       headerConfig={{
-        enableTableExport: true,
+        // SJIP-520, disable download
+        enableTableExport: false,
         enableColumnSort: true,
         onColumnSortChange: (newState) =>
           dispatch(

--- a/src/views/ParticipantEntity/BiospecimenTable/index.tsx
+++ b/src/views/ParticipantEntity/BiospecimenTable/index.tsx
@@ -81,7 +81,8 @@ const BiospecimenTable = ({ participant, loading }: OwnProps) => {
             key="downloadSampleData"
           />,
         ],
-        enableTableExport: true,
+        // SJIP-520, disable download
+        enableTableExport: false,
         enableColumnSort: true,
         onColumnSortChange: (newState) =>
           dispatch(

--- a/src/views/ParticipantEntity/DiagnosisTable/index.tsx
+++ b/src/views/ParticipantEntity/DiagnosisTable/index.tsx
@@ -44,7 +44,8 @@ const DiagnosisTable = ({ participant, loading }: OwnProps) => {
       columns={getDiagnosisDefaultColumns()}
       initialColumnState={initialColumnState}
       headerConfig={{
-        enableTableExport: true,
+        // SJIP-520, disable download
+        enableTableExport: false,
         enableColumnSort: true,
         onColumnSortChange: (newState) =>
           dispatch(

--- a/src/views/ParticipantEntity/PhenotypeTable/index.tsx
+++ b/src/views/ParticipantEntity/PhenotypeTable/index.tsx
@@ -44,7 +44,8 @@ const PhenotypeTable = ({ participant, loading }: OwnProps) => {
       columns={getPhenotypeDefaultColumns()}
       initialColumnState={initialColumnState}
       headerConfig={{
-        enableTableExport: true,
+        // SJIP-520, disable download
+        enableTableExport: false,
         enableColumnSort: true,
         onColumnSortChange: (newState) =>
           dispatch(

--- a/src/views/Variants/components/PageContent/VariantsTable/index.tsx
+++ b/src/views/Variants/components/PageContent/VariantsTable/index.tsx
@@ -234,9 +234,10 @@ const defaultColumns: ProColumnType[] = [
     tooltip: intl.get('screen.variants.table.frequence.tooltip'),
     dataIndex: 'internal_frequencies',
     key: 'internal_frequencies',
-    sorter: {
-      multiple: 1,
-    },
+    // SJIP-501 api broke on that one
+    // sorter: {
+    //   multiple: 1,
+    // },
     render: (internalFrequencies: IVariantInternalFrequencies) =>
       internalFrequencies?.total?.af && isNumber(internalFrequencies.total.af)
         ? toExponentialNotation(internalFrequencies?.total?.af)


### PR DESCRIPTION
# FIX

- closes #[520](https://d3b.atlassian.net/browse/SJIP-520)

## Description
Participant Entity Page:

- Diagnosis Table
![image](https://github.com/include-dcc/include-portal-ui/assets/65532894/90f94f15-a9da-49f5-a302-3bb109b64c42)

- Phenotype Tabe
- Biospecimen
![image](https://github.com/include-dcc/include-portal-ui/assets/65532894/401ea501-60eb-470d-a78a-e4b930f5b320)
(L'indexation étant en cours, il n'y avait pas de participant avec ces données)

File Entity Page:

- Participant / Sample table
![image](https://github.com/include-dcc/include-portal-ui/assets/65532894/d6852d40-2df5-43b5-81e1-699c3423e647)




