### PR TITLE
fix(bioreq): SJIP-627 change guideline to manifest

### DIFF
--- a/src/components/Biospecimens/Request/RequestBiospecimenModal.tsx
+++ b/src/components/Biospecimens/Request/RequestBiospecimenModal.tsx
@@ -88,8 +88,8 @@ const RequestBiospecimenModal = ({ biospecimenIds, isOpen, closeModal, sqon }: O
             biospecimenRequestName: name,
           },
           translation: {
-            errorMessage: intl.get('api.biospecimenRequest.error.guidelinesReport'),
-            successMessage: intl.get('api.biospecimenRequest.success.guidelinesReport'),
+            errorMessage: intl.get('api.biospecimenRequest.error.manifestReport'),
+            successMessage: intl.get('api.biospecimenRequest.success.manifestReport'),
           },
           callback: () => {
             dispatch(fetchSavedSet());

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -138,12 +138,12 @@ const en = {
       error: {
         messageUpdate: 'Unable to update biospecimen request',
         messageDelete: 'Unable to delete biospecimen request',
-        guidelinesReport:
+        manifestReport:
           'An error occurred and we were unable to download your file. Please try again.',
       },
       success: {
         messageUpdate: 'Your biospecimen request has been updated.',
-        guidelinesReport: 'Guidelines downloaded successfully.',
+        manifestReport: 'Manifest downloaded successfully.',
       },
     },
     cavatica: {
@@ -839,11 +839,11 @@ const en = {
             buttonLabel: 'Request biospecimen',
             modal: {
               title: 'Request biospecimen',
-              okText: 'Download guidelines',
+              okText: 'Download manifest',
               cancelText: 'Cancel',
               closeText: 'Close',
               description:
-                'You are about to download the guidelines and supporting documents needed to request the selected biospecimen. The report will include information on <strong>{availableSamplesCount} available samples</strong> (out of {totalCount} selected).',
+                'You are about to download the manifest and supporting documents needed to request the selected biospecimen. The report will include information on <strong>{availableSamplesCount} available samples</strong> (out of {totalCount} selected).',
               nameForm: {
                 title: 'Provide a name for your request',
                 note: 'This request will be saved to your dashboard for future reference.',


### PR DESCRIPTION
# FIX : Use manifest instead of guidelines

## Description

[SJIP-627](https://d3b.atlassian.net/browse/SJIP-627)

Change wording to manifest in modal message, button and in success message.

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
<img width="697" alt="Capture d’écran, le 2023-10-25 à 12 12 03" src="https://github.com/include-dcc/include-portal-ui/assets/133775440/994c17e9-3c6f-474f-8255-6ad02f8a48c5">
<img width="398" alt="Capture d’écran, le 2023-10-25 à 12 12 21" src="https://github.com/include-dcc/include-portal-ui/assets/133775440/a1164d77-7c07-4af7-a062-a49e0b81e48f">

### After
<img width="697" alt="Capture d’écran, le 2023-10-25 à 12 08 25" src="https://github.com/include-dcc/include-portal-ui/assets/133775440/d6cbd655-6bb8-4510-9745-8644fb53a6bd">
<img width="407" alt="Capture d’écran, le 2023-10-25 à 12 08 11" src="https://github.com/include-dcc/include-portal-ui/assets/133775440/c91bc83a-4d6f-4e6d-8ce2-f7f853ee0dd1">
