### PR TITLE
fix(bioreq): SJIP-663 fix ghost widget

### DIFF
--- a/src/views/Dashboard/components/DashboardCards/BiospecimenRequests/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/BiospecimenRequests/index.tsx
@@ -2,13 +2,11 @@ import intl from 'react-intl-universal';
 import Empty from '@ferlab/ui/core/components/Empty';
 import GridCard from '@ferlab/ui/core/view/v2/GridCard';
 import { List, Typography } from 'antd';
-import { getFTEnvVarByKey } from 'helpers/EnvVariables';
 import CardErrorPlaceholder from 'views/Dashboard/components/CardErrorPlaceHolder';
 import CardHeader from 'views/Dashboard/components/CardHeader';
 import { DashboardCardProps } from 'views/Dashboard/components/DashboardCards';
 import { DATA_EXPLORATION_QB_ID } from 'views/DataExploration/utils/constant';
 
-import { BIOSPECIMEN_REQUEST_KEY } from 'components/Biospecimens/Request/requestBiospecimen.utils';
 import { IUserSetOutput, SetType } from 'services/api/savedSet/models';
 import { SUPPORT_EMAIL } from 'store/report/thunks';
 import { useSavedSet } from 'store/savedSet';
@@ -64,10 +62,7 @@ const getItemList = (
 };
 
 const BiospecimenRequests = ({ id, key, className = '' }: DashboardCardProps) => {
-  const hasRequestBio = getFTEnvVarByKey(BIOSPECIMEN_REQUEST_KEY);
   const { savedSets, isLoading, fetchingError } = useSavedSet();
-
-  if (hasRequestBio !== 'true') return <></>;
 
   return (
     <GridCard

--- a/src/views/Dashboard/components/DashboardCards/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/index.tsx
@@ -50,12 +50,13 @@ export const dashboardCards: TSortableItems[] = [
     className: cx(styles.cardColxxl6, styles.cardColxxl5),
     component: <SavedSets id="4" className={styles.dashboardCard} />,
   },
-  {
-    id: '5',
-    xs: 24,
-    md: 12,
-    xxl: 8,
-    className: cx(styles.cardColxxl6, styles.cardColxxl5),
-    component: <BiospecimenRequests id="5" className={styles.dashboardCard} />,
-  },
 ];
+
+export const biospecimenRequestCard = {
+  id: '5',
+  xs: 24,
+  md: 12,
+  xxl: 8,
+  className: cx(styles.cardColxxl6, styles.cardColxxl5),
+  component: <BiospecimenRequests id="5" className={styles.dashboardCard} />,
+};

--- a/src/views/Dashboard/index.tsx
+++ b/src/views/Dashboard/index.tsx
@@ -5,12 +5,13 @@ import { Space, Typography } from 'antd';
 import { getFTEnvVarByKey } from 'helpers/EnvVariables';
 
 import { AlterTypes } from 'common/types';
+import { BIOSPECIMEN_REQUEST_KEY } from 'components/Biospecimens/Request/requestBiospecimen.utils';
 import NotificationBanner from 'components/featureToggle/NotificationBanner';
 import { useUser } from 'store/user';
 import { updateUserConfig } from 'store/user/thunks';
 import { orderCardIfNeeded } from 'utils/helper';
 
-import { dashboardCards } from './components/DashboardCards';
+import { biospecimenRequestCard, dashboardCards } from './components/DashboardCards';
 import DataExplorationLinks from './components/DashboardCards/DataExplorationLinks';
 
 import styles from './index.module.scss';
@@ -24,6 +25,9 @@ const BANNER_MSG_KEY = FT_FLAG_KEY + '_MSG';
 const Dashboard = () => {
   const dispatch = useDispatch();
   const { userInfo } = useUser();
+  const hasRequestBio = getFTEnvVarByKey(BIOSPECIMEN_REQUEST_KEY);
+  const cards =
+    hasRequestBio === 'true' ? [...dashboardCards, biospecimenRequestCard] : dashboardCards;
 
   return (
     <Space direction="vertical" size={24} className={styles.dashboardWrapper}>
@@ -52,7 +56,7 @@ const Dashboard = () => {
             }),
           )
         }
-        items={orderCardIfNeeded(dashboardCards, userInfo?.config.dashboard?.cards?.order)}
+        items={orderCardIfNeeded(cards, userInfo?.config.dashboard?.cards?.order)}
         gutter={[24, 24]}
       />
     </Space>


### PR DESCRIPTION
# FIX : Remove empty widget when is toggled off

## Description

[SJIP-663](https://d3b.atlassian.net/browse/SJIP-663)

Acceptance Criterias

When variable environment for biospecimen request is toggled off we don't want an empty widget in the dashboard. We can see it on move other widget.

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
https://github.com/include-dcc/include-portal-ui/assets/133775440/e5537feb-a665-46a5-be83-2f5d2c59c55b

### After
https://github.com/include-dcc/include-portal-ui/assets/133775440/05ed81b0-52cf-4046-8673-90b5e90f04e8

