### PR TITLE
feat(bioreq): SJIP-571 redirect from widget

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@apollo/client": "^3.5.10",
         "@dnd-kit/core": "^4.0.3",
         "@dnd-kit/sortable": "^5.1.0",
-        "@ferlab/ui": "^7.13.3",
+        "@ferlab/ui": "^7.13.9",
         "@loadable/component": "^5.15.2",
         "@nivo/bar": "^0.79.1",
         "@nivo/pie": "^0.79.1",
@@ -2773,9 +2773,9 @@
       }
     },
     "node_modules/@ferlab/ui": {
-      "version": "7.13.7",
-      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-7.13.7.tgz",
-      "integrity": "sha512-u2HoASpifnFaCTnKF8TPOi1ZOICegK5JiPFx4lR90Ijp26n4sVHYCDSC0tqZfipYfL9mO3uNNnQWnr4a/p6w0A==",
+      "version": "7.13.9",
+      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-7.13.9.tgz",
+      "integrity": "sha512-dMgIH/rnvovNvuH90yepnkI+3hrwkQDN9ilJuyll4JrPxKIQFp+SfmCLtGq3Y3wM9mMW0PnsULzk5uAQNq1EIg==",
       "dependencies": {
         "@ant-design/icons": "^4.7.0",
         "@dnd-kit/core": "^4.0.3",
@@ -23452,9 +23452,9 @@
       "requires": {}
     },
     "@ferlab/ui": {
-      "version": "7.13.7",
-      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-7.13.7.tgz",
-      "integrity": "sha512-u2HoASpifnFaCTnKF8TPOi1ZOICegK5JiPFx4lR90Ijp26n4sVHYCDSC0tqZfipYfL9mO3uNNnQWnr4a/p6w0A==",
+      "version": "7.13.9",
+      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-7.13.9.tgz",
+      "integrity": "sha512-dMgIH/rnvovNvuH90yepnkI+3hrwkQDN9ilJuyll4JrPxKIQFp+SfmCLtGq3Y3wM9mMW0PnsULzk5uAQNq1EIg==",
       "requires": {
         "@ant-design/icons": "^4.7.0",
         "@dnd-kit/core": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@apollo/client": "^3.5.10",
     "@dnd-kit/core": "^4.0.3",
     "@dnd-kit/sortable": "^5.1.0",
-    "@ferlab/ui": "^7.13.3",
+    "@ferlab/ui": "^7.13.9",
     "@loadable/component": "^5.15.2",
     "@nivo/bar": "^0.79.1",
     "@nivo/pie": "^0.79.1",

--- a/src/store/savedSet/thunks.ts
+++ b/src/store/savedSet/thunks.ts
@@ -8,6 +8,7 @@ import { DATA_EXPLORATION_QB_ID } from 'views/DataExploration/utils/constant';
 import { SavedSetApi } from 'services/api/savedSet';
 import {
   IUserSetOutput,
+  SetType,
   TUserSavedSetInsert,
   TUserSavedSetUpdate,
 } from 'services/api/savedSet/models';
@@ -137,9 +138,9 @@ const fetchSharedBispecimenRequest = createAsyncThunk<
       query: generateQuery({
         newFilters: [
           generateValueFilter({
-            field: getSetFieldId(data.setType),
+            field: getSetFieldId(SetType.BIOSPECIMEN),
             value: [setValue],
-            index: data.setType,
+            index: SetType.BIOSPECIMEN,
           }),
         ],
       }),

--- a/src/views/Dashboard/components/DashboardCards/BiospecimenRequests/ListItem.tsx
+++ b/src/views/Dashboard/components/DashboardCards/BiospecimenRequests/ListItem.tsx
@@ -12,7 +12,7 @@ import copy from 'copy-to-clipboard';
 import { formatDistance } from 'date-fns';
 
 import { SHARED_BIOSPECIMEN_REQUEST_ID_QUERY_PARAM_KEY } from 'components/Biospecimens/Request/requestBiospecimen.utils';
-import { IUserSetOutput } from 'services/api/savedSet/models';
+import { IUserSetOutput, SetType } from 'services/api/savedSet/models';
 import { globalActions } from 'store/global';
 import { getSetFieldId } from 'store/savedSet';
 import { deleteSavedSet } from 'store/savedSet/thunks';
@@ -85,9 +85,9 @@ const ListItem = ({ data, queryBuilderId }: OwnProps) => {
             query: generateQuery({
               newFilters: [
                 generateValueFilter({
-                  field: getSetFieldId(data.setType),
+                  field: getSetFieldId(SetType.BIOSPECIMEN),
                   value: [setValue],
-                  index: data.setType,
+                  index: SetType.BIOSPECIMEN,
                 }),
               ],
             }),


### PR DESCRIPTION
# FEAT: Biospecimen request redirection from widget

## Description

[SJIP-571](https://d3b.atlassian.net/browse/SJIP-571)

- on biospecimen request creation => add entry in dashboard widget
- on click on item from widget => redirection to data exploration with filter in a query
⚠️ we don't have the good result on the redirection du to an issue on field used to make the set and the data which is not unique for a sample id given.

Include also ferlab upgrade for style fixes. 

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before

### After
video is too big I put it in the ticket.
