### PR TITLE
fix(study): SJIP-711 adjust typo and styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@apollo/client": "^3.5.10",
         "@dnd-kit/core": "^4.0.3",
         "@dnd-kit/sortable": "^5.1.0",
-        "@ferlab/ui": "^9.9.0",
+        "@ferlab/ui": "^9.9.1",
         "@loadable/component": "^5.15.2",
         "@nivo/bar": "^0.84.0",
         "@nivo/pie": "^0.84.0",
@@ -2876,9 +2876,9 @@
       }
     },
     "node_modules/@ferlab/ui": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-9.9.0.tgz",
-      "integrity": "sha512-GQ483+6SXm2V6szLsXiy37n5iKEKThV1PWj3T3NVLAxRu0KuFvTwgv1vah2RQZgjZ06h6Z6g1O6P37HsYAj77g==",
+      "version": "9.9.1",
+      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-9.9.1.tgz",
+      "integrity": "sha512-EzyvcqOSNhOVVbMkN7aPmkgXoCkc6kwQ5U/xyK73II5y33CQOHBpuu/ToOQ6RJdtGgWhAbtfy+R8/VjA/Jr1kQ==",
       "dependencies": {
         "@ant-design/icons": "^4.7.0",
         "@dnd-kit/core": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@apollo/client": "^3.5.10",
     "@dnd-kit/core": "^4.0.3",
     "@dnd-kit/sortable": "^5.1.0",
-    "@ferlab/ui": "^9.9.0",
+    "@ferlab/ui": "^9.9.1",
     "@loadable/component": "^5.15.2",
     "@nivo/bar": "^0.84.0",
     "@nivo/pie": "^0.84.0",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1479,8 +1479,13 @@ const en = {
     study: {
       access_limitation: 'Access Limitation',
       access_requirement: 'Access Requirement',
+      statistic: {
+        title: 'Statistic',
+        header: 'Summary Statistics',
+        phenotype: 'Most Frequent Phenotypes (HPO)',
+        mondo: 'Most Frequent Diagnoses (MONDO)',
+      },
       title: 'Data',
-      header: 'Summary Statistics',
       count: '{count, plural, =0 {Study} =1 {Study} other {Studies}}',
       study: 'Study',
       affectedStudies: {

--- a/src/views/StudyEntity/index.tsx
+++ b/src/views/StudyEntity/index.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useRef, useState } from 'react';
 import intl from 'react-intl-universal';
 import { useParams } from 'react-router';
+import { ReadOutlined } from '@ant-design/icons';
 import { ISyntheticSqon } from '@ferlab/ui/core/data/sqon/types';
 import {
   aggregationToChartData,
   treeNodeToChartData,
 } from '@ferlab/ui/core/layout/ResizableGridLayout/utils';
-import { ReadOutlined } from '@ant-design/icons';
 import EntityPage, {
   EntityDataset,
   EntityDescriptions,
@@ -39,7 +39,7 @@ import style from './index.module.scss';
 
 enum SectionId {
   SUMMARY = 'summary',
-  DATA = 'data',
+  STATISTIC = 'statistic',
   DATA_ACCESS = 'data_access',
   DATA_FILE = 'data_file',
   DATASET = 'dataset',
@@ -178,7 +178,7 @@ const StudyEntity = () => {
 
   const defaultLinks = [
     { href: `#${SectionId.SUMMARY}`, title: intl.get('entities.global.summary') },
-    { href: `#${SectionId.DATA}`, title: intl.get('entities.study.title') },
+    { href: `#${SectionId.STATISTIC}`, title: intl.get('entities.study.statistic.title') },
   ];
   let datasetLength = 0;
   if (hasDataset) {
@@ -213,25 +213,21 @@ const StudyEntity = () => {
         />
 
         <EntityStatistics
-          id={SectionId.DATA}
-          title={intl.get('entities.study.title')}
+          id={SectionId.STATISTIC}
+          title={intl.get('entities.study.statistic.title')}
           loading={loading}
-          header={intl.get('entities.study.header')}
+          header={intl.get('entities.study.statistic.header')}
           dictionary={{
             phenotype: {
-              headerTitle: intl.get(
-                'screen.dataExploration.tabs.summary.observed_phenotype.cardTitle',
-              ),
-              legendAxisLeft: intl.get(
-                'screen.dataExploration.tabs.summary.observed_phenotype.cardTitle',
-              ),
+              headerTitle: intl.get('entities.study.statistic.phenotype'),
+              legendAxisLeft: intl.get('entities.study.statistic.phenotype'),
               legendAxisBottom: intl.get(
                 'screen.dataExploration.tabs.summary.observed_phenotype.legendAxisBottom',
               ),
             },
             mondo: {
-              headerTitle: intl.get('screen.dataExploration.tabs.summary.mondo.cardTitle'),
-              legendAxisLeft: intl.get('screen.dataExploration.tabs.summary.mondo.cardTitle'),
+              headerTitle: intl.get('entities.study.statistic.mondo'),
+              legendAxisLeft: intl.get('entities.study.statistic.mondo'),
               legendAxisBottom: intl.get(
                 'screen.dataExploration.tabs.summary.mondo.legendAxisBottom',
               ),

--- a/src/views/StudyEntity/utils/summary.tsx
+++ b/src/views/StudyEntity/utils/summary.tsx
@@ -50,7 +50,7 @@ const getSummaryDescriptions = (study?: IStudyEntity): IEntityDescriptionsItem[]
   },
   {
     label: intl.get('entities.study.data_source'),
-    value: study?.data_source || TABLE_EMPTY_PLACE_HOLDER,
+    value: study?.data_source?.join(', ') || TABLE_EMPTY_PLACE_HOLDER,
   },
   {
     label: intl.get('entities.study.date_collection_start'),


### PR DESCRIPTION
# FIX

- closes #[711](https://d3b.atlassian.net/browse/SJIP-711)

## Description
Pourrais-tu mettre comme les titres des 2 charts
Most Frequent Phenotypes (HPO)
Most Frequent diagnoses (MONDO)
J’ai modifié le nom de la section à Statistic au lieu de “Data”  et le nom du tableau Pourra rester comme tu l’as “Summary Statistics”
Un peu de padding entre data access et le tableau de statistics
Faudrait que Clinical Data Source Type soit comma separated entre les valeurs

[[JIRA LINK]](https://d3b.atlassian.net/browse/SJIP-711)



## Screenshot

![image](https://github.com/include-dcc/include-portal-ui/assets/65532894/b5a2feb5-cc08-459f-bc75-1b546e96cc4a)
![image](https://github.com/include-dcc/include-portal-ui/assets/65532894/02926063-827f-44b2-8fdf-caba0cda56a1)


