### PR TITLE
fix(user): SJIP-694 user config lost

### DIFF
--- a/src/store/user/slice.ts
+++ b/src/store/user/slice.ts
@@ -67,9 +67,9 @@ const userSlice = createSlice({
         config: action.payload,
       },
     }));
-    builder.addCase(updateUserConfig.rejected, (state, action) => ({
+    builder.addCase(updateUserConfig.rejected, (state) => ({
       ...state,
-      error: action.payload,
+      isLoading: false,
     }));
 
     // Delete User

--- a/src/store/user/thunks.ts
+++ b/src/store/user/thunks.ts
@@ -1,11 +1,12 @@
+import { TColumnStates } from '@ferlab/ui/core/components/ProTable/types';
 import { createAsyncThunk } from '@reduxjs/toolkit';
+import { cloneDeep, get, keys, merge, set } from 'lodash';
 
 import { UserApi } from 'services/api/user';
 import { TUser, TUserConfig, TUserUpdate } from 'services/api/user/models';
 import { globalActions } from 'store/global';
 import { RootState } from 'store/types';
 import { handleThunkApiReponse } from 'store/utils';
-import { mergeDeep } from 'utils/object';
 
 import { userActions } from './slice';
 
@@ -58,38 +59,34 @@ const updateUser = createAsyncThunk<
   },
 );
 
-const updateUserConfig = createAsyncThunk<
-  TUserConfig,
-  TUserConfig,
-  { rejectValue: string; state: RootState }
->(
-  'user/update/config',
+const cleanupConfig = (config: TUserConfig): TUserConfig => {
+  // keep last item
+  const removeDuplicates = (cols: TColumnStates) =>
+    cols.filter((c, i) => !cols.some((other, j) => c.key === other.key && j > i));
+
+  // for every tables in config replace columns with no duplicates
+  keys(config.data_exploration?.tables).forEach((key) => {
+    const path = 'data_exploration.tables.' + key + '.columns';
+    const cols = get(config, path, []);
+    set(config, path, removeDuplicates(cols));
+  });
+
+  return config;
+};
+
+const updateUserConfig = createAsyncThunk<TUserConfig, TUserConfig, { state: RootState }>(
+  'user/updateConfig',
   async (config, thunkAPI) => {
-    const { user } = thunkAPI.getState();
+    const state = thunkAPI.getState();
+    const mergedConfig = cleanupConfig(
+      merge(cloneDeep(state?.user?.userInfo?.config), cloneDeep(config)),
+    );
+    await UserApi.update({ config: mergedConfig });
 
-    const deepCopyUserConfig = JSON.parse(JSON.stringify(user.userInfo?.config));
-    const deepCopyNewConfig = JSON.parse(JSON.stringify(config));
-    const mergedConfig =
-      deepCopyUserConfig.length > 0
-        ? mergeDeep<TUserConfig>(deepCopyUserConfig, deepCopyNewConfig)
-        : deepCopyNewConfig;
-
-    const { error } = await UserApi.update({
-      config: mergedConfig,
-    });
-
-    return handleThunkApiReponse({
-      error: error,
-      data: mergedConfig,
-      reject: thunkAPI.rejectWithValue,
-    });
+    return mergedConfig;
   },
   {
-    condition: (config) => {
-      if (Object.keys(config).length < 1) {
-        return false;
-      }
-    },
+    condition: (config) => Object.keys(config).length > 0,
   },
 );
 


### PR DESCRIPTION
# FIX : User config update saved only one page config

## Description

[SJIP-694](https://d3b.atlassian.net/browse/SJIP-694)

Acceptance Criterias
- When a user changes columns config he wants it's saved for an other visit.

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
See video in ticket.

### After
https://github.com/include-dcc/include-portal-ui/assets/133775440/653f4461-237b-4b56-892f-fd93a12cc42a
