### PR TITLE
fix(bioreq): SJIP-626 select all count

### DIFF
--- a/src/components/Biospecimens/Request/RequestBiospecimenButton.tsx
+++ b/src/components/Biospecimens/Request/RequestBiospecimenButton.tsx
@@ -6,14 +6,14 @@ import { Button } from 'antd';
 import RequestBiospecimenModal from './RequestBiospecimenModal';
 
 interface OwnProps {
-  biospecimenIds: string[];
+  nbBiospecimenSelected: number;
   disabled?: boolean;
   sqon?: ISqonGroupFilter;
   type?: 'default' | 'primary';
 }
 
 const RequestBiospecimenButton = ({
-  biospecimenIds,
+  nbBiospecimenSelected,
   disabled = false,
   type = 'default',
   sqon,
@@ -27,9 +27,9 @@ const RequestBiospecimenButton = ({
       </Button>
       {isOpen && (
         <RequestBiospecimenModal
-          biospecimenIds={biospecimenIds}
           isOpen={isOpen}
           closeModal={() => setIsOpen(false)}
+          nbBiospecimenSelected={nbBiospecimenSelected}
           sqon={sqon}
         />
       )}

--- a/src/components/Biospecimens/Request/RequestBiospecimenModal.tsx
+++ b/src/components/Biospecimens/Request/RequestBiospecimenModal.tsx
@@ -25,7 +25,7 @@ const ARRANGER_PROJECT_ID = EnvironmentVariables.configFor('ARRANGER_PROJECT_ID'
 const REPORTS_API_URL = EnvironmentVariables.configFor('REPORTS_API_URL');
 
 type OwnProps = {
-  biospecimenIds: string[];
+  nbBiospecimenSelected: number;
   isOpen: boolean;
   closeModal: () => void;
   sqon?: ISqonGroupFilter;
@@ -39,7 +39,7 @@ export const headers = () => ({
   Authorization: `Bearer ${keycloak.token}`,
 });
 
-const RequestBiospecimenModal = ({ biospecimenIds, isOpen, closeModal, sqon }: OwnProps) => {
+const RequestBiospecimenModal = ({ nbBiospecimenSelected, isOpen, closeModal, sqon }: OwnProps) => {
   const [editForm] = Form.useForm();
   const dispatch = useDispatch();
   const { isLoading, savedSets } = useSavedSet();
@@ -136,7 +136,7 @@ const RequestBiospecimenModal = ({ biospecimenIds, isOpen, closeModal, sqon }: O
             <Text>
               {intl.getHTML(`screen.dataExploration.tabs.biospecimens.request.modal.description`, {
                 availableSamplesCount,
-                totalCount: biospecimenIds.length,
+                totalCount: nbBiospecimenSelected,
               })}
             </Text>
           </div>

--- a/src/components/Biospecimens/Request/RequestBiospecimenTable.tsx
+++ b/src/components/Biospecimens/Request/RequestBiospecimenTable.tsx
@@ -70,7 +70,7 @@ const RequestBiospecimenTable = ({
   return (
     <Table
       columns={getDataTypeColumns()}
-      dataSource={data}
+      dataSource={data.map((i) => ({ ...i, key: i.study_code }))}
       pagination={false}
       size="small"
       rowClassName={styles.notStriped}

--- a/src/views/DataExploration/components/PageContent/tabs/Biospecimens/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Biospecimens/index.tsx
@@ -354,9 +354,9 @@ const BioSpecimenTab = ({ sqon }: OwnProps) => {
         extra: [
           hasRequestBio === 'true' && (
             <RequestBiospecimenButton
-              biospecimenIds={selectedAllResults ? [] : selectedKeys}
               disabled={selectedKeys.length === 0 && !selectedAllResults}
               key="requestBiospecimen"
+              nbBiospecimenSelected={selectedAllResults ? results.total : selectedKeys.length}
               sqon={getCurrentSqon()}
               type="primary"
             />


### PR DESCRIPTION
# FIX : Display selected count on select all

## Description

[SJIP-626](https://d3b.atlassian.net/browse/SJIP-626)

Acceptance Criterias
When we select all biospecimens in the table, the total count in the modal description need to be filled.

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
<img width="1065" alt="Capture d’écran, le 2023-10-31 à 11 15 39" src="https://github.com/include-dcc/include-portal-ui/assets/133775440/a3682034-d425-4d3e-b253-afc029836f93">

### After
<img width="1065" alt="Capture d’écran, le 2023-10-31 à 11 09 56" src="https://github.com/include-dcc/include-portal-ui/assets/133775440/62b0e0cf-86f7-4a56-af32-e6126c3e98a9">
