### PR TITLE
:recycle: Refactor tsv to be performed client-side if needed

### DIFF
--- a/src/helpers/roles.ts
+++ b/src/helpers/roles.ts
@@ -1,2 +1,0 @@
-export const hasUserRole = (user: any) =>
-  Array.isArray(user.roles) && !!user.roles[0];

--- a/src/store/report/thunks.tsx
+++ b/src/store/report/thunks.tsx
@@ -136,6 +136,51 @@ const fetchTsvReport = createAsyncThunk<void, TFetchTSVArgs, { rejectValue: stri
   },
 );
 
+const fetchLocalTsvReport = createAsyncThunk<
+  void,
+  {
+    index: string;
+    fileName?: string;
+    headers: ProColumnType[];
+    cols: { key: string; visible: boolean }[];
+    rows: any[];
+  },
+  { rejectValue: string }
+>('report/generate/tsv', async (args, thunkAPI) => {
+  // !! This function assumes that it is called only when the table is not empty. Said otherwise, data is never empty !!
+  const messageKey = 'report_pending';
+
+  try {
+    const formattedDate = format(new Date(), 'yyyy-MM-dd');
+    const formattedFileName = `include-${args.fileName ?? args.index}-table-${formattedDate}.tsv`;
+
+    const visibleKeys = (args.cols || []).filter((c) => c.visible).map((c) => c.key);
+    const visibleHeaders = args.headers.filter((h) => visibleKeys.includes(h.key));
+    const visibleTitle = visibleHeaders.map((h) => h.title);
+    const visibleRows = (args.rows || []).reduce(
+      (rs, r) => [...rs, visibleHeaders.map((h) => r[h.key])],
+      [],
+    );
+
+    const shapeIsOK = visibleRows.every((r: unknown[]) => r.length === visibleTitle.length);
+    if (!shapeIsOK) {
+      showErrorReportNotif(thunkAPI);
+      return thunkAPI.rejectWithValue('error');
+    }
+
+    const doc: string = [visibleTitle, ...visibleRows]
+      .reduce((text, row) => text + '\n' + row.join('\t'), '')
+      .trimStart();
+
+    saveAs(new Blob([doc], { type: 'text/plain;charset=utf-8' }), formattedFileName);
+
+    thunkAPI.dispatch(globalActions.destroyMessages([messageKey]));
+  } catch {
+    thunkAPI.dispatch(globalActions.destroyMessages([messageKey]));
+    showErrorReportNotif(thunkAPI);
+  }
+});
+
 const idField = (index: string) => {
   switch (index) {
     case INDEXES.PARTICIPANT:
@@ -213,4 +258,4 @@ const getTitleFromColumns = (columns: ProColumnType[], field: string) => {
   return column.title;
 };
 
-export { fetchReport, fetchTsvReport };
+export { fetchReport, fetchTsvReport, fetchLocalTsvReport };

--- a/src/views/DataExploration/components/PageContent/tabs/Summary/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/index.tsx
@@ -20,7 +20,7 @@ const SummaryTab = () => {
       <ResizableGridLayout
         uid={UID}
         defaultLayouts={defaultLayouts}
-        layouts={userInfo?.config.data_exploration?.summary?.layouts}
+        layouts={userInfo?.config.data_exploration?.summary?.layouts || defaultLayouts}
         onReset={(layouts: TSerializedResizableGridLayoutConfig[]) => {
           dispatch(
             updateUserConfig({

--- a/src/views/FileEntity/utils/biospecimens.tsx
+++ b/src/views/FileEntity/utils/biospecimens.tsx
@@ -20,7 +20,7 @@ export const getBiospecimenColumns = (): ProColumnType[] => [
   },
   {
     key: 'study_code',
-    dataIndex: ['study', 'study_code'],
+    dataIndex: ['study_code'],
     title: intl.get('entities.study.study'),
     render: (study_code: string) => study_code || TABLE_EMPTY_PLACE_HOLDER,
   },
@@ -67,6 +67,8 @@ export const getBiospecimensFromFile = (file?: IFileEntity) => {
     participant.biospecimens.hits.edges.map((biospecimen) => ({
       ...participant,
       ...biospecimen.node,
+      //study_code here simplifies further data manipulation
+      study_code: participant.study.study_code,
     })),
   );
 };


### PR DESCRIPTION
# REFACTOR : TSV (participant entity page + file entity page)



[[JIRA LINK]](https://d3b.atlassian.net/browse/SJIP-538?atlOrigin=eyJpIjoiMTQ5ODI1NGZkMDNiNDljMDk3NzI0ZjI3ZjUxZTEwMTkiLCJwIjoiaiJ9)

![image](https://github.com/include-dcc/include-portal-ui/assets/54366437/41e83baa-3252-4438-8506-2d5a1a13d02e)
![image](https://github.com/include-dcc/include-portal-ui/assets/54366437/d48249ae-8e27-4796-8dbb-aa7bf61fb045)

NOTE: hpo terms is excluded from the tsv for phenotype table



