### PR TITLE
feat(variant): SJIP-508 add redirect on study code to data explo

### DIFF
--- a/src/graphql/biospecimens/models.ts
+++ b/src/graphql/biospecimens/models.ts
@@ -1,6 +1,7 @@
 import { IFileEntity } from 'graphql/files/models';
 import { ArrangerResultsTree } from 'graphql/models';
 import { IParticipantEntity } from 'graphql/participants/models';
+import { IStudyEntity } from 'graphql/studies/models';
 
 export interface IBiospecimenResultTree {
   biospecimen: ArrangerResultsTree<IBiospecimenEntity>;
@@ -23,6 +24,7 @@ export interface IBiospecimenEntity {
   age_at_biospecimen_collection: number;
   biospecimen_storage: string;
   study_id: string;
+  study: IStudyEntity;
   laboratory_procedure: string;
   collection_sample_id: string;
   collection_sample_type: string;

--- a/src/graphql/biospecimens/queries.ts
+++ b/src/graphql/biospecimens/queries.ts
@@ -30,6 +30,10 @@ export const SEARCH_BIOSPECIMEN_QUERY = gql`
             volume_unit
             biospecimen_storage
             study_id
+            study {
+              study_code
+              study_id
+            }
             nb_files
 
             participant {

--- a/src/graphql/files/queries.ts
+++ b/src/graphql/files/queries.ts
@@ -29,6 +29,7 @@ export const SEARCH_FILES_QUERY = gql`
             }
             study {
               study_id
+              study_code
               study_name
             }
             sequencing_experiment {

--- a/src/graphql/participants/queries.ts
+++ b/src/graphql/participants/queries.ts
@@ -19,6 +19,10 @@ export const SEARCH_PARTICIPANT_QUERY = gql`
             participant_id
             external_id
             study_id
+            study {
+              study_code
+              study_id
+            }
             study_external_id
             down_syndrome_status
             sex

--- a/src/views/DataExploration/components/PageContent/tabs/Biospecimens/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Biospecimens/index.tsx
@@ -17,6 +17,7 @@ import { useBiospecimen } from 'graphql/biospecimens/actions';
 import { IBiospecimenEntity } from 'graphql/biospecimens/models';
 import { INDEXES } from 'graphql/constants';
 import { IParticipantEntity } from 'graphql/participants/models';
+import { IStudyEntity } from 'graphql/studies/models';
 import SetsManagementDropdown from 'views/DataExploration/components/SetsManagementDropdown';
 import StudyPopoverRedirect from 'views/DataExploration/components/StudyPopoverRedirect';
 import {
@@ -58,17 +59,18 @@ const getDefaultColumns = (): ProColumnType<any>[] => [
     render: (sample_id: string) => sample_id || TABLE_EMPTY_PLACE_HOLDER,
   },
   {
-    key: 'study_id',
+    key: 'study',
+    dataIndex: 'study',
     title: 'Study',
     sorter: { multiple: 1 },
-    render: (record: IBiospecimenEntity) =>
-      record.study_id ? (
+    render: (study: IStudyEntity) =>
+      study?.study_id ? (
         <StudyPopoverRedirect
-          studyId={record.study_id}
-          text={record.study_id || ''}
+          studyId={study.study_id}
+          text={study.study_code || ''}
         ></StudyPopoverRedirect>
       ) : (
-        TABLE_EMPTY_PLACE_HOLDER
+        study?.study_code || TABLE_EMPTY_PLACE_HOLDER
       ),
   },
   {

--- a/src/views/DataExploration/components/PageContent/tabs/DataFiles/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/DataFiles/index.tsx
@@ -17,6 +17,7 @@ import { Tag, Tooltip } from 'antd';
 import { INDEXES } from 'graphql/constants';
 import { useDataFiles } from 'graphql/files/actions';
 import { FileAccessType, IFileEntity, ITableFileEntity } from 'graphql/files/models';
+import { IStudyEntity } from 'graphql/studies/models';
 import SetsManagementDropdown from 'views/DataExploration/components/SetsManagementDropdown';
 import StudyPopoverRedirect from 'views/DataExploration/components/StudyPopoverRedirect';
 import {
@@ -121,17 +122,18 @@ const getDefaultColumns = (
     render: (file_name: string) => file_name || TABLE_EMPTY_PLACE_HOLDER,
   },
   {
-    key: 'study.study_id',
+    dataIndex: 'study',
+    key: 'study',
     title: 'Study',
     sorter: { multiple: 1 },
-    render: (record: IFileEntity) =>
-      record?.study?.study_id ? (
+    render: (study: IStudyEntity) =>
+      study?.study_id ? (
         <StudyPopoverRedirect
-          studyId={record.study.study_id}
-          text={record.study.study_id || ''}
+          studyId={study.study_id}
+          text={study.study_code || ''}
         ></StudyPopoverRedirect>
       ) : (
-        TABLE_EMPTY_PLACE_HOLDER
+        study?.study_code || TABLE_EMPTY_PLACE_HOLDER
       ),
   },
   {

--- a/src/views/DataExploration/components/PageContent/tabs/Participants/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Participants/index.tsx
@@ -26,6 +26,7 @@ import {
   ITableParticipantEntity,
   Sex,
 } from 'graphql/participants/models';
+import { IStudyEntity } from 'graphql/studies/models';
 import { capitalize } from 'lodash';
 import SetsManagementDropdown from 'views/DataExploration/components/SetsManagementDropdown';
 import StudyPopoverRedirect from 'views/DataExploration/components/StudyPopoverRedirect';
@@ -76,18 +77,21 @@ const defaultColumns: ProColumnType<any>[] = [
     ),
   },
   {
-    key: 'study_id',
+    key: 'study',
     title: 'Study',
-    dataIndex: 'study_id',
+    dataIndex: 'study',
     sorter: {
       multiple: 1,
     },
     className: styles.studyIdCell,
-    render: (study_id: string) =>
-      study_id ? (
-        <StudyPopoverRedirect studyId={study_id} text={study_id || ''}></StudyPopoverRedirect>
+    render: (study: IStudyEntity) =>
+      study?.study_id ? (
+        <StudyPopoverRedirect
+          studyId={study.study_id}
+          text={study.study_code || ''}
+        ></StudyPopoverRedirect>
       ) : (
-        TABLE_EMPTY_PLACE_HOLDER
+        study?.study_code || TABLE_EMPTY_PLACE_HOLDER
       ),
   },
   {

--- a/src/views/DataExploration/index.tsx
+++ b/src/views/DataExploration/index.tsx
@@ -56,7 +56,7 @@ export const filterGroups: {
     groups: [
       {
         facets: [
-          'study_id',
+          'study__study_code',
           'down_syndrome_status',
           <TreeFacet
             key="mondo"

--- a/src/views/VariantEntity/utils/frequencies.tsx
+++ b/src/views/VariantEntity/utils/frequencies.tsx
@@ -1,4 +1,5 @@
 import intl from 'react-intl-universal';
+import { Link } from 'react-router-dom';
 import { InfoCircleOutlined } from '@ant-design/icons';
 import { ProColumnType, TProTableSummary } from '@ferlab/ui/core/components/ProTable/types';
 import { addQuery } from '@ferlab/ui/core/components/QueryBuilder/utils/useQueryBuilderState';
@@ -24,6 +25,28 @@ export const getFrequenciesItems = (): ProColumnType[] => [
     dataIndex: 'study_code',
     key: 'study_code',
     title: intl.get('screen.variants.frequencies.studies'),
+    render: (study_code: string) => (
+      <Link
+        to={STATIC_ROUTES.DATA_EXPLORATION_PARTICIPANTS}
+        onClick={() =>
+          addQuery({
+            queryBuilderId: DATA_EXPLORATION_QB_ID,
+            query: generateQuery({
+              newFilters: [
+                generateValueFilter({
+                  field: 'study.study_code',
+                  value: [study_code],
+                  index: INDEXES.PARTICIPANT,
+                }),
+              ],
+            }),
+            setAsActive: true,
+          })
+        }
+      >
+        {study_code}
+      </Link>
+    ),
   },
   {
     title: intl.get('screen.variants.frequencies.participants'),


### PR DESCRIPTION
# FEAT : redirect to data explo on study code in frequency table from variant entity

- closes [SJIP-508](https://d3b.atlassian.net/browse/SJIP-508)

## Description

- Add redirect to data explo on click on study code in frequency table (variant entity page)
- Use study code instead of study id in data explo for facet and in study coloumn in each tab (point 2, 3 and 4 in https://d3b.atlassian.net/browse/SJIP-527)

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/bd98c322-703e-471a-b68e-87936a48dc9b)

### After
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/9c0e1e86-ae37-40d7-86ae-0222d8631c39)
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/e0f9420a-d1c8-40c2-91d8-c488d0120909)
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/7e3d15d3-5f01-4e8b-9dd8-681d1f37fd01)
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/5491caf8-4cf0-48d5-9bc1-20ff1f412665)
