### PR TITLE
fix(summary): SJIP-728 fix default graph position

### DIFF
--- a/src/views/DataExploration/components/PageContent/tabs/Summary/utils/grid.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/utils/grid.tsx
@@ -185,13 +185,13 @@ export const getDefaultLayouts = (): IResizableGridLayoutConfig[] => [
       h: 3,
       w: 6,
       x: 3,
-      y: 4,
+      y: 6,
     },
     sm: {
       h: 3,
       w: 5,
       x: 3,
-      y: 4,
+      y: 6,
     },
     xs: {
       h: 3,


### PR DESCRIPTION
# FIX : small and medium default graph position

## Description

[SJIP-728](https://d3b.atlassian.net/browse/SJIP-728)

Acceptance Criterias
- in `sm` and `md` grid size with default position, category graph must be on the right of demographic chart.

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
<img width="1529" alt="Capture d’écran, le 2024-03-05 à 15 45 59" src="https://github.com/include-dcc/include-portal-ui/assets/133775440/0a79a33a-775b-43fa-a8e6-9f3aa73e793b">

### After
<img width="1646" alt="Capture d’écran, le 2024-03-05 à 16 44 24" src="https://github.com/include-dcc/include-portal-ui/assets/133775440/3b7b8403-ca3c-477b-b0d9-bc930415d18e">