### PR TITLE
feat(file): SJIP-109 add file manifest download button

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -17,3 +17,5 @@ export const SHARED_FILTER_ID_QUERY_PARAM_KEY = 'sharedFilterId';
 export const DEFAULT_GRAVATAR_PLACEHOLDER = `${EnvironmentVariables.configFor(
   'INCLUDE_WEB_ROOT',
 )}/avatar-placeholder.png`;
+
+export const MAX_ITEMS_QUERY = 10000;

--- a/src/components/uiKit/reports/DownloadClinicalDataDropdown.tsx
+++ b/src/components/uiKit/reports/DownloadClinicalDataDropdown.tsx
@@ -1,0 +1,66 @@
+import intl from 'react-intl-universal';
+import { useDispatch } from 'react-redux';
+import { DownloadOutlined } from '@ant-design/icons';
+import { ISqonGroupFilter, ISyntheticSqon } from '@ferlab/ui/core/data/sqon/types';
+import { Button, Dropdown, Menu } from 'antd';
+import { INDEXES } from 'graphql/constants';
+import { generateSelectionSqon } from 'views/DataExploration/utils/selectionSqon';
+
+import { ReportType } from 'services/api/reports/models';
+import { fetchReport } from 'store/report/thunks';
+
+const CLINICAL_DATA_WITH_FAMILY = 'CLINICAL_DATA_WITH_FAMILY';
+
+interface OwnProps {
+  participantIds: string[];
+  sqon?: ISqonGroupFilter;
+  type?: 'default' | 'primary';
+}
+
+const DownloadClinicalDataDropdown = ({ participantIds, sqon, type = 'default' }: OwnProps) => {
+  const dispatch = useDispatch();
+
+  const getCurrentSqon = (): ISyntheticSqon =>
+    sqon || generateSelectionSqon(INDEXES.PARTICIPANT, participantIds);
+
+  const menu = (
+    <Menu
+      onClick={(e) =>
+        dispatch(
+          fetchReport({
+            data: {
+              sqon: getCurrentSqon(),
+              name: ReportType.CLINICAL_DATA,
+              withFamily: e.key === CLINICAL_DATA_WITH_FAMILY,
+            },
+          }),
+        )
+      }
+      items={[
+        {
+          key: ReportType.CLINICAL_DATA,
+          label: intl.get('api.report.clinicalData.participant', { count: participantIds.length }),
+        },
+        {
+          key: CLINICAL_DATA_WITH_FAMILY,
+          label: intl.get('api.report.clinicalData.family', { count: participantIds.length }),
+        },
+      ]}
+    />
+  );
+
+  return (
+    <Dropdown
+      key="actionDropdown"
+      disabled={participantIds.length === 0}
+      overlay={menu}
+      placement="bottomLeft"
+    >
+      <Button type={type} icon={<DownloadOutlined />}>
+        {intl.get('api.report.clinicalData.download')}
+      </Button>
+    </Dropdown>
+  );
+};
+
+export default DownloadClinicalDataDropdown;

--- a/src/components/uiKit/reports/DownloadFileManifestModal/FilesTable.tsx
+++ b/src/components/uiKit/reports/DownloadFileManifestModal/FilesTable.tsx
@@ -1,0 +1,87 @@
+import intl from 'react-intl-universal';
+import { ProColumnType } from '@ferlab/ui/core/components/ProTable/types';
+import { ISyntheticSqon } from '@ferlab/ui/core/data/sqon/types';
+import { numberWithCommas } from '@ferlab/ui/core/utils/numberUtils';
+import { Table } from 'antd';
+import { AxiosRequestConfig } from 'axios';
+import EnvironmentVariables from 'helpers/EnvVariables';
+
+import { TABLE_EMPTY_PLACE_HOLDER } from 'common/constants';
+import useApi from 'hooks/useApi';
+import { headers, REPORTS_ROUTES } from 'services/api/reports';
+import { ReportType } from 'services/api/reports/models';
+import { formatFileSize } from 'utils/formatFileSize';
+
+import styles from './index.module.scss';
+
+const ARRANGER_PROJECT_ID = EnvironmentVariables.configFor('ARRANGER_PROJECT_ID');
+
+interface IFileByDataType {
+  key: string;
+  value: string;
+  nb_participants: number;
+  nb_files: number;
+  size: number;
+}
+
+export const getDataTypeColumns = (): ProColumnType<any>[] => [
+  {
+    key: 'value',
+    dataIndex: 'value',
+    title: intl.get('api.report.fileManifest.dataType'),
+    render: (value: string) => value || TABLE_EMPTY_PLACE_HOLDER,
+  },
+  {
+    key: 'nb_participants',
+    dataIndex: 'nb_participants',
+    title: intl.get('api.report.fileManifest.participants'),
+    render: (nb_participants: number) =>
+      nb_participants ? numberWithCommas(nb_participants) : TABLE_EMPTY_PLACE_HOLDER,
+  },
+  {
+    key: 'nb_files',
+    dataIndex: 'nb_files',
+    title: intl.get('api.report.fileManifest.files'),
+    render: (nb_files: number) =>
+      nb_files ? numberWithCommas(nb_files) : TABLE_EMPTY_PLACE_HOLDER,
+  },
+  {
+    key: 'size',
+    dataIndex: 'size',
+    title: intl.get('api.report.fileManifest.size'),
+    render: (size: number) =>
+      formatFileSize(size, { output: 'string' }) || TABLE_EMPTY_PLACE_HOLDER,
+  },
+];
+
+const FilesTable = ({ sqon }: { sqon: ISyntheticSqon }) => {
+  const config: AxiosRequestConfig = {
+    // @ts-ignore
+    url: REPORTS_ROUTES[ReportType.FILE_MANIFEST_STATS],
+    method: 'POST',
+    responseType: 'json',
+    data: {
+      sqon,
+      projectId: ARRANGER_PROJECT_ID,
+    },
+    headers: headers(),
+  };
+
+  const { loading, result } = useApi({ config });
+  const files = (result as IFileByDataType[]) || [];
+
+  return (
+    <Table
+      columns={getDataTypeColumns()}
+      dataSource={files}
+      pagination={false}
+      size="small"
+      rowClassName={styles.notStriped}
+      className={styles.table}
+      bordered
+      loading={loading}
+    />
+  );
+};
+
+export default FilesTable;

--- a/src/components/uiKit/reports/DownloadFileManifestModal/index.module.scss
+++ b/src/components/uiKit/reports/DownloadFileManifestModal/index.module.scss
@@ -1,0 +1,28 @@
+@import 'src/style/themes/include/colors';
+
+.notStriped {
+  background-color: inherit !important;
+}
+
+.modal {
+  max-height: 600px;
+  width: 740px !important;
+}
+
+.table {
+    margin-top: 30px;
+}
+
+.tooMuchFilesIcon {
+  font-size: 21px !important;
+  margin-top: 2px;
+}
+
+.tooMuchFiles {
+  *[class$="-alert-message"] {
+    font-weight: 600;
+  }
+
+  margin-top: 30px;
+  color: $red-8;
+}

--- a/src/components/uiKit/reports/DownloadFileManifestModal/index.tsx
+++ b/src/components/uiKit/reports/DownloadFileManifestModal/index.tsx
@@ -1,0 +1,78 @@
+import { useState } from 'react';
+import intl from 'react-intl-universal';
+import { useDispatch } from 'react-redux';
+import { DownloadOutlined } from '@ant-design/icons';
+import { ISyntheticSqon } from '@ferlab/ui/core/data/sqon/types';
+import { Button, Checkbox, Modal } from 'antd';
+
+import { ReportType } from 'services/api/reports/models';
+import { fetchReport } from 'store/report/thunks';
+
+import TooMuchFilesAlert from '../TooMuchFilesAlert';
+
+import FilesTable from './FilesTable';
+
+import styles from './index.module.scss';
+
+interface IDownloadFileManifestProps {
+  sqon: ISyntheticSqon;
+  type?: 'default' | 'primary';
+  isDisabled?: boolean;
+  hasTooManyFiles?: boolean;
+}
+
+const DownloadFileManifestModal = ({
+  sqon,
+  type = 'default',
+  isDisabled,
+  hasTooManyFiles,
+}: IDownloadFileManifestProps) => {
+  const dispatch = useDispatch();
+
+  const [isModalVisible, setIsModalVisible] = useState(false);
+  const [isFamilyChecked, setIsFamilyChecked] = useState(false);
+
+  return (
+    <>
+      <Button
+        icon={<DownloadOutlined />}
+        onClick={() => setIsModalVisible(true)}
+        type={type}
+        disabled={isDisabled}
+      >
+        {intl.get('api.report.fileManifest.button')}
+      </Button>
+      <Modal
+        open={isModalVisible}
+        title={intl.get('api.report.fileManifest.title')}
+        okText={intl.get('api.report.fileManifest.okText')}
+        okButtonProps={{ disabled: hasTooManyFiles }}
+        cancelText={intl.get('api.report.fileManifest.cancel')}
+        onCancel={() => setIsModalVisible(false)}
+        onOk={() => {
+          dispatch(
+            fetchReport({
+              data: {
+                name: ReportType.FILE_MANIFEST,
+                fileName: isFamilyChecked ? `familyManifest` : ReportType.FILE_MANIFEST,
+                sqon,
+                withFamily: isFamilyChecked,
+              },
+              callback: () => setIsModalVisible(false),
+            }),
+          );
+        }}
+        className={styles.modal}
+      >
+        <p>{intl.getHTML('api.report.fileManifest.text')}</p>
+        <Checkbox checked={isFamilyChecked} onChange={() => setIsFamilyChecked(!isFamilyChecked)}>
+          {intl.get('api.report.fileManifest.textCheckbox')}
+        </Checkbox>
+        {hasTooManyFiles && <TooMuchFilesAlert />}
+        {!hasTooManyFiles && isModalVisible && <FilesTable sqon={sqon} />}
+      </Modal>
+    </>
+  );
+};
+
+export default DownloadFileManifestModal;

--- a/src/components/uiKit/reports/DownloadRequestAccessModal/FilesTable.tsx
+++ b/src/components/uiKit/reports/DownloadRequestAccessModal/FilesTable.tsx
@@ -1,0 +1,67 @@
+import intl from 'react-intl-universal';
+import { ProColumnType } from '@ferlab/ui/core/components/ProTable/types';
+import { ISyntheticSqon } from '@ferlab/ui/core/data/sqon/types';
+import { Table } from 'antd';
+import { AxiosRequestConfig } from 'axios';
+import EnvironmentVariables from 'helpers/EnvVariables';
+
+import { TABLE_EMPTY_PLACE_HOLDER } from 'common/constants';
+import useApi from 'hooks/useApi';
+import { headers, REPORTS_ROUTES } from 'services/api/reports';
+import { ReportType } from 'services/api/reports/models';
+
+import styles from './index.module.scss';
+
+const ARRANGER_PROJECT_ID = EnvironmentVariables.configFor('ARRANGER_PROJECT_ID');
+
+interface IFileByStudy {
+  key: string;
+  study_name: string;
+  nb_files: number;
+}
+
+export const getColumns = (): ProColumnType<any>[] => [
+  {
+    key: 'study_name',
+    dataIndex: 'study_name',
+    title: intl.get('entities.study.study'),
+    render: (label: string) => label || TABLE_EMPTY_PLACE_HOLDER,
+  },
+  {
+    key: 'nb_files',
+    dataIndex: 'nb_files',
+    title: intl.get('entities.file.files'),
+    render: (label: string) => label || TABLE_EMPTY_PLACE_HOLDER,
+  },
+];
+
+const FilesTable = ({ sqon }: { sqon: ISyntheticSqon }) => {
+  const config: AxiosRequestConfig = {
+    // @ts-ignore
+    url: REPORTS_ROUTES[ReportType.FILE_REQUEST_ACCESS_STATS],
+    method: 'POST',
+    responseType: 'json',
+    data: {
+      sqon,
+      projectId: ARRANGER_PROJECT_ID,
+    },
+    headers: headers(),
+  };
+  const { loading, result } = useApi({ config });
+  const files = (result as IFileByStudy[]) || [];
+
+  return (
+    <Table
+      columns={getColumns()}
+      dataSource={files}
+      pagination={false}
+      size="small"
+      rowClassName={styles.notStriped}
+      className={styles.table}
+      bordered
+      loading={loading}
+    />
+  );
+};
+
+export default FilesTable;

--- a/src/components/uiKit/reports/DownloadRequestAccessModal/index.module.scss
+++ b/src/components/uiKit/reports/DownloadRequestAccessModal/index.module.scss
@@ -1,0 +1,28 @@
+@import 'src/style/themes/include/colors';
+
+.notStriped {
+  background-color: inherit !important;
+}
+
+.modal {
+  max-height: 600px;
+  width: 740px !important;
+}
+
+.table {
+  margin-top: 30px;
+}
+
+.tooMuchFilesIcon {
+  font-size: 21px !important;
+  margin-top: 2px;
+}
+
+.tooMuchFiles {
+  *[class$="-alert-message"] {
+    font-weight: 600;
+  }
+
+  margin-top: 30px;
+  color: $red-8;
+}

--- a/src/components/uiKit/reports/DownloadRequestAccessModal/index.tsx
+++ b/src/components/uiKit/reports/DownloadRequestAccessModal/index.tsx
@@ -1,0 +1,91 @@
+import { useState } from 'react';
+import intl from 'react-intl-universal';
+import { useDispatch } from 'react-redux';
+import { DownloadOutlined } from '@ant-design/icons';
+import ExternalLink from '@ferlab/ui/core/components/ExternalLink';
+import { ISyntheticSqon } from '@ferlab/ui/core/data/sqon/types';
+import { Button, Checkbox, Modal } from 'antd';
+import EnvVariables from 'helpers/EnvVariables';
+
+import { ReportType } from 'services/api/reports/models';
+import { fetchReport } from 'store/report/thunks';
+
+import TooMuchFilesAlert from '../TooMuchFilesAlert';
+
+import FilesTable from './FilesTable';
+
+import styles from './index.module.scss';
+
+interface IDownloadFileManifestProps {
+  sqon: ISyntheticSqon;
+  type?: 'default' | 'primary';
+  isDisabled?: boolean;
+  hasTooManyFiles?: boolean;
+}
+
+const DownloadRequestAccessModal = ({
+  sqon,
+  type = 'default',
+  isDisabled,
+  hasTooManyFiles: hasTooManyFiles,
+}: IDownloadFileManifestProps) => {
+  const dispatch = useDispatch();
+
+  const [isModalVisible, setIsModalVisible] = useState(false);
+  const [isFamilyChecked, setIsFamilyChecked] = useState(false);
+
+  // TODO: to replace when file access are enable in KF
+  const docHref = `${EnvVariables.configFor(
+    'CQDG_DOCUMENTATION',
+  )}/en/acces-donnees/demande-acces-donnees`;
+
+  return (
+    <>
+      <Button
+        icon={<DownloadOutlined />}
+        onClick={() => setIsModalVisible(true)}
+        type={type}
+        disabled={isDisabled}
+      >
+        {intl.get('api.report.requestAccess.button')}
+      </Button>
+      <Modal
+        visible={isModalVisible}
+        title={intl.get('api.report.requestAccess.title')}
+        okText={intl.get('api.report.requestAccess.okText')}
+        okButtonProps={{ disabled: hasTooManyFiles }}
+        cancelText={intl.get('api.report.requestAccess.cancel')}
+        onCancel={() => setIsModalVisible(false)}
+        onOk={() => {
+          dispatch(
+            fetchReport({
+              data: {
+                name: ReportType.FILE_REQUEST_ACCESS,
+                sqon,
+                withFamily: isFamilyChecked,
+              },
+              callback: () => setIsModalVisible(false),
+            }),
+          );
+        }}
+        className={styles.modal}
+      >
+        <div>
+          {intl.get('api.report.requestAccess.text')}
+          <ExternalLink href={docHref}>
+            {intl.get('api.report.requestAccess.textLink')}
+          </ExternalLink>
+          .
+        </div>
+        <br />
+        <Checkbox checked={isFamilyChecked} onChange={() => setIsFamilyChecked(!isFamilyChecked)}>
+          {intl.get('api.report.requestAccess.textCheckbox')}
+        </Checkbox>
+        {hasTooManyFiles && <TooMuchFilesAlert />}
+        {!hasTooManyFiles && isModalVisible && <FilesTable sqon={sqon} />}
+      </Modal>
+    </>
+  );
+};
+
+export default DownloadRequestAccessModal;

--- a/src/components/uiKit/reports/TooMuchFilesAlert.tsx
+++ b/src/components/uiKit/reports/TooMuchFilesAlert.tsx
@@ -1,0 +1,18 @@
+import intl from 'react-intl-universal';
+import { CloseCircleOutlined } from '@ant-design/icons';
+import { Alert } from 'antd';
+
+import styles from './DownloadRequestAccessModal/index.module.scss';
+
+const TooMuchFilesAlert = () => (
+  <Alert
+    type="error"
+    showIcon
+    icon={<CloseCircleOutlined className={styles.tooMuchFilesIcon} />}
+    className={styles.tooMuchFiles}
+    message={intl.get('api.report.error.tooMuchFilesTitle')}
+    description={intl.get('api.report.error.tooMuchFiles')}
+  />
+);
+
+export default TooMuchFilesAlert;

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -196,6 +196,9 @@ const en = {
         title: 'Error',
         message: 'We were unable to generate the report at this time. Please try again later or ',
         support: 'contact support',
+        tooMuchFilesTitle: 'Maximum number exceeded',
+        tooMuchFiles:
+          'A maximum of 10,000 files can be inlcuded at a time. Please narrow your selection and try again.',
       },
       inProgress: {
         title: 'Processing',
@@ -204,6 +207,20 @@ const en = {
       onSuccess: {
         title: 'Success',
         fetchReport: 'Report downloaded successfully',
+      },
+      fileManifest: {
+        button: 'Manifest',
+        title: 'File manifest',
+        okText: 'Download',
+        cancel: 'Cancel',
+        text: `Download a manifest of the selected files which can be used for bulk downloading using Cavatica’s <a target="_blank" href="https://docs.cavatica.org/docs/import-from-a-drs-server" style="text-decoration: underline;">Import from an GA4GH Data Repository Service (DRS)</a>. This manifest also includes additional information, including the participant and samples associated with these files.`,
+        subText: 'In development and will be available soon.',
+        textCheckbox: `Include data files of the same type for the participants' related family members for this selection.`,
+        summary: 'Summary',
+        dataType: 'Data Type',
+        participants: 'Participants',
+        files: 'Files',
+        size: 'Size',
       },
     },
     noData: 'No data',

--- a/src/services/api/reports/index.ts
+++ b/src/services/api/reports/index.ts
@@ -10,11 +10,15 @@ import { ReportConfig, ReportType } from './models';
 const REPORTS_API_URL = EnvironmentVariables.configFor('REPORTS_API_URL');
 const arrangerProjectId = EnvironmentVariables.configFor('ARRANGER_PROJECT_ID');
 
-const REPORTS_ROUTES = {
+export const REPORTS_ROUTES = {
   [ReportType.CLINICAL_DATA]: `${REPORTS_API_URL}/reports/clinical-data`,
   [ReportType.CLINICAL_DATA_FAM]: `${REPORTS_API_URL}/reports/family-clinical-data`,
   [ReportType.BIOSEPCIMEN_DATA]: `${REPORTS_API_URL}/reports/biospecimen-data`,
   [ReportType.BIOSEPCIMEN_REQUEST]: `${REPORTS_API_URL}/reports/biospecimen-request`,
+  [ReportType.FILE_MANIFEST]: `${REPORTS_API_URL}/reports/file-manifest`,
+  [ReportType.FILE_MANIFEST_STATS]: `${REPORTS_API_URL}/reports/file-manifest/stats`,
+  [ReportType.FILE_REQUEST_ACCESS]: `${REPORTS_API_URL}/reports/file-request-access`,
+  [ReportType.FILE_REQUEST_ACCESS_STATS]: `${REPORTS_API_URL}/reports/file-request-access/stats`,
 };
 
 const joinWithPadding = (l: number[]) => l.reduce((xs, x) => xs + `${x}`.padStart(2, '0'), '');
@@ -32,7 +36,7 @@ const makeFilenameDatePart = (date = new Date()) => {
   return `${prefixes}T${suffixes}Z`;
 };
 
-const headers = () => ({
+export const headers = () => ({
   'Content-Type': 'application/json',
   Accept: '*/*',
   Authorization: `Bearer ${keycloak.token}`,
@@ -61,6 +65,7 @@ const generateReport = (config: ReportConfig) => {
       projectId: arrangerProjectId,
       filename: `include_${config.fileName || config.name}_${makeFilenameDatePart(new Date())}`,
       biospecimenRequestName: config.biospecimenRequestName,
+      withFamily: config.withFamily,
     },
     headers: headers(),
   });

--- a/src/services/api/reports/models.ts
+++ b/src/services/api/reports/models.ts
@@ -6,6 +6,7 @@ export type ReportConfig = {
   fileName?: string;
   projectId?: string;
   biospecimenRequestName?: string;
+  withFamily?: boolean;
 };
 
 export enum ReportType {
@@ -13,6 +14,10 @@ export enum ReportType {
   CLINICAL_DATA_FAM = 'familyClinicalData',
   BIOSEPCIMEN_DATA = 'biospecimenData',
   BIOSEPCIMEN_REQUEST = 'biospecimenRequest',
+  FILE_MANIFEST = 'manifest',
+  FILE_MANIFEST_STATS = 'fileManifestStats',
+  FILE_REQUEST_ACCESS = 'fileRequestAccess',
+  FILE_REQUEST_ACCESS_STATS = 'fileRequestAccessStats',
 }
 
 export interface IDownloadTranslation {

--- a/src/views/DataExploration/components/PageContent/tabs/DataFiles/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/DataFiles/index.tsx
@@ -33,9 +33,10 @@ import {
 import { generateSelectionSqon } from 'views/DataExploration/utils/selectionSqon';
 import { DEFAULT_OFFSET } from 'views/Variants/utils/constants';
 
-import { TABLE_EMPTY_PLACE_HOLDER } from 'common/constants';
+import { MAX_ITEMS_QUERY, TABLE_EMPTY_PLACE_HOLDER } from 'common/constants';
 import { FENCE_CONNECTION_STATUSES } from 'common/fenceTypes';
 import CavaticaAnalyzeButton from 'components/Cavatica/AnalyzeButton';
+import DownloadFileManifestModal from 'components/uiKit/reports/DownloadFileManifestModal';
 import { SetType } from 'services/api/savedSet/models';
 import { useFenceConnection } from 'store/fenceConnection';
 import { fetchTsvReport } from 'store/report/thunks';
@@ -329,6 +330,10 @@ const DataFilesTab = ({ sqon }: OwnProps) => {
     });
   }, [queryConfig]);
 
+  const hasTooManyFiles =
+    selectedKeys.length > MAX_ITEMS_QUERY ||
+    (selectedAllResults && results.total > MAX_ITEMS_QUERY);
+
   return (
     <>
       <ProTable<ITableFileEntity>
@@ -409,6 +414,12 @@ const DataFilesTab = ({ sqon }: OwnProps) => {
               fileIds={selectedAllResults ? [] : selectedKeys}
               sqon={sqon}
               key="file-cavatica-upload"
+            />,
+            <DownloadFileManifestModal
+              key="download-file-manifest"
+              sqon={getCurrentSqon()}
+              isDisabled={!selectedKeys.length && !selectedAllResults}
+              hasTooManyFiles={hasTooManyFiles}
             />,
           ],
         }}


### PR DESCRIPTION
# FEAT 

- closes #109

## Description
https://d3b.atlassian.net/browse/SJIP-109

Implement the Post-MVP version of File manifest button as it is done in KF but with the INCLUDE color scheme:

## Screenshot
### Before
![image](https://github.com/include-dcc/include-portal-ui/assets/65532894/80fb4b76-798b-4800-a5f5-2669863cb8e5)

### After
![image](https://github.com/include-dcc/include-portal-ui/assets/65532894/adf48256-0941-49da-ad2e-8cdbb35397d4)
![image](https://github.com/include-dcc/include-portal-ui/assets/65532894/56148195-9bb2-4969-a313-9561aaa5bd94)
![image](https://github.com/include-dcc/include-portal-ui/assets/65532894/5047399d-409f-4857-b8f1-2346b0e68c60)



