### PR TITLE
fix(file): SJIP-109 add download manifest on page file entity

### DIFF
--- a/src/views/FileEntity/Title/index.tsx
+++ b/src/views/FileEntity/Title/index.tsx
@@ -1,12 +1,17 @@
 import intl from 'react-intl-universal';
 import { FileImageOutlined, LockOutlined, UnlockFilled } from '@ant-design/icons';
+import { ISyntheticSqon } from '@ferlab/ui/core/data/sqon/types';
+import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/utils';
 import { EntityTitle } from '@ferlab/ui/core/pages/EntityPage';
 import { Popover, Space } from 'antd';
+import { INDEXES } from 'graphql/constants';
 import { IFileEntity } from 'graphql/files/models';
+import { DATA_FILES_SAVED_SETS_FIELD } from 'views/DataExploration/utils/constant';
 
 import { FENCE_CONNECTION_STATUSES } from 'common/fenceTypes';
 import CavaticaAnalyzeButton from 'components/Cavatica/AnalyzeButton';
 import PopoverContentLink from 'components/uiKit/PopoverContentLink';
+import DownloadFileManifestModal from 'components/uiKit/reports/DownloadFileManifestModal';
 import { useFenceConnection } from 'store/fenceConnection';
 import { userHasAccessToFile } from 'utils/dataFiles';
 
@@ -28,6 +33,17 @@ const FileEntityTitle: React.FC<OwnProps> = ({ file, loading }) => {
         connectionStatus.gen3 === FENCE_CONNECTION_STATUSES.connected,
       )
     : false;
+
+  const generateSqonForFile = (): ISyntheticSqon =>
+    generateQuery({
+      newFilters: [
+        generateValueFilter({
+          field: DATA_FILES_SAVED_SETS_FIELD,
+          index: INDEXES.FILE,
+          value: file ? [file?.file_id] : [],
+        }),
+      ],
+    });
 
   const title = {
     text: file?.file_id,
@@ -60,7 +76,17 @@ const FileEntityTitle: React.FC<OwnProps> = ({ file, loading }) => {
         <LockOutlined className={styles.locked} />
       </Popover>
     ),
-    extra: <Space>{file && <CavaticaAnalyzeButton fileIds={[file.file_id]} />}</Space>,
+    extra: (
+      <Space>
+        <DownloadFileManifestModal
+          key="file-entity-manifest"
+          sqon={generateSqonForFile()}
+          isDisabled={false}
+          hasTooManyFiles={false}
+        />
+        {file && <CavaticaAnalyzeButton type="primary" fileIds={[file.file_id]} />}
+      </Space>
+    ),
   };
 
   return <EntityTitle {...title} loading={loading} />;


### PR DESCRIPTION
# FIX
- closes #[109](https://d3b.atlassian.net/browse/SJIP-109)

## Description
Il manque le bouton dans la page File Entity

## Screenshot
![image](https://github.com/include-dcc/include-portal-ui/assets/65532894/48f75a60-0607-4fd4-970d-120bfb046d79)
![image](https://github.com/include-dcc/include-portal-ui/assets/65532894/65b4f6f5-0906-4df1-a0c2-faf6d93389e8)


## Mention

@kstonge

