### PR TITLE
fix(profile): SJIP-649 alert message style

### DIFF
--- a/src/components/Biospecimens/Request/NoSampleModal.tsx
+++ b/src/components/Biospecimens/Request/NoSampleModal.tsx
@@ -1,6 +1,8 @@
 import intl from 'react-intl-universal';
 import { Alert, Modal } from 'antd';
 
+import styles from './requestBiospecimen.module.scss';
+
 type OwnProps = {
   isOpen: boolean;
   closeModal: () => void;
@@ -22,9 +24,11 @@ const NoSampleModal = ({ isOpen, closeModal }: OwnProps) => (
   >
     <Alert
       type="info"
-      message={intl.getHTML(
-        'screen.dataExploration.tabs.biospecimens.request.modal.alert.infoMessage',
-      )}
+      message={
+        <span className={styles.alertTitle}>
+          {intl.getHTML('screen.dataExploration.tabs.biospecimens.request.modal.alert.infoMessage')}
+        </span>
+      }
       description={intl.getHTML(
         'screen.dataExploration.tabs.biospecimens.request.modal.alert.infoDescription',
       )}

--- a/src/components/Biospecimens/Request/RequestBiospecimenModal.tsx
+++ b/src/components/Biospecimens/Request/RequestBiospecimenModal.tsx
@@ -116,9 +116,13 @@ const RequestBiospecimenModal = ({ isOpen, closeModal, sqon }: OwnProps) => {
       {error && (
         <Alert
           type="error"
-          message={intl.get(
-            'screen.dataExploration.tabs.biospecimens.request.modal.alert.errorMessage',
-          )}
+          message={
+            <span className={styles.alertTitle}>
+              {intl.get(
+                'screen.dataExploration.tabs.biospecimens.request.modal.alert.errorMessage',
+              )}
+            </span>
+          }
           description={intl.get(
             'screen.dataExploration.tabs.biospecimens.request.modal.alert.errorDescription',
           )}

--- a/src/components/Biospecimens/Request/requestBiospecimen.module.scss
+++ b/src/components/Biospecimens/Request/requestBiospecimen.module.scss
@@ -21,3 +21,7 @@
 .tooltip {
   border-bottom: 1px dotted;
 }
+
+.alertTitle {
+  font-weight: 600;
+}

--- a/src/style/themes/include/antd/alerts.less
+++ b/src/style/themes/include/antd/alerts.less
@@ -41,7 +41,6 @@
   }
 
   &-message {
-    font-weight: 600;
     a {
       color: inherit;
       text-decoration: underline;


### PR DESCRIPTION
# FIX : Remove bold on alert info message in Profile page

## Description

[SJIP-649](https://d3b.atlassian.net/browse/SJIP-649)

Acceptance Criterias
the whole sentence shouldn’t be bolded. Only the authentication method and the  associated email or ID. This makes it so that the terms have an even heavier bold weight. See design and update accordingly.

In fact for biospecimen request I have added default style to bold alert title but when we don't have title the description is bold. So I change biospecimen request.

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
<img width="1033" alt="Capture d’écran, le 2024-01-30 à 15 15 24" src="https://github.com/include-dcc/include-portal-ui/assets/133775440/aa5fc9ad-fd78-454c-86f4-d9cff2955476">

### After
<img width="694" alt="Capture d’écran, le 2024-01-30 à 14 58 29" src="https://github.com/include-dcc/include-portal-ui/assets/133775440/2f3e1a08-5718-404a-be82-df574624d66d">
<img width="1028" alt="Capture d’écran, le 2024-01-30 à 14 58 43" src="https://github.com/include-dcc/include-portal-ui/assets/133775440/67d854bf-a385-4cdb-9ca7-5340ef36c9f0">
<img width="699" alt="Capture d’écran, le 2024-01-30 à 15 03 50" src="https://github.com/include-dcc/include-portal-ui/assets/133775440/d6fde76f-d3e2-4447-ab27-8cf71f03be7a">
