### PR TITLE
fix(tag): SJIP-688 link color in tag

### DIFF
--- a/src/style/themes/include/antd/tags.less
+++ b/src/style/themes/include/antd/tags.less
@@ -65,3 +65,10 @@
     background-color: @purple-2;
   }
 }
+
+.ant-tag a {
+  color: inherit;
+}
+.ant-tag a:hover {
+  color: inherit;
+}


### PR DESCRIPTION
# FIX : link color in tag

## Description

[SJIP-688](https://d3b.atlassian.net/browse/SJIP-688)

Acceptance Criterias

- The link text color within tags should not change.

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before

### After
<img width="418" alt="Capture d’écran, le 2024-01-22 à 14 40 29" src="https://github.com/include-dcc/include-portal-ui/assets/133775440/91a79b62-be0d-4692-afd9-22754bf9a87d">