### PR TITLE
fix: SJIP-603 fix operator precedence for page navigation

### DIFF
--- a/src/views/Community/index.tsx
+++ b/src/views/Community/index.tsx
@@ -66,7 +66,7 @@ const CommunityPage = () => {
       />
       <Space className={styles.usersListWrapper} size={24} direction="vertical">
         <TableHeader
-          pageIndex={activeFilter.pageIndex || 0 + 1}
+          pageIndex={(activeFilter.pageIndex || 0) + 1}
           pageSize={DEFAULT_PAGE_SIZE}
           total={count}
           dictionary={{


### PR DESCRIPTION
# FIX : fixed operator precendence error

- closes [#TICKET_NUMBER](https://d3b.atlassian.net/browse/SJIP-603)

## Description

[[JIRA LINK]](https://d3b.atlassian.net/browse/SJIP-603)

pagination for page one and two shows the same number.

## Validation

- [ ] Code Approved
- [ ] QA Done

## Screenshot
### After

https://github.com/include-dcc/include-portal-ui/assets/98903/48da392a-109b-46de-994e-8c44b3f7d95d


## Mention

@kstonge

