### PR TITLE
feat(biospecimen request): SJIP-572 add share feature

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -606,9 +606,16 @@ const en = {
             existingNameError: 'A biospecimen request with this name already exists',
             maximumLength: 'characters maximum',
           },
+          shareModal: {
+            title: 'Confirm public set',
+            cancelText: 'Cancel',
+            okText: 'Confirm',
+            content:
+              'By confirming, you will make your biospecimen request public in order to be able to share it.',
+          },
           shareLink: {
-            success: 'Link copied to clipboard',
-            error: 'Unable to copy link to clipboard',
+            success: { title: 'Success', description: 'Link copied to clipboard' },
+            error: { title: 'Error', description: 'Unable to copy link to clipboard' },
           },
         },
       },
@@ -913,7 +920,7 @@ const en = {
       biospecimen_fhir_id_1: 'Sample ID',
       biospecimen_fhir_id_2: 'Sample ID',
     },
-    biospecimen_id: 'Sample ID',
+    biospecimen_id: 'Biospecimen',
     study: {
       study_code: 'Study Code',
       study_name: 'Study Name',

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -607,11 +607,12 @@ const en = {
             maximumLength: 'characters maximum',
           },
           shareModal: {
-            title: 'Confirm public set',
+            title: 'Share link to biospecimen request?',
             cancelText: 'Cancel',
-            okText: 'Confirm',
-            content:
-              'By confirming, you will make your biospecimen request public in order to be able to share it.',
+            okText: 'Copy link',
+            content: 'Note that anyone with this link will have access to:',
+            firstPoint: 'The biospecimen request title',
+            secondPoint: 'The list of biospecimens in the request',
           },
           shareLink: {
             success: { title: 'Success', description: 'Link copied to clipboard' },

--- a/src/middleware/AuthMiddleware.tsx
+++ b/src/middleware/AuthMiddleware.tsx
@@ -8,7 +8,7 @@ import Spinner from 'components/uiKit/Spinner';
 import useQueryParams from 'hooks/useQueryParams';
 import { useSavedFilter } from 'store/savedFilter';
 import { fetchSavedFilters, fetchSharedSavedFilter } from 'store/savedFilter/thunks';
-import { fetchSavedSet, fetchSharedBispecimenRequest } from 'store/savedSet/thunks';
+import { fetchSavedSet, fetchSharedBiospecimenRequest } from 'store/savedSet/thunks';
 import { useUser } from 'store/user';
 import { userActions } from 'store/user/slice';
 import { fetchUser } from 'store/user/thunks';
@@ -31,7 +31,7 @@ const AuthMiddleware = ({ children }: Props) => {
       dispatch(fetchSharedSavedFilter(sharedFilterId));
     }
     if (biospecimenRequestId) {
-      dispatch(fetchSharedBispecimenRequest(biospecimenRequestId));
+      dispatch(fetchSharedBiospecimenRequest(biospecimenRequestId));
     }
     // eslint-disable-next-line
   }, []);

--- a/src/services/api/savedSet/index.ts
+++ b/src/services/api/savedSet/index.ts
@@ -1,24 +1,40 @@
 import EnvironmentVariables from 'helpers/EnvVariables';
-import {TUserSavedSetInsert, TUserSavedSetUpdate, TUserSavedSet, IUserSetOutput} from './models';
+
 import { sendRequest } from 'services/api';
 
+import {
+  IUserSetOutput,
+  TBiospecimenRequest,
+  TUserSavedSet,
+  TUserSavedSetInsert,
+  TUserSavedSetUpdate,
+} from './models';
+
 const SETS_API_URL = `${EnvironmentVariables.configFor('ARRANGER_API')}/sets`;
+const USERS_API_URL = `${EnvironmentVariables.configFor('USERS_API')}/user-sets`;
 
 const headers = () => ({
   'Content-Type': 'application/json',
 });
 
-const fetchAll = (tag?: string) =>
+const fetchAll = () =>
   sendRequest<IUserSetOutput[]>({
     method: 'GET',
     url: SETS_API_URL,
     headers: headers(),
   });
 
-const fetchById = (id: string) =>
+const shareById = (id: string) =>
   sendRequest<IUserSetOutput>({
+    method: 'PUT',
+    url: `${USERS_API_URL}/shared/${id}`,
+    headers: headers(),
+  });
+
+const getSharedById = (id: string) =>
+  sendRequest<TBiospecimenRequest>({
     method: 'GET',
-    url: `${SETS_API_URL}/${id}`,
+    url: `${USERS_API_URL}/shared/${id}`,
     headers: headers(),
   });
 
@@ -55,9 +71,10 @@ const destroy = (id: string) =>
 
 export const SavedSetApi = {
   fetchAll,
-  fetchById,
   create,
   update,
   destroy,
   setAsDefault,
+  shareById,
+  getSharedById,
 };

--- a/src/services/api/savedSet/models.ts
+++ b/src/services/api/savedSet/models.ts
@@ -1,3 +1,6 @@
+import { ISqonGroupFilter } from '@ferlab/ui/core/data/sqon/types';
+import { ISort } from '@ferlab/ui/core/graphql/types';
+
 import { ISavedSet } from 'store/savedSet/types';
 
 export type TUserSavedSet = ISavedSet & {
@@ -17,6 +20,22 @@ export type IUserSetOutput = {
   tag: string;
   size: number;
   setType: SetType;
+};
+
+export type TBiospecimenRequest = {
+  id: string;
+  alias: string;
+  content: {
+    idField: string;
+    ids: string[];
+    setType: SetType;
+    sort: ISort[];
+    sqon: ISqonGroupFilter;
+  };
+  sharedpublicly: boolean;
+  keycloak_id: string;
+  creation_date: string;
+  updated_date: string;
 };
 
 export type TUserSavedSetInsert = Omit<

--- a/src/store/savedSet/slice.ts
+++ b/src/store/savedSet/slice.ts
@@ -7,7 +7,7 @@ import {
   createSavedSet,
   deleteSavedSet,
   fetchSavedSet,
-  fetchSharedBispecimenRequest,
+  fetchSharedBiospecimenRequest,
   updateSavedSet,
 } from './thunks';
 
@@ -48,16 +48,16 @@ const savedSetSlice = createSlice({
       isLoading: false,
     }));
     // Fetch Shared
-    builder.addCase(fetchSharedBispecimenRequest.pending, (state) => {
+    builder.addCase(fetchSharedBiospecimenRequest.pending, (state) => {
       state.isLoading = true;
       state.fetchingError = undefined;
     });
-    builder.addCase(fetchSharedBispecimenRequest.fulfilled, (state, action) => ({
+    builder.addCase(fetchSharedBiospecimenRequest.fulfilled, (state, action) => ({
       ...state,
       sharedBiospecimenRequest: action.payload,
       isLoading: false,
     }));
-    builder.addCase(fetchSharedBispecimenRequest.rejected, (state, action) => ({
+    builder.addCase(fetchSharedBiospecimenRequest.rejected, (state, action) => ({
       ...state,
       fetchingError: action.payload,
       isLoading: false,

--- a/src/store/savedSet/thunks.ts
+++ b/src/store/savedSet/thunks.ts
@@ -9,6 +9,7 @@ import { SavedSetApi } from 'services/api/savedSet';
 import {
   IUserSetOutput,
   SetType,
+  TBiospecimenRequest,
   TUserSavedSetInsert,
   TUserSavedSetUpdate,
 } from 'services/api/savedSet/models';
@@ -20,7 +21,7 @@ import { getSetFieldId } from '.';
 const fetchSavedSet = createAsyncThunk<IUserSetOutput[], void | string, { rejectValue: string }>(
   'savedsets/fetch',
   async (tag, thunkAPI) => {
-    const { data, error } = await SavedSetApi.fetchAll(tag as string);
+    const { data, error } = await SavedSetApi.fetchAll();
 
     return handleThunkApiReponse({
       error,
@@ -118,19 +119,13 @@ const deleteSavedSet = createAsyncThunk<string, string, { rejectValue: string }>
   },
 );
 
-const fetchSharedBispecimenRequest = createAsyncThunk<
-  IUserSetOutput | undefined,
+const fetchSharedBiospecimenRequest = createAsyncThunk<
+  TBiospecimenRequest | undefined,
   string,
   { rejectValue: string }
 >('shared/savedsets/fetch', async (id, thunkAPI) => {
-  const { data, error } = await SavedSetApi.fetchById(id);
+  const { data, error } = await SavedSetApi.getSharedById(id);
 
-  // if (data) {
-  //   setQueryBuilderState(FILTER_TAG_QB_ID_MAPPING[data.tag], {
-  //     active: isEmpty(data.queries) ? v4() : data.queries[0].id,
-  //     state: data.queries ?? [],
-  //   });
-  // }
   if (data) {
     const setValue = `${SET_ID_PREFIX}${data.id}`;
     addQuery({
@@ -138,7 +133,7 @@ const fetchSharedBispecimenRequest = createAsyncThunk<
       query: generateQuery({
         newFilters: [
           generateValueFilter({
-            field: getSetFieldId(SetType.BIOSPECIMEN),
+            field: getSetFieldId(SetType.BIOSPECIMEN_REQUEST),
             value: [setValue],
             index: SetType.BIOSPECIMEN,
           }),
@@ -160,5 +155,5 @@ export {
   createSavedSet,
   updateSavedSet,
   deleteSavedSet,
-  fetchSharedBispecimenRequest,
+  fetchSharedBiospecimenRequest,
 };

--- a/src/store/savedSet/thunks.ts
+++ b/src/store/savedSet/thunks.ts
@@ -136,6 +136,7 @@ const fetchSharedBiospecimenRequest = createAsyncThunk<
             field: getSetFieldId(SetType.BIOSPECIMEN_REQUEST),
             value: [setValue],
             index: SetType.BIOSPECIMEN,
+            overrideValuesName: data.alias,
           }),
         ],
       }),

--- a/src/store/savedSet/types.ts
+++ b/src/store/savedSet/types.ts
@@ -1,7 +1,7 @@
 import { ISqonGroupFilter } from '@ferlab/ui/core/data/sqon/types';
 import { ISort } from '@ferlab/ui/core/graphql/types';
 
-import { IUserSetOutput } from 'services/api/savedSet/models';
+import { IUserSetOutput, TBiospecimenRequest } from 'services/api/savedSet/models';
 
 export interface ISavedSet {
   idField: string;
@@ -15,7 +15,7 @@ export interface ISavedSet {
 export type initialState = {
   defaultFilter?: ISavedSet;
   savedSets: IUserSetOutput[];
-  sharedBiospecimenRequest?: IUserSetOutput;
+  sharedBiospecimenRequest?: TBiospecimenRequest;
   isLoading: boolean;
   isUpdating: boolean;
   error?: any;

--- a/src/views/Dashboard/components/DashboardCards/BiospecimenRequests/ListItem.tsx
+++ b/src/views/Dashboard/components/DashboardCards/BiospecimenRequests/ListItem.tsx
@@ -59,8 +59,22 @@ const ListItem = ({ set, queryBuilderId }: OwnProps) => {
           Modal.confirm({
             title: intl.get('screen.dashboard.cards.biospecimenRequest.shareModal.title'),
             okText: intl.get('screen.dashboard.cards.biospecimenRequest.shareModal.okText'),
-            content: intl.get('screen.dashboard.cards.biospecimenRequest.shareModal.content'),
-            cancelText: intl.get('screen.dashboard.cards.biospecimenRequest.shareModal.cancelText'),
+            content: (
+              <>
+                {intl.get('screen.dashboard.cards.biospecimenRequest.shareModal.content')}
+                <ul>
+                  <li>
+                    {intl.get('screen.dashboard.cards.biospecimenRequest.shareModal.firstPoint')}
+                  </li>
+                  <li>
+                    {intl.get('screen.dashboard.cards.biospecimenRequest.shareModal.secondPoint')}
+                  </li>
+                </ul>
+              </>
+            ),
+            cancelText: intl.getHTML(
+              'screen.dashboard.cards.biospecimenRequest.shareModal.cancelText',
+            ),
             onOk: async () => {
               // call back to change sharedpublicly boolean
               const { data } = await SavedSetApi.shareById(set.id);
@@ -94,6 +108,7 @@ const ListItem = ({ set, queryBuilderId }: OwnProps) => {
                 );
               }
             },
+            width: 440,
           })
         }
         onClick={() => {

--- a/src/views/Dashboard/components/DashboardCards/BiospecimenRequests/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/BiospecimenRequests/index.tsx
@@ -58,7 +58,7 @@ const getItemList = (
       }}
       dataSource={fetchingError ? [] : dataSource}
       loading={isLoading}
-      renderItem={(item) => <ListItem data={item} queryBuilderId={queryBuilderId} />}
+      renderItem={(item) => <ListItem set={item} queryBuilderId={queryBuilderId} />}
     />
   );
 };


### PR DESCRIPTION
# FEAT : Add share feature in dashboard widget

## Description

[SJIP-572](https://d3b.atlassian.net/browse/SJIP-572)

Add share feature in the dashboard widget to switch public the set and copy the link. For the receiver, be able to open the link to exploration page with the set of another person in his query builder.

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
N/A
### After
Video is too big I will put it in the Jira ticket if you want to see it.