### PR TITLE
fix(bioreq): SJIP-571 refresh widget

### DIFF
--- a/src/components/Biospecimens/Request/RequestBiospecimenModal.tsx
+++ b/src/components/Biospecimens/Request/RequestBiospecimenModal.tsx
@@ -79,7 +79,7 @@ const RequestBiospecimenModal = ({ biospecimenIds, isOpen, onCancel, sqon }: Own
       ]);
     } else {
       // set creation and download zip
-      dispatch(
+      await dispatch(
         fetchReport({
           data: {
             sqon: sqon!,
@@ -94,8 +94,8 @@ const RequestBiospecimenModal = ({ biospecimenIds, isOpen, onCancel, sqon }: Own
           callback: () => onCancel(),
         }),
       );
-      onCancel();
       dispatch(fetchSavedSet());
+      onCancel();
     }
   };
 


### PR DESCRIPTION
# FIX : refresh set list too quickly

## Description

[SJIP-571](https://d3b.atlassian.net/browse/SJIP-571)

Widget list item is refreshed too quickly and maybe before the end of set creation in the back.

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before

### After
