### PR TITLE
feat(explo variants): SJIP-521 remove no data checkbox on range filter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@apollo/client": "^3.5.10",
         "@dnd-kit/core": "^4.0.3",
         "@dnd-kit/sortable": "^5.1.0",
-        "@ferlab/ui": "^7.9.9",
+        "@ferlab/ui": "^7.9.10",
         "@loadable/component": "^5.15.2",
         "@nivo/bar": "^0.79.1",
         "@nivo/pie": "^0.79.1",
@@ -2773,9 +2773,9 @@
       }
     },
     "node_modules/@ferlab/ui": {
-      "version": "7.9.9",
-      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-7.9.9.tgz",
-      "integrity": "sha512-2Ruo4nW/0luGGy/UUA4JgIw8srCPlxvBlE0q5KV50nXp1eRdoBiJ26hGEl6y1Z6+LSp8gXdfQtAEbLaBzO2LZA==",
+      "version": "7.9.10",
+      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-7.9.10.tgz",
+      "integrity": "sha512-8t2/QOycj9YlA4vrAvI4NCrmI+6D30y0+HyoTpWAadq7uTaPHdOcJHAyQdYaZKTz4MO97KE9kt6PD9MF3Asy8A==",
       "dependencies": {
         "@ant-design/icons": "^4.7.0",
         "@dnd-kit/core": "^4.0.3",
@@ -23465,9 +23465,9 @@
       "requires": {}
     },
     "@ferlab/ui": {
-      "version": "7.9.9",
-      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-7.9.9.tgz",
-      "integrity": "sha512-2Ruo4nW/0luGGy/UUA4JgIw8srCPlxvBlE0q5KV50nXp1eRdoBiJ26hGEl6y1Z6+LSp8gXdfQtAEbLaBzO2LZA==",
+      "version": "7.9.10",
+      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-7.9.10.tgz",
+      "integrity": "sha512-8t2/QOycj9YlA4vrAvI4NCrmI+6D30y0+HyoTpWAadq7uTaPHdOcJHAyQdYaZKTz4MO97KE9kt6PD9MF3Asy8A==",
       "requires": {
         "@ant-design/icons": "^4.7.0",
         "@dnd-kit/core": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@apollo/client": "^3.5.10",
     "@dnd-kit/core": "^4.0.3",
     "@dnd-kit/sortable": "^5.1.0",
-    "@ferlab/ui": "^7.9.9",
+    "@ferlab/ui": "^7.9.10",
     "@loadable/component": "^5.15.2",
     "@nivo/bar": "^0.79.1",
     "@nivo/pie": "^0.79.1",

--- a/src/components/uiKit/FilterList/CustomFilterContainer.tsx
+++ b/src/components/uiKit/FilterList/CustomFilterContainer.tsx
@@ -72,8 +72,6 @@ const CustomFilterContainer = ({
     dictionary: getFacetsDictionary(),
     noDataInputOption,
   });
-  console.log('noDataInputOption', noDataInputOption);
-  console.log('filterGroup', filterGroup);
 
   const filters = results?.aggregations ? getFilters(results?.aggregations, filterKey) : [];
   const selectedFilters = results?.data

--- a/src/components/uiKit/FilterList/CustomFilterContainer.tsx
+++ b/src/components/uiKit/FilterList/CustomFilterContainer.tsx
@@ -24,6 +24,7 @@ type OwnProps = {
   filtersOpen?: boolean;
   filterMapper?: TCustomFilterMapper;
   headerTooltip?: boolean;
+  noDataInputOption?: boolean;
 };
 
 const CustomFilterContainer = ({
@@ -36,6 +37,7 @@ const CustomFilterContainer = ({
   extendedMappingResults,
   filterMapper,
   headerTooltip,
+  noDataInputOption,
 }: OwnProps) => {
   const [isSearchVisible, setIsSearchVisible] = useState(false);
   const [isOpen, setIsOpen] = useState(defaultOpen);
@@ -61,14 +63,17 @@ const CustomFilterContainer = ({
   };
 
   const aggregations = results?.aggregations ? results?.aggregations[filterKey] : {};
-  const filterGroup = getFilterGroup(
-    found,
-    aggregations,
-    [],
-    true,
+  const filterGroup = getFilterGroup({
+    extendedMapping: found,
+    aggregation: aggregations,
+    rangeTypes: [],
+    filterFooter: true,
     headerTooltip,
-    getFacetsDictionary(),
-  );
+    dictionary: getFacetsDictionary(),
+    noDataInputOption,
+  });
+  console.log('noDataInputOption', noDataInputOption);
+  console.log('filterGroup', filterGroup);
 
   const filters = results?.aggregations ? getFilters(results?.aggregations, filterKey) : [];
   const selectedFilters = results?.data

--- a/src/components/uiKit/FilterList/index.tsx
+++ b/src/components/uiKit/FilterList/index.tsx
@@ -20,6 +20,7 @@ type OwnProps = {
   extendedMappingResults: IExtendedMappingResults;
   filterInfo: FilterInfo;
   filterMapper?: TCustomFilterMapper;
+  noDataInputOption?: boolean;
 };
 
 const { Text } = Typography;
@@ -43,9 +44,10 @@ const FilterList = ({
   extendedMappingResults,
   filterInfo,
   filterMapper,
+  noDataInputOption,
 }: OwnProps) => {
   const [filtersOpen, setFiltersOpen] = useState<boolean | undefined>(isAllFacetOpen(filterInfo));
-
+  console.log('noDataInputOption FilterList', noDataInputOption);
   if (extendedMappingResults.loading) {
     return <Spin className={styles.filterLoader} spinning />;
   }
@@ -87,6 +89,7 @@ const FilterList = ({
                   defaultOpen={filterInfo.defaultOpenFacets?.includes(facet) ? true : undefined}
                   filterMapper={filterMapper}
                   headerTooltip={group.tooltips?.includes(facet)}
+                  noDataInputOption={noDataInputOption}
                 />
               ) : (
                 <div key={i + ii} className={cx(styles.customFilterWrapper, styles.filter)}>

--- a/src/components/uiKit/FilterList/index.tsx
+++ b/src/components/uiKit/FilterList/index.tsx
@@ -20,7 +20,6 @@ type OwnProps = {
   extendedMappingResults: IExtendedMappingResults;
   filterInfo: FilterInfo;
   filterMapper?: TCustomFilterMapper;
-  noDataInputOption?: boolean;
 };
 
 const { Text } = Typography;
@@ -44,7 +43,6 @@ const FilterList = ({
   extendedMappingResults,
   filterInfo,
   filterMapper,
-  noDataInputOption,
 }: OwnProps) => {
   const [filtersOpen, setFiltersOpen] = useState<boolean | undefined>(isAllFacetOpen(filterInfo));
   if (extendedMappingResults.loading) {
@@ -88,7 +86,7 @@ const FilterList = ({
                   defaultOpen={filterInfo.defaultOpenFacets?.includes(facet) ? true : undefined}
                   filterMapper={filterMapper}
                   headerTooltip={group.tooltips?.includes(facet)}
-                  noDataInputOption={noDataInputOption}
+                  noDataInputOption={!group.noDataOption?.includes(facet)}
                 />
               ) : (
                 <div key={i + ii} className={cx(styles.customFilterWrapper, styles.filter)}>

--- a/src/components/uiKit/FilterList/index.tsx
+++ b/src/components/uiKit/FilterList/index.tsx
@@ -47,7 +47,6 @@ const FilterList = ({
   noDataInputOption,
 }: OwnProps) => {
   const [filtersOpen, setFiltersOpen] = useState<boolean | undefined>(isAllFacetOpen(filterInfo));
-  console.log('noDataInputOption FilterList', noDataInputOption);
   if (extendedMappingResults.loading) {
     return <Spin className={styles.filterLoader} spinning />;
   }

--- a/src/components/uiKit/FilterList/types.ts
+++ b/src/components/uiKit/FilterList/types.ts
@@ -6,6 +6,7 @@ export interface FilterGroup {
   title?: string;
   facets: string[] | React.ReactNode[];
   tooltips?: string[];
+  noDataOption?: string[];
 }
 
 export interface FilterInfo {

--- a/src/graphql/utils/Filters.tsx
+++ b/src/graphql/utils/Filters.tsx
@@ -57,7 +57,12 @@ export const generateFilters = ({
       (f: TExtendedMapping) => f.field === underscoreToDot(key),
     );
 
-    const filterGroup = getFilterGroup(found, aggregations[key], [], filterFooter);
+    const filterGroup = getFilterGroup({
+      extendedMapping: found,
+      aggregation: aggregations[key],
+      rangeTypes: [],
+      filterFooter,
+    });
     const filters = getFilters(aggregations, key);
     const selectedFilters = getSelectedFilters({
       queryBuilderId,

--- a/src/views/Variants/index.tsx
+++ b/src/views/Variants/index.tsx
@@ -171,6 +171,7 @@ const Variants = () => {
           queryBuilderId={VARIANT_REPO_QB_ID}
           extendedMappingResults={variantMappingResults}
           filterInfo={filterGroups[FilterTypes.Participant]}
+          noDataInputOption={false}
         />
       ),
     },

--- a/src/views/Variants/index.tsx
+++ b/src/views/Variants/index.tsx
@@ -171,7 +171,6 @@ const Variants = () => {
           queryBuilderId={VARIANT_REPO_QB_ID}
           extendedMappingResults={variantMappingResults}
           filterInfo={filterGroups[FilterTypes.Participant]}
-          noDataInputOption={false}
         />
       ),
     },
@@ -187,6 +186,7 @@ const Variants = () => {
           queryBuilderId={VARIANT_REPO_QB_ID}
           extendedMappingResults={variantMappingResults}
           filterInfo={filterGroups[FilterTypes.Variant]}
+          noDataInputOption={false}
         />
       ),
     },
@@ -202,6 +202,7 @@ const Variants = () => {
           queryBuilderId={VARIANT_REPO_QB_ID}
           extendedMappingResults={variantMappingResults}
           filterInfo={filterGroups[FilterTypes.Gene]}
+          noDataInputOption={false}
         />
       ),
     },
@@ -217,6 +218,7 @@ const Variants = () => {
           queryBuilderId={VARIANT_REPO_QB_ID}
           extendedMappingResults={variantMappingResults}
           filterInfo={filterGroups[FilterTypes.Pathogenicity]}
+          noDataInputOption={false}
         />
       ),
     },
@@ -232,6 +234,7 @@ const Variants = () => {
           queryBuilderId={VARIANT_REPO_QB_ID}
           extendedMappingResults={variantMappingResults}
           filterInfo={filterGroups[FilterTypes.Frequency]}
+          noDataInputOption={false}
         />
       ),
     },

--- a/src/views/Variants/index.tsx
+++ b/src/views/Variants/index.tsx
@@ -66,6 +66,7 @@ const filterGroups: {
           'studies__zygosity',
           'studies__transmission',
         ],
+        noDataOption: ['start'],
       },
     ],
   },
@@ -86,6 +87,8 @@ const filterGroups: {
           'genes__gnomad__pli',
           'genes__gnomad__loeuf',
         ],
+        tooltips: ['genes__gnomad__pli', 'genes__gnomad__loeuf'],
+        noDataOption: ['genes__gnomad__pli', 'genes__gnomad__loeuf'],
       },
       {
         title: intl.get('facets.genePanels'),
@@ -101,8 +104,6 @@ const filterGroups: {
           'genes__omim__name',
           'genes__ddd__disease_name',
           'genes__cosmic__tumour_types_germline',
-          'genes__gnomad__pli',
-          'genes__gnomad__loeuf',
         ],
       },
     ],
@@ -136,6 +137,14 @@ const filterGroups: {
           'genes__consequences__predictions__revel_score',
           'genes__consequences__predictions__sift_pred',
         ],
+        noDataOption: [
+          'genes__consequences__predictions__cadd_score',
+          'genes__consequences__predictions__cadd_phred',
+          'genes__consequences__predictions__dann_score',
+          'genes__consequences__predictions__revel_score',
+          'genes__spliceai__ds',
+          'genes__consequences__predictions__sift_pred',
+        ],
       },
     ],
   },
@@ -143,6 +152,14 @@ const filterGroups: {
     groups: [
       {
         facets: [
+          'internal_frequencies__total__af',
+          'external_frequencies__gnomad_genomes_2_1_1__af',
+          'external_frequencies__gnomad_genomes_3__af',
+          'external_frequencies__gnomad_exomes_2_1_1__af',
+          'external_frequencies__topmed_bravo__af',
+          'external_frequencies__thousand_genomes__af',
+        ],
+        noDataOption: [
           'internal_frequencies__total__af',
           'external_frequencies__gnomad_genomes_2_1_1__af',
           'external_frequencies__gnomad_genomes_3__af',
@@ -186,7 +203,6 @@ const Variants = () => {
           queryBuilderId={VARIANT_REPO_QB_ID}
           extendedMappingResults={variantMappingResults}
           filterInfo={filterGroups[FilterTypes.Variant]}
-          noDataInputOption={false}
         />
       ),
     },
@@ -202,7 +218,6 @@ const Variants = () => {
           queryBuilderId={VARIANT_REPO_QB_ID}
           extendedMappingResults={variantMappingResults}
           filterInfo={filterGroups[FilterTypes.Gene]}
-          noDataInputOption={false}
         />
       ),
     },
@@ -218,7 +233,6 @@ const Variants = () => {
           queryBuilderId={VARIANT_REPO_QB_ID}
           extendedMappingResults={variantMappingResults}
           filterInfo={filterGroups[FilterTypes.Pathogenicity]}
-          noDataInputOption={false}
         />
       ),
     },
@@ -234,7 +248,6 @@ const Variants = () => {
           queryBuilderId={VARIANT_REPO_QB_ID}
           extendedMappingResults={variantMappingResults}
           filterInfo={filterGroups[FilterTypes.Frequency]}
-          noDataInputOption={false}
         />
       ),
     },


### PR DESCRIPTION
# FEAT : Hide no data option for range filters

- closes [SJIP-521](https://d3b.atlassian.net/browse/SJIP-521)

## Description

Hide no data checbox on this facets:
- Variant > Position
- Gene > gnomAD pLI
- Gene > gnomAD LOEUF
- Pathogenicity > CADD 
- Pathogenicity > CADD (Phred)
- Pathogenicity > DANN 
- Pathogenicity > REVEL
- Pathogenicity >  SpliceAI
- Frequency > INCLUDE Allele Frequency
- Frequency > gnomAD Genome 2.1.1
- Frequency > gnomAD Genome 3
- Frequency > gnomAD Exome 2.1.1
- Frequency > TopMed
- Frequency > 1000 Genomes

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/2bd24629-c106-4cb1-bdd1-1ed28f360f76)
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/06221b44-3d29-4fe8-99d6-1ce9cf79e35a)
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/e53593c6-500d-4b3b-a7e1-e75b2d6d9c6e)
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/7e0a6133-fa1d-49cb-9c63-ea6a6fdc7b8e)
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/e12a9e65-121b-48be-9923-d866035b038b)
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/b07d95f1-5da0-4f00-a143-64362d3bbad4)
