### PR TITLE
fix(study): SJIP-527 change study_id to study_code

### DIFF
--- a/src/components/Cavatica/AnalyzeModal/index.tsx
+++ b/src/components/Cavatica/AnalyzeModal/index.tsx
@@ -202,7 +202,7 @@ const AnalyseModal = () => {
 };
 
 const aggregateFilesToStudy = (filesToCopy: IFileEntity[]) =>
-  Object.entries(groupBy(filesToCopy, 'study.study_id')).map((study) => ({
+  Object.entries(groupBy(filesToCopy, 'study.study_code')).map((study) => ({
     title: study[1][0].study.study_name,
     nbFiles: study[1].length,
   }));

--- a/src/graphql/participants/queries.ts
+++ b/src/graphql/participants/queries.ts
@@ -128,7 +128,6 @@ export const GET_PARTICIPANT_ENTITY = gql`
               }
             }
             family_type
-
             files {
               hits {
                 total
@@ -192,6 +191,7 @@ export const GET_PARTICIPANT_ENTITY = gql`
             study {
               study_name
               external_id
+              study_code
             }
             study_id
             sex

--- a/src/views/FileEntity/utils/biospecimens.tsx
+++ b/src/views/FileEntity/utils/biospecimens.tsx
@@ -19,10 +19,10 @@ export const getBiospecimenColumns = (): ProColumnType[] => [
       ),
   },
   {
-    key: 'study_id',
-    dataIndex: 'study_id',
+    key: 'study_code',
+    dataIndex: ['study', 'study_code'],
     title: intl.get('entities.study.study'),
-    render: (study_id: string) => study_id || TABLE_EMPTY_PLACE_HOLDER,
+    render: (study_code: string) => study_code || TABLE_EMPTY_PLACE_HOLDER,
   },
   {
     key: 'down_syndrome_status',

--- a/src/views/FileEntity/utils/getSummaryItems.tsx
+++ b/src/views/FileEntity/utils/getSummaryItems.tsx
@@ -17,7 +17,7 @@ const getSummaryItems = (file?: IFileEntity): IEntityDescriptionsItem[] => [
   {
     label: intl.get('entities.study.study'),
     value: file?.study
-      ? `${file.study.study_name} (${file.study.study_id})`
+      ? `${file.study.study_name} (${file.study.study_code})`
       : TABLE_EMPTY_PLACE_HOLDER,
   },
   {

--- a/src/views/ParticipantEntity/utils/summary.tsx
+++ b/src/views/ParticipantEntity/utils/summary.tsx
@@ -37,7 +37,8 @@ export const getSummaryItems = (participant?: IParticipantEntity): IEntityDescri
   {
     label: intl.get('entities.study.study'),
     value:
-      `${participant?.study.study_name} (${participant?.study_id})` || TABLE_EMPTY_PLACE_HOLDER,
+      `${participant?.study.study_name} (${participant?.study?.study_code})` ||
+      TABLE_EMPTY_PLACE_HOLDER,
   },
   {
     label: intl.get('entities.participant.dbgap'),

--- a/src/views/Studies/index.tsx
+++ b/src/views/Studies/index.tsx
@@ -44,9 +44,9 @@ const columns: ProColumnType<any>[] = [
     title: 'Study Code',
     render: (record: IStudyEntity) =>
       record.website ? (
-        <ExternalLink href={record.website}>{record.study_id}</ExternalLink>
+        <ExternalLink href={record.website}>{record.study_code}</ExternalLink>
       ) : (
-        record.study_id
+        record.study_code
       ),
   },
   {
@@ -96,8 +96,8 @@ const columns: ProColumnType<any>[] = [
               query: generateQuery({
                 newFilters: [
                   generateValueFilter({
-                    field: 'study_id',
-                    value: [record.study_id],
+                    field: 'study_code',
+                    value: [record.study_code],
                     index: INDEXES.PARTICIPANT,
                   }),
                 ],
@@ -135,8 +135,8 @@ const columns: ProColumnType<any>[] = [
               query: generateQuery({
                 newFilters: [
                   generateValueFilter({
-                    field: 'study_id',
-                    value: [record.study_id],
+                    field: 'study_code',
+                    value: [record.study_code],
                     index: INDEXES.PARTICIPANT,
                   }),
                 ],

--- a/src/views/Variants/components/PageContent/VariantsTable/index.tsx
+++ b/src/views/Variants/components/PageContent/VariantsTable/index.tsx
@@ -166,7 +166,7 @@ const defaultColumns: ProColumnType[] = [
       }
 
       const ids = hydrateResults(studies?.hits?.edges || []).map(
-        (node: IVariantStudyEntity) => node.study_id,
+        (node: IVariantStudyEntity) => node.study_code,
       );
 
       return (
@@ -178,7 +178,7 @@ const defaultColumns: ProColumnType[] = [
               query: generateQuery({
                 newFilters: [
                   generateValueFilter({
-                    field: 'study_id',
+                    field: 'study_code',
                     value: ids,
                     index: INDEXES.PARTICIPANT,
                   }),


### PR DESCRIPTION
# FIX 

- closes #[527](https://d3b.atlassian.net/browse/SJIP-527)

## Description

Studies page – Study Code column
![image](https://github.com/include-dcc/include-portal-ui/assets/65532894/e7d62aa6-5ca9-4b1d-b3ba-ed94943fc562)


Participant Entity page

Summary section Study  (the study code is in parenthesis) 
Redirect Study

https://github.com/include-dcc/include-portal-ui/assets/65532894/bb48ace4-e17f-4009-9912-da78c1a5b0e1



File  Entity page

Summary section Study  (the study code is in parenthesis) 
Redirect Study
https://github.com/include-dcc/include-portal-ui/assets/65532894/53cb98b0-fa39-44f3-a022-4f32709e223b
Section Participnat/Sample, colonne Study
![image](https://github.com/include-dcc/include-portal-ui/assets/65532894/48082a96-9ae4-474e-aba7-dab6cfc3c90a)


Analyze in Cavatica button modal
can only be tested on prod

