### PR TITLE
fix: SJIP-603 fix operator precedence for page navigation current page

### DIFF
--- a/src/views/Community/index.tsx
+++ b/src/views/Community/index.tsx
@@ -96,6 +96,7 @@ const CommunityPage = () => {
           className={styles.membersList}
           pagination={{
             total: count,
+            current: (activeFilter.pageIndex || 0) + 1,
             pageSize: DEFAULT_PAGE_SIZE,
             onChange: (page) => {
               setCurrentPage(page - 1);


### PR DESCRIPTION
# FIX : current page  not correctly reset to 

- closes [#603](https://d3b.atlassian.net/browse/SJIP-603)

## Description

[[JIRA LINK]](https://d3b.atlassian.net/browse/SJIP-603)

Page index not correctly reset to 0 when a filter is activated

Acceptance Criterias

## Validation

- [ ] Code Approved
