### PR TITLE
fix(filter): SJIP-612 manage no data in QB

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@apollo/client": "^3.5.10",
         "@dnd-kit/core": "^4.0.3",
         "@dnd-kit/sortable": "^5.1.0",
-        "@ferlab/ui": "^7.14.3",
+        "@ferlab/ui": "^7.14.6",
         "@loadable/component": "^5.15.2",
         "@nivo/bar": "^0.79.1",
         "@nivo/pie": "^0.79.1",
@@ -2862,9 +2862,9 @@
       }
     },
     "node_modules/@ferlab/ui": {
-      "version": "7.14.3",
-      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-7.14.3.tgz",
-      "integrity": "sha512-ndPTI32qi1VavnIFhmCF5jvLlNKsbJWJPsjVAMUHVZu2TODC/A5zdzyzOvNqO0KHhgysfLd0PlwdeSUn3t9zsQ==",
+      "version": "7.14.6",
+      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-7.14.6.tgz",
+      "integrity": "sha512-GhT98BH9xnxeEEG2b+HVAHSKv6vHfSo23oS2RCXQBd6eOw0+KwGUeLODBf7ztmi9Fc8/Tok7Ej0mfxUvB/slwg==",
       "dependencies": {
         "@ant-design/icons": "^4.7.0",
         "@dnd-kit/core": "^4.0.3",
@@ -24539,9 +24539,9 @@
       "requires": {}
     },
     "@ferlab/ui": {
-      "version": "7.14.3",
-      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-7.14.3.tgz",
-      "integrity": "sha512-ndPTI32qi1VavnIFhmCF5jvLlNKsbJWJPsjVAMUHVZu2TODC/A5zdzyzOvNqO0KHhgysfLd0PlwdeSUn3t9zsQ==",
+      "version": "7.14.6",
+      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-7.14.6.tgz",
+      "integrity": "sha512-GhT98BH9xnxeEEG2b+HVAHSKv6vHfSo23oS2RCXQBd6eOw0+KwGUeLODBf7ztmi9Fc8/Tok7Ej0mfxUvB/slwg==",
       "requires": {
         "@ant-design/icons": "^4.7.0",
         "@dnd-kit/core": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@apollo/client": "^3.5.10",
     "@dnd-kit/core": "^4.0.3",
     "@dnd-kit/sortable": "^5.1.0",
-    "@ferlab/ui": "^7.14.3",
+    "@ferlab/ui": "^7.14.6",
     "@loadable/component": "^5.15.2",
     "@nivo/bar": "^0.79.1",
     "@nivo/pie": "^0.79.1",

--- a/src/components/uiKit/FilterList/GenericFilters.tsx
+++ b/src/components/uiKit/FilterList/GenericFilters.tsx
@@ -1,8 +1,9 @@
 import { Layout, Spin } from 'antd';
-import { generateFilters } from 'graphql/utils/Filters';
-import useGetAggregations from 'hooks/graphql/useGetAggregations';
 import { ExtendedMappingResults } from 'graphql/models';
 import { AGGREGATION_QUERY } from 'graphql/queries';
+import { generateFilters } from 'graphql/utils/Filters';
+
+import useGetAggregations from 'hooks/graphql/useGetAggregations';
 
 import styles from './Filters.module.scss';
 
@@ -12,6 +13,7 @@ type OwnProps = {
   field: string;
   sqon: any;
   extendedMappingResults: ExtendedMappingResults;
+  noDataInputOption?: boolean;
 };
 
 const GenericFilters = ({
@@ -20,6 +22,7 @@ const GenericFilters = ({
   field,
   sqon,
   extendedMappingResults,
+  noDataInputOption,
 }: OwnProps) => {
   const results = useGetAggregations(
     {
@@ -42,6 +45,7 @@ const GenericFilters = ({
           showSearchInput: true,
           useFilterSelector: true,
           index,
+          noDataInputOption,
         })}
       </Layout>
     </Spin>

--- a/src/components/utils/filterUtils.tsx
+++ b/src/components/utils/filterUtils.tsx
@@ -1,0 +1,21 @@
+import { FilterInfo } from 'components/uiKit/FilterList/types';
+
+export const getNoDataOptionValue = (
+  field: string,
+  filterGroups: {
+    [type: string]: FilterInfo;
+  },
+): boolean | undefined => {
+  let noDataInputOption = undefined;
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
+  for (const [key, value] of Object.entries(filterGroups)) {
+    const groupWithField = value.groups.find((group) => group.facets.includes(field));
+    if (groupWithField?.noDataOption?.includes(field)) {
+      noDataInputOption = false;
+      return noDataInputOption;
+    }
+  }
+
+  return noDataInputOption;
+};

--- a/src/components/utils/filterUtils.tsx
+++ b/src/components/utils/filterUtils.tsx
@@ -8,8 +8,7 @@ export const getNoDataOptionValue = (
 ): boolean | undefined => {
   let noDataInputOption = undefined;
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
-  for (const [key, value] of Object.entries(filterGroups)) {
+  for (const value of Object.values(filterGroups)) {
     const groupWithField = value.groups.find((group) => group.facets.includes(field));
     if (groupWithField?.noDataOption?.includes(field)) {
       noDataInputOption = false;

--- a/src/graphql/utils/Filters.tsx
+++ b/src/graphql/utils/Filters.tsx
@@ -40,6 +40,7 @@ export const generateFilters = ({
   filterFooter = false,
   showSearchInput = false,
   useFilterSelector = false,
+  noDataInputOption,
   index,
 }: {
   queryBuilderId: string;
@@ -50,6 +51,7 @@ export const generateFilters = ({
   filterFooter: boolean;
   showSearchInput: boolean;
   useFilterSelector: boolean;
+  noDataInputOption?: boolean;
   index?: string;
 }) =>
   Object.keys(aggregations || []).map((key) => {
@@ -92,6 +94,7 @@ export const generateFilters = ({
           }}
           searchInputVisible={showSearchInput}
           selectedFilters={selectedFilters}
+          noDataInputOption={noDataInputOption}
         />
       </div>
     );

--- a/src/views/DataExploration/components/PageContent/index.tsx
+++ b/src/views/DataExploration/components/PageContent/index.tsx
@@ -35,6 +35,8 @@ import {
 
 import { SHARED_FILTER_ID_QUERY_PARAM_KEY } from 'common/constants';
 import GenericFilters from 'components/uiKit/FilterList/GenericFilters';
+import { FilterInfo } from 'components/uiKit/FilterList/types';
+import { getNoDataOptionValue } from 'components/utils/filterUtils';
 import useQBStateWithSavedFilters from 'hooks/useQBStateWithSavedFilters';
 import { ArrangerApi } from 'services/api/arranger';
 import { SavedFilterTag } from 'services/api/savedFilter/models';
@@ -66,6 +68,9 @@ type OwnProps = {
   fileMapping: ExtendedMappingResults;
   biospecimenMapping: ExtendedMappingResults;
   participantMapping: ExtendedMappingResults;
+  filterGroups: {
+    [type: string]: FilterInfo;
+  };
   tabId?: string;
 };
 
@@ -88,6 +93,7 @@ const PageContent = ({
   biospecimenMapping,
   participantMapping,
   tabId = TAB_IDS.SUMMARY,
+  filterGroups,
 }: OwnProps) => {
   const dispatch = useDispatch<any>();
   const history = useHistory();
@@ -179,6 +185,10 @@ const PageContent = ({
             const index = filter.content.index!;
             const field = filter.content.field;
             const { sqon, mapping } = getSqonAndMappingByIndex(index as INDEXES);
+            const noDataInputOption = getNoDataOptionValue(
+              field.replaceAll('.', '__'),
+              filterGroups,
+            );
             setSelectedFilterContent(
               <GenericFilters
                 queryBuilderId={DATA_EXPLORATION_QB_ID}
@@ -186,6 +196,7 @@ const PageContent = ({
                 field={dotToUnderscore(field)}
                 sqon={sqon}
                 extendedMappingResults={mapping}
+                noDataInputOption={noDataInputOption}
               />,
             );
           },

--- a/src/views/DataExploration/index.tsx
+++ b/src/views/DataExploration/index.tsx
@@ -207,6 +207,7 @@ const DataExploration = () => {
           fileMapping={fileMappingResults}
           biospecimenMapping={biospecimenMappingResults}
           participantMapping={participantMappingResults}
+          filterGroups={filterGroups}
           tabId={tab}
         />
       </ScrollContent>

--- a/src/views/Variants/components/PageContent/index.tsx
+++ b/src/views/Variants/components/PageContent/index.tsx
@@ -26,6 +26,8 @@ import {
 import { SHARED_FILTER_ID_QUERY_PARAM_KEY } from 'common/constants';
 import LineStyleIcon from 'components/Icons/LineStyleIcon';
 import GenericFilters from 'components/uiKit/FilterList/GenericFilters';
+import { FilterInfo } from 'components/uiKit/FilterList/types';
+import { getNoDataOptionValue } from 'components/utils/filterUtils';
 import useQBStateWithSavedFilters from 'hooks/useQBStateWithSavedFilters';
 import { ArrangerApi } from 'services/api/arranger';
 import { SavedFilterTag } from 'services/api/savedFilter/models';
@@ -48,6 +50,9 @@ import styles from './index.module.scss';
 
 type OwnProps = {
   variantMapping: IExtendedMappingResults;
+  filterGroups: {
+    [type: string]: FilterInfo;
+  };
 };
 
 const addTagToFilter = (filter: ISavedFilter) => ({
@@ -55,7 +60,7 @@ const addTagToFilter = (filter: ISavedFilter) => ({
   tag: SavedFilterTag.VariantsExplorationPage,
 });
 
-const PageContent = ({ variantMapping }: OwnProps) => {
+const PageContent = ({ variantMapping, filterGroups }: OwnProps) => {
   const dispatch = useDispatch<any>();
   const { userInfo } = useUser();
   const { savedSets } = useSavedSet();
@@ -171,6 +176,10 @@ const PageContent = ({ variantMapping }: OwnProps) => {
           onFacetClick: (filter) => {
             const index = filter.content.index!;
             const field = filter.content.field;
+            const noDataInputOption = getNoDataOptionValue(
+              field.replaceAll('.', '__'),
+              filterGroups,
+            );
 
             setSelectedFilterContent(
               <GenericFilters
@@ -179,6 +188,7 @@ const PageContent = ({ variantMapping }: OwnProps) => {
                 field={dotToUnderscore(field)}
                 sqon={variantResolvedSqon}
                 extendedMappingResults={variantMapping}
+                noDataInputOption={noDataInputOption}
               />,
             );
           },

--- a/src/views/Variants/index.tsx
+++ b/src/views/Variants/index.tsx
@@ -259,7 +259,7 @@ const Variants = () => {
     <div className={styles.variantsLayout}>
       <SidebarMenu className={styles.sideMenu} menuItems={menuItems} />
       <ScrollContent id={SCROLL_WRAPPER_ID} className={styles.scrollContent}>
-        <PageContent variantMapping={variantMappingResults} />
+        <PageContent variantMapping={variantMappingResults} filterGroups={filterGroups} />
       </ScrollContent>
     </div>
   );


### PR DESCRIPTION
# FIX : Remove no data option for range filters in QB

## Description

[SJIP-612](https://d3b.atlassian.net/browse/SJIP-612)

Acceptance Criterias
Remove no data option for range filters in QB dropdown in Variants and Data exploration page.

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot

### Before

<img width="934" alt="Capture d’écran, le 2023-11-14 à 16 39 34" src="https://github.com/include-dcc/include-portal-ui/assets/133775440/daa7ba31-12b6-4b21-a1f1-03aa5a64bffb">

### After

<img width="934" alt="Capture d’écran, le 2023-11-15 à 10 14 27" src="https://github.com/include-dcc/include-portal-ui/assets/133775440/cd81ecf1-03df-4081-a7fc-05d00acc9693">

<img width="934" alt="Capture d’écran, le 2023-11-15 à 10 15 01" src="https://github.com/include-dcc/include-portal-ui/assets/133775440/62e3082c-39bb-4bbd-8c30-1b0cda264bd0">

