### PR TITLE
fix: SJIP-595 duplicate tooltip on safari

### DIFF
--- a/src/views/Variants/components/PageContent/VariantsTable/index.module.scss
+++ b/src/views/Variants/components/PageContent/VariantsTable/index.module.scss
@@ -14,3 +14,8 @@
   overflow-wrap: unset;
   white-space: nowrap;
 }
+
+.variantTableCellElipsis::after {
+  content: '';
+  display: block;
+}


### PR DESCRIPTION
#BUG | remove double tooltip on safari

- closes https://d3b.atlassian.net/browse/SJIP-595

## Description

no double tooltip on safari

## Validation

- [ ] Code Approved
- [ ] Test Coverage
- [ ] QA Done

## Screenshot 

### After

![image](https://github.com/kids-first/kf-portal-ui/assets/98903/c8b5e447-9304-41a2-b330-ae65b45a38f9)
