### PR TITLE
feat(entity): SJIP-535 add container_id to biospecimen table

### DIFF
--- a/src/views/ParticipantEntity/utils/biospecimens.tsx
+++ b/src/views/ParticipantEntity/utils/biospecimens.tsx
@@ -26,6 +26,12 @@ export const getBiospecimensDefaultColumns = (): ProColumnType[] => [
       ),
   },
   {
+    key: 'files.biospecimens.container_id',
+    title: intl.get('entities.biospecimen.container_id'),
+    render: (biospecimen: IBiospecimenEntity) =>
+      biospecimen?.container_id || TABLE_EMPTY_PLACE_HOLDER,
+  },
+  {
     key: 'files.biospecimens.sample_type',
     title: intl.get('entities.biospecimen.sample_type'),
     render: (biospecimen: IBiospecimenEntity) =>
@@ -44,13 +50,6 @@ export const getBiospecimensDefaultColumns = (): ProColumnType[] => [
     render: (biospecimen: IBiospecimenEntity) => (
       <AgeCell ageInDays={biospecimen?.age_at_biospecimen_collection} />
     ),
-  },
-  {
-    key: 'files.biospecimens.container_id',
-    title: intl.get('entities.biospecimen.container_id'),
-    render: (biospecimen: IBiospecimenEntity) =>
-      biospecimen?.container_id || TABLE_EMPTY_PLACE_HOLDER,
-    defaultHidden: true,
   },
   {
     key: 'files.biospecimens.volume_ul',


### PR DESCRIPTION
# FEAT

- closes #[535](https://d3b.atlassian.net/browse/SJIP-535)

## Description
Set the Container ID as default in the Biopsecimen table of the part. entity page. We can see that there are many rows that seem identical but the actual unique values for certain studies is the container ID (or commonly known as aliquot). Place it after the Collection ID


## Screenshot

![image](https://github.com/include-dcc/include-portal-ui/assets/65532894/371df341-dd6c-4b30-9534-50e9f5c30a20)


