### PR TITLE
feat(widget): SJIP-648 empty for filter and set

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -585,21 +585,23 @@ const en = {
         },
         savedFilters: {
           title: 'Saved Filters',
-          noSavedFilters: 'You have no saved filters',
+          noSavedFilters:
+            'A saved filter is a virtual query created by applying one or more filters to a data set. Save your first filter from the query builder at the top of the <a href="{dataExploHref}" style="text-decoration: underline;">Data Exploration</a> and <a href="{variantsHref}" style="text-decoration: underline;">Variants Exploration</a> pages.',
           lastSaved: 'Last saved: {date} ago',
           infoPopover: {
             content:
-              'A saved filter is a virtual query created by applying one or more filters to a data set. They can be saved and revisited for later use. You can create and manage saved filters from the query builder at the top of the <a href="{dataExploHref}" style="text-decoration: underline;">Data Exploration</a> and <a href="{variantsHref}" style="text-decoration: underline;">Variants</a> pages.',
+              'A saved filter is a virtual query created by applying one or more filters to a data set. They can be saved and revisited for later use. You can create and manage saved filters from the query builder at the top of the <a href="{dataExploHref}" style="text-decoration: underline;">Data Exploration</a> and <a href="{variantsHref}" style="text-decoration: underline;">Variants Exploration</a> pages.',
             title: 'Managing Saved Filters',
           },
         },
         savedSets: {
           title: 'Saved Sets',
-          noSavedFilters: 'You have no saved sets',
+          noSavedSets:
+            'A saved set is a collection of one or more entity IDs which can be saved and revisited for later use. Save your first set at the top of the table of results in <a href="{dataExploHref}" style="text-decoration: underline;">Data Exploration</a> and <a href="{variantsHref}" style="text-decoration: underline;">Variants Exploration</a> pages.',
           lastSaved: 'Last saved: {date} ago',
           infoPopover: {
             content:
-              'A saved set is a collection of one or more entity IDs which can be saved and revisited for later use. You can create saved sets at the top of the table of results in the <a href="{dataExploHref}" style="text-decoration: underline;">Data Exploration</a> and <a href="{variantsHref}" style="text-decoration: underline;">Variants</a> pages.',
+              'A saved set is a collection of one or more entity IDs which can be saved and revisited for later use. You can create saved sets at the top of the table of results in the <a href="{dataExploHref}" style="text-decoration: underline;">Data Exploration</a> and <a href="{variantsHref}" style="text-decoration: underline;">Variants Exploration</a> pages.',
             title: 'Managing Saved Sets',
           },
         },

--- a/src/views/Dashboard/components/DashboardCards/SavedFilters/index.module.scss
+++ b/src/views/Dashboard/components/DashboardCards/SavedFilters/index.module.scss
@@ -10,6 +10,10 @@
   *[class$='-item-meta-description'] {
     font-size: 12px;
   }
+
+  div[class$='-list-empty-text'] {
+    padding: 24px;
+  }
 }
 
 .setTabs {
@@ -18,6 +22,10 @@
   :global(.ant-tabs-content) {
     height: 100%;
     overflow: auto;
+
+    :global(.ant-tabs-tabpane) {
+      height: 100%;
+    }
   }
 
   :global(.ant-tabs-tab) {

--- a/src/views/Dashboard/components/DashboardCards/SavedFilters/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/SavedFilters/index.tsx
@@ -56,7 +56,11 @@ const SavedFilterListWrapper = ({
       ) : (
         <Empty
           imageType="grid"
-          description={intl.get('screen.dashboard.cards.savedFilters.noSavedFilters')}
+          description={intl.getHTML('screen.dashboard.cards.savedFilters.noSavedFilters', {
+            dataExploHref: STATIC_ROUTES.DATA_EXPLORATION,
+            variantsHref: STATIC_ROUTES.VARIANTS,
+          })}
+          noPadding
         />
       ),
     }}

--- a/src/views/Dashboard/components/DashboardCards/SavedSets/index.module.scss
+++ b/src/views/Dashboard/components/DashboardCards/SavedSets/index.module.scss
@@ -1,6 +1,6 @@
 @import 'src/style/themes/include/colors';
 
-.savedFiltersList {
+.savedSetsList {
   height: 100%;
   overflow: auto;
   min-height: 200px;
@@ -12,6 +12,10 @@
   *[class$='-item-meta-description'] {
     font-size: 12px;
   }
+
+  div[class$='-list-empty-text'] {
+    padding: 24px;
+  }
 }
 
 .setTabs {
@@ -20,6 +24,10 @@
   :global(.ant-tabs-content) {
     height: 100%;
     overflow: auto;
+
+    :global(.ant-tabs-tabpane) {
+      height: 100%;
+    }
   }
 
   :global(.ant-tabs-tab) {

--- a/src/views/Dashboard/components/DashboardCards/SavedSets/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/SavedSets/index.tsx
@@ -53,7 +53,11 @@ const getItemList = (
       ) : (
         <Empty
           imageType="grid"
-          description={intl.get('screen.dashboard.cards.savedSets.noSavedFilters')}
+          description={intl.getHTML('screen.dashboard.cards.savedSets.noSavedSets', {
+            dataExploHref: STATIC_ROUTES.DATA_EXPLORATION,
+            variantsHref: STATIC_ROUTES.VARIANTS,
+          })}
+          noPadding
         />
       ),
     }}


### PR DESCRIPTION
# FEAT : Dashboard widget, update empty tab for filter and set

Description
[SJIP-648](https://d3b.atlassian.net/browse/SJIP-648)

Acceptance Criterias

Rework empty tab for filter and set widget, change wording and style.
Rework style for list tab when we have no scroll to display fully height background
(Validate by Lucas)

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
<img width="1134" alt="Capture d’écran, le 2023-11-28 à 15 49 37" src="https://github.com/include-dcc/include-portal-ui/assets/133775440/bbe72543-5424-4ed9-a48f-7902f9c9ec7c">

### After
<img width="558" alt="Capture d’écran, le 2023-11-28 à 15 46 35" src="https://github.com/include-dcc/include-portal-ui/assets/133775440/bb2a336b-2923-48c2-9d34-7f9911ba16b9">
<img width="558" alt="Capture d’écran, le 2023-11-28 à 15 46 51" src="https://github.com/include-dcc/include-portal-ui/assets/133775440/98ae2d1e-bf14-480e-b426-5d59d646a3dc">

