### PR TITLE
feat(bioreq): SJIP-636 manage limit selection

### DIFF
--- a/src/components/Biospecimens/Request/RequestBiospecimenButton.tsx
+++ b/src/components/Biospecimens/Request/RequestBiospecimenButton.tsx
@@ -3,24 +3,42 @@ import intl from 'react-intl-universal';
 import { ISqonGroupFilter } from '@ferlab/ui/core/data/sqon/types';
 import { Button } from 'antd';
 
+import RequestBiospecimenLimitModal from './RequestBiospecimenLimitModal';
 import RequestBiospecimenModal from './RequestBiospecimenModal';
 
 interface OwnProps {
+  nbBiospecimenSelected: number;
   disabled?: boolean;
   sqon?: ISqonGroupFilter;
   type?: 'default' | 'primary';
 }
 
-const RequestBiospecimenButton = ({ disabled = false, type = 'default', sqon }: OwnProps) => {
+const RequestBiospecimenButton = ({
+  disabled = false,
+  nbBiospecimenSelected,
+  type = 'default',
+  sqon,
+}: OwnProps) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
+  const [isLimitOpen, setIsLimitOpen] = useState<boolean>(false);
 
   return (
     <>
-      <Button type={type} disabled={disabled} onClick={() => setIsOpen(true)}>
+      <Button
+        type={type}
+        disabled={disabled}
+        onClick={() => (nbBiospecimenSelected <= 10000 ? setIsOpen(true) : setIsLimitOpen(true))}
+      >
         {intl.get('screen.dataExploration.tabs.biospecimens.request.buttonLabel')}
       </Button>
       {isOpen && (
         <RequestBiospecimenModal isOpen={isOpen} closeModal={() => setIsOpen(false)} sqon={sqon} />
+      )}
+      {isLimitOpen && (
+        <RequestBiospecimenLimitModal
+          isOpen={isLimitOpen}
+          closeModal={() => setIsLimitOpen(false)}
+        />
       )}
     </>
   );

--- a/src/components/Biospecimens/Request/RequestBiospecimenLimitModal.tsx
+++ b/src/components/Biospecimens/Request/RequestBiospecimenLimitModal.tsx
@@ -1,5 +1,4 @@
 import intl from 'react-intl-universal';
-import { ISqonGroupFilter } from '@ferlab/ui/core/data/sqon/types';
 import { Alert, Modal, Typography } from 'antd';
 
 import styles from './requestBiospecimen.module.scss';
@@ -7,7 +6,6 @@ import styles from './requestBiospecimen.module.scss';
 type OwnProps = {
   isOpen: boolean;
   closeModal: () => void;
-  sqon?: ISqonGroupFilter;
 };
 
 const { Text } = Typography;

--- a/src/components/Biospecimens/Request/RequestBiospecimenLimitModal.tsx
+++ b/src/components/Biospecimens/Request/RequestBiospecimenLimitModal.tsx
@@ -32,10 +32,10 @@ const RequestBiospecimenLimitModal = ({ isOpen, closeModal }: OwnProps) => (
       </div>
       <Alert
         type="error"
-        message={intl.getHTML(
+        message={intl.get(
           'screen.dataExploration.tabs.biospecimens.request.modal.alert.limitMessage',
         )}
-        description={intl.getHTML(
+        description={intl.get(
           'screen.dataExploration.tabs.biospecimens.request.modal.alert.limitDescription',
         )}
       />

--- a/src/components/Biospecimens/Request/RequestBiospecimenLimitModal.tsx
+++ b/src/components/Biospecimens/Request/RequestBiospecimenLimitModal.tsx
@@ -1,0 +1,48 @@
+import intl from 'react-intl-universal';
+import { ISqonGroupFilter } from '@ferlab/ui/core/data/sqon/types';
+import { Alert, Modal, Typography } from 'antd';
+
+import styles from './requestBiospecimen.module.scss';
+
+type OwnProps = {
+  isOpen: boolean;
+  closeModal: () => void;
+  sqon?: ISqonGroupFilter;
+};
+
+const { Text } = Typography;
+
+const RequestBiospecimenLimitModal = ({ isOpen, closeModal }: OwnProps) => (
+  <Modal
+    cancelText={intl.get('screen.dataExploration.tabs.biospecimens.request.modal.cancelText')}
+    title={intl.get('screen.dataExploration.tabs.biospecimens.request.modal.title')}
+    open={isOpen}
+    onCancel={() => {
+      closeModal();
+    }}
+    okButtonProps={{
+      disabled: true,
+    }}
+    okText={intl.get('screen.dataExploration.tabs.biospecimens.request.modal.okText')}
+    width={680}
+  >
+    <div className={styles.modalWrapper}>
+      <div className={styles.description}>
+        <Text>
+          {intl.get(`screen.dataExploration.tabs.biospecimens.request.modal.description`)}
+        </Text>
+      </div>
+      <Alert
+        type="error"
+        message={intl.getHTML(
+          'screen.dataExploration.tabs.biospecimens.request.modal.alert.limitMessage',
+        )}
+        description={intl.getHTML(
+          'screen.dataExploration.tabs.biospecimens.request.modal.alert.limitDescription',
+        )}
+      />
+    </div>
+  </Modal>
+);
+
+export default RequestBiospecimenLimitModal;

--- a/src/components/Biospecimens/Request/RequestBiospecimenModal.tsx
+++ b/src/components/Biospecimens/Request/RequestBiospecimenModal.tsx
@@ -116,10 +116,10 @@ const RequestBiospecimenModal = ({ isOpen, closeModal, sqon }: OwnProps) => {
       {error && (
         <Alert
           type="error"
-          message={intl.getHTML(
+          message={intl.get(
             'screen.dataExploration.tabs.biospecimens.request.modal.alert.errorMessage',
           )}
-          description={intl.getHTML(
+          description={intl.get(
             'screen.dataExploration.tabs.biospecimens.request.modal.alert.errorDescription',
           )}
         />

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -886,6 +886,9 @@ const en = {
                 infoMessage: 'No available samples',
                 infoDescription:
                   'There are no biospecimen samples available for your selection. Please make different selection and try again.',
+                limitMessage: 'Maximum number exceeded',
+                limitDescription:
+                  'A maximum of 10,000 biospecimens can be included at once. Please narrow down your selection and try again.',
               },
             },
           },

--- a/src/views/DataExploration/components/PageContent/tabs/Biospecimens/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Biospecimens/index.tsx
@@ -356,6 +356,7 @@ const BioSpecimenTab = ({ sqon }: OwnProps) => {
             <RequestBiospecimenButton
               disabled={selectedKeys.length === 0 && !selectedAllResults}
               key="requestBiospecimen"
+              nbBiospecimenSelected={selectedAllResults ? results.total : selectedKeys.length}
               sqon={getCurrentSqon()}
               type="primary"
             />


### PR DESCRIPTION
# FEAT : Manage limit biospecimen selection

## Description

[SJIP-636](https://d3b.atlassian.net/browse/SJIP-636)

Acceptance Criterias
If the selection exceed 10 000, user can't download the manifest and a message is displayed to explain why.

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
<img width="1005" alt="Capture d’écran, le 2023-11-07 à 10 43 20" src="https://github.com/include-dcc/include-portal-ui/assets/133775440/2a8e1a03-59de-48a5-82a4-a8885e054955">

### After
<img width="1005" alt="Capture d’écran, le 2023-11-07 à 10 43 36" src="https://github.com/include-dcc/include-portal-ui/assets/133775440/5cb34ac0-3b8f-45fc-8b1e-c3e471aec071">
