### PR TITLE
fix(profile): SJIP-696 remove 404 flash

### DIFF
--- a/src/views/ProfileSettings/index.tsx
+++ b/src/views/ProfileSettings/index.tsx
@@ -15,15 +15,18 @@ const { Title } = Typography;
 
 const ProfileSettings = () => {
   const { userInfo } = useUser();
+  const keycloak_id = userInfo?.keycloak_id;
 
   return (
     <div className={styles.profileSettingsWrapper}>
       <Space size={16} direction="vertical" className={styles.profileSettings}>
         <div className={styles.profileSettingsHeader}>
           <Title level={4}>{intl.get('screen.profileSettings.title')}</Title>
-          <Link to={`/member/${userInfo?.keycloak_id}`}>
-            <Button type="primary">{intl.get('screen.profileSettings.viewProfile')}</Button>
-          </Link>
+          {keycloak_id && (
+            <Link to={`/member/${keycloak_id}`}>
+              <Button type="primary">{intl.get('screen.profileSettings.viewProfile')}</Button>
+            </Link>
+          )}
         </div>
         <Space size={24} direction="vertical" className={styles.cardsWrapper}>
           <IdentificationCard />


### PR DESCRIPTION
# FIX : Profile view from Profile Edition flash a 404 error page on load

## Description

[SJIP-696](https://d3b.atlassian.net/browse/SJIP-696)

Acceptance Criterias
- Profile view from profile edition should not show a 404 error page before loading.

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
See video in ticket.

### After
https://github.com/include-dcc/include-portal-ui/assets/133775440/770b6731-aa14-443f-a153-94179a6fd5ce
