### PR TITLE
fix(query): SJIP-638 fix redirect from variant

### DIFF
--- a/src/views/VariantEntity/SummaryHeader/index.tsx
+++ b/src/views/VariantEntity/SummaryHeader/index.tsx
@@ -47,7 +47,7 @@ const SummaryHeader = ({ variant }: OwnProps) => {
                 generateValueFilter({
                   field: 'study.study_code',
                   value: studyCodes,
-                  index: '',
+                  index: INDEXES.PARTICIPANT,
                 }),
               ],
             }),


### PR DESCRIPTION
# FIX : Query pill dropdown not working (error 500)

## Description

[SJIP-638](https://d3b.atlassian.net/browse/SJIP-638)

Acceptance Criterias
When we are redirect to data exploration from variant entity by the studies link, the value filter generated produce a 500 error on value click to display the dropdown.

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
https://github.com/include-dcc/include-portal-ui/assets/133775440/e3573414-1349-4a52-8da7-5a61a883393f

### After
https://github.com/include-dcc/include-portal-ui/assets/133775440/c8fcd53b-b36a-49cf-8843-14d75cb9bf18