### PR TITLE
fix(variant): SJIP-532 fix study code

### DIFF
--- a/src/views/Variants/components/PageContent/VariantsTable/index.tsx
+++ b/src/views/Variants/components/PageContent/VariantsTable/index.tsx
@@ -180,7 +180,7 @@ const defaultColumns: ProColumnType[] = [
               query: generateQuery({
                 newFilters: [
                   generateValueFilter({
-                    field: 'study_code',
+                    field: 'study.study_code',
                     value: ids,
                     index: INDEXES.PARTICIPANT,
                   }),


### PR DESCRIPTION
# FIX 

- closes #[532](https://d3b.atlassian.net/browse/SJIP-532)

## Description

When clicking on the study redirect, it seems like it doesn’t search the same study_code between variant and data exploration page as seen in the screenshots below. The Study Code should be the same between both pages. 
![image](https://github.com/include-dcc/include-portal-ui/assets/65532894/2efc3b1a-e1e2-4fd0-a233-84fe00d6258d)
![image](https://github.com/include-dcc/include-portal-ui/assets/65532894/172c8cd9-f318-48ba-9cd5-149e6204ccbb)


## Screenshot
https://github.com/include-dcc/include-portal-ui/assets/65532894/fc603da8-09ad-4d0f-96cb-577b7221c4da


