### PR TITLE
feat(cavatica): SJIP-718 add sorter when starting cavatica analyse

### DIFF
--- a/src/components/Cavatica/AnalyzeButton/index.tsx
+++ b/src/components/Cavatica/AnalyzeButton/index.tsx
@@ -8,6 +8,7 @@ import {
 } from '@ferlab/ui/core/components/Widgets/Cavatica/type';
 import { BooleanOperators } from '@ferlab/ui/core/data/sqon/operators';
 import { ISqonGroupFilter } from '@ferlab/ui/core/data/sqon/types';
+import { ISort } from '@ferlab/ui/core/graphql/types';
 import { CAVATICA_FILE_BATCH_SIZE } from 'views/DataExploration/utils/constant';
 
 import { CavaticaApi } from 'services/api/cavatica';
@@ -28,6 +29,7 @@ import { SUPPORT_EMAIL } from 'store/report/thunks';
 interface OwnProps {
   fileIds: string[];
   sqon?: ISqonGroupFilter;
+  sort?: ISort[];
   type?: 'default' | 'primary';
   disabled?: boolean;
 }
@@ -35,6 +37,7 @@ interface OwnProps {
 const CavaticaAnalyzeButton: React.FC<OwnProps> = ({
   fileIds,
   sqon,
+  sort = [],
   type = 'default',
   disabled = false,
 }) => {
@@ -49,10 +52,11 @@ const CavaticaAnalyzeButton: React.FC<OwnProps> = ({
             op: BooleanOperators.and,
             content: [],
           },
+          sort,
           fileIds,
         }),
       ),
-    [dispatch, fileIds, sqon],
+    [dispatch, fileIds, sqon, sort],
   );
 
   useEffect(() => {

--- a/src/store/passport/thunks.ts
+++ b/src/store/passport/thunks.ts
@@ -12,6 +12,7 @@ import {
 import { BooleanOperators } from '@ferlab/ui/core/data/sqon/operators';
 import { ISqonGroupFilter } from '@ferlab/ui/core/data/sqon/types';
 import { termToSqon } from '@ferlab/ui/core/data/sqon/utils';
+import { ISort } from '@ferlab/ui/core/graphql/types';
 import { createAsyncThunk } from '@reduxjs/toolkit';
 import { IFileEntity, IFileResultTree } from 'graphql/files/models';
 import { SEARCH_FILES_QUERY } from 'graphql/files/queries';
@@ -217,6 +218,7 @@ export const beginCavaticaAnalyse = createAsyncThunk<
   },
   {
     sqon: ISqonGroupFilter;
+    sort: ISort[];
     fileIds: string[];
   },
   { rejectValue: string; state: RootState }
@@ -254,6 +256,7 @@ export const beginCavaticaAnalyse = createAsyncThunk<
     query: SEARCH_FILES_QUERY.loc?.source.body,
     variables: {
       sqon,
+      sort: args.sort,
       first: CAVATICA_FILE_BATCH_SIZE,
     },
   });

--- a/src/views/DataExploration/components/PageContent/tabs/DataFiles/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/DataFiles/index.tsx
@@ -419,6 +419,7 @@ const DataFilesTab = ({ sqon }: OwnProps) => {
               type="primary"
               fileIds={selectedAllResults ? [] : selectedKeys}
               sqon={sqon}
+              sort={queryConfig.sort ?? DEFAULT_FILE_QUERY_SORT}
               key="file-cavatica-upload"
             />,
             <DownloadFileManifestModal


### PR DESCRIPTION
# FIX | FEAT | REFACTOR | PERF | DOCS : TITLE

- closes #[718](https://d3b.atlassian.net/browse/SJIP-718)

## Description
Lors du bulk import, il faudrait utiliser le même sorter que dans le tableau où on à fait selectAll quand on fetch les ids de fichiers. Car vue que plusieurs requêtes sont envoyé, on n’est pas sûr de recevoir les données dans le même ordre

## Screenshot
![image](https://github.com/include-dcc/include-portal-ui/assets/65532894/8329fdcf-f62c-4d3d-aa0c-e9fd957d4065)




