### PR TITLE
fix: SJIP-600 add missing column study in export TSV

### DIFF
--- a/src/store/report/thunks.tsx
+++ b/src/store/report/thunks.tsx
@@ -214,7 +214,9 @@ const fetchTsxReport = async (
         key: col.key,
         visible: col.defaultHidden || true,
       }));
-  colStates = colStates.filter(({ visible }) => !!visible);
+  colStates = colStates
+    .filter(({ visible }) => !!visible)
+    .map((column) => (column.key === 'study' ? { ...column, key: 'study.study_code' } : column));
 
   const columnKeyOrdered = [...colStates].sort((a, b) => a.index - b.index).map(({ key }) => key);
   const tsvColumnsConfig = data!.data[args.index].columnsState.state.columns.filter(({ field }) =>
@@ -257,7 +259,9 @@ const fetchTsxReport = async (
 };
 
 const getTitleFromColumns = (columns: ProColumnType[], field: string) => {
-  const column = columns.find(({ key }) => key === field);
+  const fieldToUse = field === 'study.study_code' ? 'study' : field;
+
+  const column = columns.find(({ key }) => key === fieldToUse);
 
   if (!column || (column.title && typeof column.title !== 'string')) {
     return startCase(field.replace(/\./g, ' '));


### PR DESCRIPTION
# FIX: add missing column study in export TSV

- closes [#SJIP-600](https://d3b.atlassian.net/jira/software/c/projects/SJIP/boards/93?selectedIssue=SJIP-600)

## Description

In the backed arranger doesn't have a column called "study" so we need to change the mapping so that it gets the study_code. For the Header we need to change back study.study_code to study

[[JIRA LINK]](https://d3b.atlassian.net/jira/software/c/projects/SJIP/boards/93?selectedIssue=SJIP-600)

Acceptance Criterias

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Working TSV export

![image](https://github.com/include-dcc/include-portal-ui/assets/156684667/4383bf6c-4a8b-4116-b741-1f6ddf8d2e92)

## Working TSV export with wrong title

![image](https://github.com/include-dcc/include-portal-ui/assets/156684667/8068e3c2-56d6-42cd-8945-b7fd34207747)