### PR TITLE
fix(entity): SJIP-491 fix entity download file name

### DIFF
--- a/src/store/report/thunks.tsx
+++ b/src/store/report/thunks.tsx
@@ -93,7 +93,7 @@ const fetchTsvReport = createAsyncThunk<void, TFetchTSVArgs, { rejectValue: stri
 
     try {
       const formattedDate = format(new Date(), 'yyyy-MM-dd');
-      const formattedFileName = `include-${args.index}-table-${formattedDate}.tsv`;
+      const formattedFileName = `include-${args.fileName ?? args.index}-table-${formattedDate}.tsv`;
 
       const { data, error } = await ArrangerApi.columnStates({
         query: getColumnStateQuery(args.index),

--- a/src/store/report/types.ts
+++ b/src/store/report/types.ts
@@ -19,6 +19,7 @@ export type initialState = {
 
 export type TFetchTSVArgs = {
   index: string;
+  fileName?: string;
   columnStates: TColumnStates | undefined;
   columns: ProColumnType[];
   sqon: any;

--- a/src/views/FileEntity/BiospecimenTable/index.tsx
+++ b/src/views/FileEntity/BiospecimenTable/index.tsx
@@ -61,12 +61,30 @@ const BiospecimenTable = ({ file, loading }: OwnProps) => {
       columns={getBiospecimenColumns()}
       initialColumnState={userInfo?.config.files?.tables?.biospecimens?.columns}
       headerConfig={{
-        enableTableExport: true,
+        enableTableExport: false,
         enableColumnSort: true,
         onColumnSortChange: (newState) =>
           dispatch(
             updateUserConfig({ files: { tables: { biospecimens: { columns: newState } } } }),
           ),
+        // onTableExportClick: () =>
+        //   dispatch(
+        //     fetchTsvReport({
+        //       columnStates: userInfo?.config.files?.tables?.biospecimens?.columns,
+        //       columns: getBiospecimenColumns(),
+        //       index: INDEXES.FILE,
+        //       fileName: 'participants-samples',
+        //       sqon: generateQuery({
+        //         newFilters: [
+        //           generateValueFilter({
+        //             field: 'file_id',
+        //             index: INDEXES.FILE,
+        //             value: file?.file_id ? [file?.file_id] : [],
+        //           }),
+        //         ],
+        //       }),
+        //     }),
+        //   ),
       }}
     />
   );

--- a/src/views/ParticipantEntity/BiospecimenTable/index.tsx
+++ b/src/views/ParticipantEntity/BiospecimenTable/index.tsx
@@ -104,6 +104,7 @@ const BiospecimenTable = ({ participant, loading }: OwnProps) => {
               columnStates: userInfo?.config.participants?.tables?.biospecimens?.columns,
               columns: getBiospecimensDefaultColumns(),
               index: INDEXES.PARTICIPANT,
+              fileName: 'biospecimens',
               sqon: generateQuery({
                 newFilters: [
                   generateValueFilter({

--- a/src/views/ParticipantEntity/DiagnosisTable/index.tsx
+++ b/src/views/ParticipantEntity/DiagnosisTable/index.tsx
@@ -67,6 +67,7 @@ const DiagnosisTable = ({ participant, loading }: OwnProps) => {
               columnStates: userInfo?.config.participants?.tables?.diagnosis?.columns,
               columns: getDiagnosisDefaultColumns(),
               index: INDEXES.PARTICIPANT,
+              fileName: 'diagnoses',
               sqon: generateQuery({
                 newFilters: [
                   generateValueFilter({

--- a/src/views/ParticipantEntity/FamilyTable/index.tsx
+++ b/src/views/ParticipantEntity/FamilyTable/index.tsx
@@ -1,8 +1,11 @@
 import intl from 'react-intl-universal';
 import { useDispatch } from 'react-redux';
+import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/utils';
 import { EntityTable } from '@ferlab/ui/core/pages/EntityPage';
+import { INDEXES } from 'graphql/constants';
 import { IParticipantEntity } from 'graphql/participants/models';
 
+import { fetchTsvReport } from 'store/report/thunks';
 import { useUser } from 'store/user';
 import { updateUserConfig } from 'store/user/thunks';
 
@@ -19,12 +22,13 @@ interface OwnProps {
 const FamilyTable = ({ participant, loading }: OwnProps) => {
   const { userInfo } = useUser();
   const dispatch = useDispatch();
+  const data = getFamilyMembers(participant);
 
   return (
     <EntityTable
       id={SectionId.FAMILY}
       loading={loading}
-      data={getFamilyMembers(participant)}
+      data={data}
       title={intl.get('entities.participant.family')}
       header={[
         intl.get('entities.participant.family_id'),
@@ -33,13 +37,31 @@ const FamilyTable = ({ participant, loading }: OwnProps) => {
         ')',
       ]}
       columns={getFamilyColumns(participant.participant_id)}
-      initialColumnState={userInfo?.config.participants?.tables?.family?.columns}
+      initialColumnState={userInfo?.config?.participants?.tables?.family?.columns}
       headerConfig={{
         enableTableExport: true,
         enableColumnSort: true,
         onColumnSortChange: (newState) =>
           dispatch(
             updateUserConfig({ participants: { tables: { family: { columns: newState } } } }),
+          ),
+        onTableExportClick: () =>
+          dispatch(
+            fetchTsvReport({
+              columnStates: userInfo?.config?.participants?.tables?.family?.columns,
+              columns: getFamilyColumns(participant.participant_id),
+              index: INDEXES.PARTICIPANT,
+              fileName: 'family',
+              sqon: generateQuery({
+                newFilters: [
+                  generateValueFilter({
+                    field: 'participant_id',
+                    index: INDEXES.PARTICIPANT,
+                    value: data ? data.map((participant) => participant.participant_id) : [],
+                  }),
+                ],
+              }),
+            }),
           ),
       }}
     />

--- a/src/views/ParticipantEntity/PhenotypeTable/index.tsx
+++ b/src/views/ParticipantEntity/PhenotypeTable/index.tsx
@@ -67,6 +67,7 @@ const PhenotypeTable = ({ participant, loading }: OwnProps) => {
               columnStates: userInfo?.config.participants?.tables?.phenotype?.columns,
               columns: getPhenotypeDefaultColumns(),
               index: INDEXES.PARTICIPANT,
+              fileName: 'phenotypes',
               sqon: generateQuery({
                 newFilters: [
                   generateValueFilter({

--- a/src/views/ParticipantEntity/utils/family.tsx
+++ b/src/views/ParticipantEntity/utils/family.tsx
@@ -13,7 +13,11 @@ import DownSyndromeStatus from '../FamilyTable/DownSyndromeStatus';
 interface IFamilyMember {
   key: string;
   participant_id: string;
-  relation: string;
+  family: {
+    family_relations: {
+      relation: string;
+    };
+  };
   down_syndrome_status?: string;
 }
 
@@ -35,15 +39,16 @@ export const getFamilyColumns = (current_participant_id: string): ProColumnType[
     },
   },
   {
-    key: 'relation',
-    dataIndex: 'relation',
+    key: 'family.family_relations.relation',
     title: intl.get('entities.participant.family_relationship'),
-    render: (relation: string) =>
-      relation ? (
+    render: (member: IFamilyMember) => {
+      const relation = member.family.family_relations.relation;
+      return relation ? (
         <Tag color={relation === 'Proband' ? 'purple' : ''}>{capitalize(relation)}</Tag>
       ) : (
         TABLE_EMPTY_PLACE_HOLDER
-      ),
+      );
+    },
   },
   {
     key: 'down_syndrome_status',
@@ -65,7 +70,11 @@ export const getFamilyColumns = (current_participant_id: string): ProColumnType[
 const getCurrentFamilyMember = (participant: IParticipantEntity): IFamilyMember => ({
   key: participant.participant_id,
   participant_id: participant.participant_id,
-  relation: 'Proband',
+  family: {
+    family_relations: {
+      relation: 'Proband',
+    },
+  },
   down_syndrome_status: participant.down_syndrome_status,
 });
 
@@ -74,7 +83,11 @@ export const getFamilyMembers = (participant: IParticipantEntity): IFamilyMember
     participant?.family?.family_relations.hits?.edges?.map((e) => ({
       key: e.node.related_participant_id,
       participant_id: e.node.related_participant_id,
-      relation: e.node.relation,
+      family: {
+        family_relations: {
+          relation: e.node.relation,
+        },
+      },
     })) || [];
 
   return [getCurrentFamilyMember(participant), ...otherFamilyMembers];


### PR DESCRIPTION
# FIX 

- closes #[491)](https://d3b.atlassian.net/browse/SJIP-491)

## Description

Voir l’[analyse Notion](https://www.notion.so/ferlab/Participant-Entity-Page-91874cd663ac4cdb99ff709909169167?pvs=4#bbf1a0056c864b4297dc9a77970e2b8b) pour la nomenclature des fichiers générés des Export dans les pages Entity.

Ex. Le fichier généré pour la table Diagnosis devrait être include-diagnoses-table-2023-06-19

Vérifier tous les Export à partir des Page Entity.

## Screenshot
![image](https://github.com/include-dcc/include-portal-ui/assets/65532894/f7b8e9dc-b68a-4cb0-8797-3c704641aeeb)



