### PR TITLE
fix(variant): SJIP-598 align frequency part link

### DIFF
--- a/src/views/VariantEntity/index.module.scss
+++ b/src/views/VariantEntity/index.module.scss
@@ -30,3 +30,7 @@
     }
   }
 }
+
+.frequencyParticipantLink {
+  padding: 0;
+}

--- a/src/views/VariantEntity/utils/frequencies.tsx
+++ b/src/views/VariantEntity/utils/frequencies.tsx
@@ -85,6 +85,7 @@ export const getFrequenciesItems = (): ProColumnType[] => [
                 setAsActive: true,
               })
             }
+            className={styles.frequencyParticipantLink}
           >
             {numberWithCommas(row.total?.pc || 0)}
           </Button>
@@ -149,6 +150,7 @@ export const getFrequenciesTableSummaryColumns = (
                 setAsActive: true,
               })
             }
+            className={styles.frequencyParticipantLink}
           >
             {numberWithCommas(totalNbOfParticipants)}
           </Button>


### PR DESCRIPTION
# FIX : Align frequency participant link

## Description

[SJIP-598](https://d3b.atlassian.net/browse/SJIP-598)

Acceptance Criterias
Align frequency participant link with value without link.

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
<img width="1005" alt="Capture d’écran, le 2023-11-07 à 11 05 30" src="https://github.com/include-dcc/include-portal-ui/assets/133775440/ce5a686f-3732-42a9-8e32-20b6ed4b3c07">

### After
<img width="1005" alt="Capture d’écran, le 2023-11-07 à 11 05 16" src="https://github.com/include-dcc/include-portal-ui/assets/133775440/d8ed20e5-5856-4c40-95c3-4c4a77f86d41">
