### PR TITLE
feat(variants): SJIP-530 remove tooltip on gnomAD facets

### DIFF
--- a/src/views/Variants/index.tsx
+++ b/src/views/Variants/index.tsx
@@ -87,7 +87,6 @@ const filterGroups: {
           'genes__gnomad__pli',
           'genes__gnomad__loeuf',
         ],
-        tooltips: ['genes__gnomad__pli', 'genes__gnomad__loeuf'],
         noDataOption: ['genes__gnomad__pli', 'genes__gnomad__loeuf'],
       },
       {


### PR DESCRIPTION
# FEAT: remove tooltip on gnomAD facets in variant explo

- closes [SJIP-530](https://d3b.atlassian.net/browse/SJIP-530)

## Description

Remove tooltip on GnomAD facets in variants.

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/50b599c3-f4b7-4481-a596-df4170a308a1)

### After
![image](https://github.com/include-dcc/include-portal-ui/assets/133775440/6a385451-873a-4f77-be6a-7efe2a3cc3bd)
