### PR TITLE
fix(filter): SJIP-630 manage filter name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@apollo/client": "^3.5.10",
         "@dnd-kit/core": "^4.0.3",
         "@dnd-kit/sortable": "^5.1.0",
-        "@ferlab/ui": "^7.13.9",
+        "@ferlab/ui": "^7.14.1",
         "@loadable/component": "^5.15.2",
         "@nivo/bar": "^0.79.1",
         "@nivo/pie": "^0.79.1",
@@ -2862,9 +2862,9 @@
       }
     },
     "node_modules/@ferlab/ui": {
-      "version": "7.13.9",
-      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-7.13.9.tgz",
-      "integrity": "sha512-dMgIH/rnvovNvuH90yepnkI+3hrwkQDN9ilJuyll4JrPxKIQFp+SfmCLtGq3Y3wM9mMW0PnsULzk5uAQNq1EIg==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-7.14.1.tgz",
+      "integrity": "sha512-YlCoLpILYgHqgfN6T49olTGPVzabZHXVc6QCz0vWYkwB6esEr5lGC05AE9vFP2saNKWbtaJDr2wMYhCZ3I+UpA==",
       "dependencies": {
         "@ant-design/icons": "^4.7.0",
         "@dnd-kit/core": "^4.0.3",
@@ -24525,9 +24525,9 @@
       "requires": {}
     },
     "@ferlab/ui": {
-      "version": "7.13.9",
-      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-7.13.9.tgz",
-      "integrity": "sha512-dMgIH/rnvovNvuH90yepnkI+3hrwkQDN9ilJuyll4JrPxKIQFp+SfmCLtGq3Y3wM9mMW0PnsULzk5uAQNq1EIg==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-7.14.1.tgz",
+      "integrity": "sha512-YlCoLpILYgHqgfN6T49olTGPVzabZHXVc6QCz0vWYkwB6esEr5lGC05AE9vFP2saNKWbtaJDr2wMYhCZ3I+UpA==",
       "requires": {
         "@ant-design/icons": "^4.7.0",
         "@dnd-kit/core": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@apollo/client": "^3.5.10",
     "@dnd-kit/core": "^4.0.3",
     "@dnd-kit/sortable": "^5.1.0",
-    "@ferlab/ui": "^7.13.9",
+    "@ferlab/ui": "^7.14.1",
     "@loadable/component": "^5.15.2",
     "@nivo/bar": "^0.79.1",
     "@nivo/pie": "^0.79.1",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -114,6 +114,7 @@ const en = {
         title: 'Error',
         messageUpdate: 'Unable to update filter',
         messageDelete: 'Unable to delete filter',
+        nameAlreadyExists: 'A filter with this name already exists',
       },
       success: {
         messageSaved: 'Filter saved',

--- a/src/store/savedFilter/thunks.ts
+++ b/src/store/savedFilter/thunks.ts
@@ -56,25 +56,32 @@ const createSavedFilter = createAsyncThunk<
 >('savedfilters/create', async (filter, thunkAPI) => {
   const { data, error } = await SavedFilterApi.create(filter);
 
-  return handleThunkApiReponse({
-    error,
-    data: data!,
-    reject: thunkAPI.rejectWithValue,
-    onError: () =>
+  if (error) {
+    if (error.response?.status === 422) {
+      thunkAPI.dispatch(
+        globalActions.displayMessage({
+          type: 'error',
+          content: intl.get('api.savedFilter.error.nameAlreadyExists'),
+        }),
+      );
+    } else {
       thunkAPI.dispatch(
         globalActions.displayMessage({
           type: 'error',
           content: intl.get('api.savedFilter.error.messageUpdate'),
         }),
-      ),
-    onSuccess: () =>
-      thunkAPI.dispatch(
-        globalActions.displayMessage({
-          type: 'success',
-          content: intl.get('api.savedFilter.success.messageSaved'),
-        }),
-      ),
-  });
+      );
+    }
+    return thunkAPI.rejectWithValue(error.message);
+  }
+
+  thunkAPI.dispatch(
+    globalActions.displayMessage({
+      type: 'success',
+      content: intl.get('api.savedFilter.success.messageSaved'),
+    }),
+  );
+  return data!;
 });
 
 const updateSavedFilter = createAsyncThunk<
@@ -85,27 +92,35 @@ const updateSavedFilter = createAsyncThunk<
   const { id, ...filterInfo } = filter;
   const { data, error } = await SavedFilterApi.update(id, filterInfo);
 
-  return handleThunkApiReponse({
-    error,
-    data: data!,
-    reject: thunkAPI.rejectWithValue,
-    onError: () =>
+  if (error) {
+    if (error.response?.status === 422) {
+      thunkAPI.dispatch(
+        globalActions.displayNotification({
+          type: 'error',
+          message: intl.get('api.savedFilter.error.title'),
+          description: intl.get('api.savedFilter.error.nameAlreadyExists'),
+        }),
+      );
+    } else {
       thunkAPI.dispatch(
         globalActions.displayNotification({
           type: 'error',
           message: intl.get('api.savedFilter.error.title'),
           description: intl.get('api.savedFilter.error.messageUpdate'),
         }),
-      ),
-    onSuccess: () =>
-      thunkAPI.dispatch(
-        globalActions.displayMessage({
-          type: 'success',
-          content: intl.get('api.savedFilter.success.messageSaved'),
-          duration: 5,
-        }),
-      ),
-  });
+      );
+    }
+    return thunkAPI.rejectWithValue(error.message);
+  }
+
+  thunkAPI.dispatch(
+    globalActions.displayMessage({
+      type: 'success',
+      content: intl.get('api.savedFilter.success.messageSaved'),
+      duration: 5,
+    }),
+  );
+  return data!;
 });
 
 const setSavedFilterAsDefault = createAsyncThunk<

--- a/src/views/DataExploration/components/PageContent/index.tsx
+++ b/src/views/DataExploration/components/PageContent/index.tsx
@@ -89,7 +89,7 @@ const PageContent = ({
   participantMapping,
   tabId = TAB_IDS.SUMMARY,
 }: OwnProps) => {
-  const dispatch = useDispatch();
+  const dispatch = useDispatch<any>();
   const history = useHistory();
   const { savedSets } = useSavedSet();
   const { queryList, activeQuery, selectedSavedFilter, savedFilterList } =

--- a/src/views/Variants/components/PageContent/index.tsx
+++ b/src/views/Variants/components/PageContent/index.tsx
@@ -56,7 +56,7 @@ const addTagToFilter = (filter: ISavedFilter) => ({
 });
 
 const PageContent = ({ variantMapping }: OwnProps) => {
-  const dispatch = useDispatch();
+  const dispatch = useDispatch<any>();
   const { userInfo } = useUser();
   const { savedSets } = useSavedSet();
   const { queryList, activeQuery, selectedSavedFilter, savedFilterList } =


### PR DESCRIPTION
# FIX : Manage filter name error

## Description

[SJIP-630](https://d3b.atlassian.net/browse/SJIP-630)

Acceptance Criterias
- Display the right error when you can't create a filter with an existing name filter
- Other fix, before if we have an error on update filter name in QB the name displayed is change even if is not save due to the error

Impact : 
- data exploration page
- variants page
- dashboard widget filter edition 

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
https://github.com/include-dcc/include-portal-ui/assets/133775440/0e3949da-98a6-477c-9c73-73b580ecd497

### After
<img width="858" alt="Capture d’écran, le 2023-11-06 à 12 13 33" src="https://github.com/include-dcc/include-portal-ui/assets/133775440/e10b4fd3-5786-4fb0-ac8a-1560571b67ef">

<img width="1368" alt="Capture d’écran, le 2023-11-06 à 12 14 01" src="https://github.com/include-dcc/include-portal-ui/assets/133775440/6e05aa22-bfde-4749-965f-c52a18ed6c1c">

https://github.com/include-dcc/include-portal-ui/assets/133775440/de656784-36d2-4b75-bd91-7f0773323d96


