### PR TITLE
fix(gnomad): SJIP-525 update version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "include-portal-ui",
-      "version": "1.6.1",
+      "version": "1.7.0",
       "dependencies": {
         "@ant-design/icons": "^4.7.0",
         "@apollo/client": "^3.5.10",
@@ -10272,19 +10272,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -29189,12 +29176,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
-    },
-    "fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -582,7 +582,7 @@ const en = {
         clinvar: 'ClinVar',
         gnomAD: {
           title: 'gnomAD',
-          tooltip: 'gnomAD 3.1.1 Allele Frequency',
+          tooltip: 'gnomAD 3.1.2 Allele Frequency',
         },
         type: 'Type',
         variant_class: 'Variant class',
@@ -622,7 +622,7 @@ const en = {
         omim: 'OMIM',
         clinVar: 'ClinVar',
         gnomadGenome311: 'gnomAD Genome (v3.1.1)',
-        gnomadGenome3: 'gnomAD Genome (v3)',
+        gnomadGenome3: 'gnomAD Genome (v3.1.2)',
         dbSNP: 'dbSNP',
       },
       consequences: {
@@ -954,7 +954,7 @@ const en = {
         af: 'gnomAD Genome 2.1.1',
       },
       gnomad_genomes_3: {
-        af: 'gnomAD Genome 3',
+        af: 'gnomAD Genome 3.1.2',
       },
       gnomad_exomes_2_1_1: {
         af: 'gnomAD Exome 2.1.1',

--- a/src/utils/translation.ts
+++ b/src/utils/translation.ts
@@ -345,7 +345,7 @@ export const getFacetsDictionary = () => ({
   },
   external_frequencies: {
     gnomad_genomes_2_1_1: { af: 'gnomAD Genome 2.1.1' },
-    gnomad_genomes_3: { af: 'gnomAD Genome 3' },
+    gnomad_genomes_3: { af: 'gnomAD Genome 3.1.2' },
     gnomad_exomes_2_1_1: { af: 'gnomAD Exome 2.1.1' },
     topmed_bravo: { af: 'TopMed' },
     thousand_genomes: { af: '1000 Genomes' },

--- a/src/views/VariantEntity/FerlabComponent/EntityPublicCohortTable.utils.tsx
+++ b/src/views/VariantEntity/FerlabComponent/EntityPublicCohortTable.utils.tsx
@@ -31,7 +31,7 @@ export const makeRowFromFrequencies = (
       alt: gnomadGenomes3.ac || null,
       altRef: gnomadGenomes3.an || null,
       cohort: {
-        cohortName: 'gnomAD Genomes (v3)',
+        cohortName: 'gnomAD Genomes (v3.1.2)',
         link: `https://gnomad.broadinstitute.org/variant/${locus}?dataset=gnomad_r3`,
       },
       frequency: toExponentialNotation(gnomadGenomes3.af),


### PR DESCRIPTION
# FIX

- closes #[525](https://d3b.atlassian.net/browse/SJIP-525)

## Description

Goal: Specify the gnomAD version in the following areas: 


1) Table of results, gnomAD header tooltip: gnomAD 3.1.1 Allele Frequency should be gnomAD 3.1.2 Allele Frequency
![image](https://github.com/include-dcc/include-portal-ui/assets/65532894/721f7514-7c08-41f7-95cc-2de17acff61e)

2) Frequency category > gnomAD Genome 3 should be gnomAD Genome 3.1.2
![image](https://github.com/include-dcc/include-portal-ui/assets/65532894/b4c8493d-dbc9-4c7a-87cc-597c631a3c94)

3) Entity page > Summary section > Frequencies gnomAD Genome (v3) should be  gnomAD Genome (v3.1.2) 
![image](https://github.com/include-dcc/include-portal-ui/assets/65532894/c4b5ea5d-ecac-461e-b272-5591565ffa0d)

4) Entity page > Public Cohort > Cohort gnomAD Genomes (v3) should be gnomAD Genome (v3.1.2)
![image](https://github.com/include-dcc/include-portal-ui/assets/65532894/78601817-3953-4d99-ab54-956785513cef)


...

## Mention

@kstonge @luclemo

