### PR TITLE
feat(summary): SJIP-749 add participant by sample_type graph

### DIFF
--- a/src/graphql/summary/queries.ts
+++ b/src/graphql/summary/queries.ts
@@ -123,3 +123,21 @@ export const DATA_CATEGORY_QUERY = `
     }
   }
 `;
+
+export const SAMPLE_TYPE_QUERY = `
+  query($sqon: JSON) {
+    participant {
+      hits(filters: $sqon) {
+        total
+      }
+      aggregations(filters: $sqon, aggregations_filter_themselves: true, include_missing: false) {
+        files__biospecimens__sample_type {
+          buckets {
+            key
+            doc_count
+          }
+        }
+      }
+    }
+  }
+`;

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1054,6 +1054,10 @@ const en = {
               legendAxisLeft: 'Data Types',
               legendAxisBottom: '# of participants',
             },
+            sampleTypeGraph: {
+              legendAxisLeft: 'Sample Types',
+              legendAxisBottom: '# of participants',
+            },
           },
           download: {
             fileNameTemplate: 'include-%name-%type-%date%extension',
@@ -1074,6 +1078,7 @@ const en = {
             dataCategoryTitle: 'Participants by Data Category',
             dataTypeTitle: 'Participants by Data Type',
             studiesTitle: 'Participants by Study',
+            sampleTypeTitle: 'Participants by Sample Type',
           },
           sampleType: {
             cardTitle: 'Sample Type',

--- a/src/views/DataExploration/components/PageContent/tabs/Summary/DataTypeGraphCard/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/DataTypeGraphCard/index.tsx
@@ -74,7 +74,6 @@ const DataTypeGraphCard = () => {
             legendPosition: 'middle',
             legendOffset: 35,
           }}
-          onClick={(datum: any) => addToQuery('data_type', datum.indexValue as string)}
           margin={{
             bottom: 45,
             left: 140,

--- a/src/views/DataExploration/components/PageContent/tabs/Summary/DemographicGraphCard/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/DemographicGraphCard/index.tsx
@@ -94,7 +94,6 @@ const DemographicsGraphCard = () => {
           <Col sm={12} md={12} lg={8}>
             <PieChart
               data={sexData}
-              onClick={(datum) => addToQuery('sex', datum.id as string)}
               colors={colors}
               legends={[
                 {
@@ -112,7 +111,6 @@ const DemographicsGraphCard = () => {
           <Col sm={12} md={12} lg={8}>
             <PieChart
               data={ethnicityData}
-              onClick={(datum) => addToQuery('ethnicity', datum.id as string)}
               colors={colors}
               legends={[
                 {
@@ -131,7 +129,6 @@ const DemographicsGraphCard = () => {
             <PieChart
               data={raceData}
               colors={colors}
-              onClick={(datum) => addToQuery('race', datum.id as string)}
               legends={[
                 {
                   anchor: 'bottom',

--- a/src/views/DataExploration/components/PageContent/tabs/Summary/SampleType/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/SampleType/index.tsx
@@ -7,7 +7,7 @@ import ResizableGridCard from '@ferlab/ui/core/layout/ResizableGridLayout/Resiza
 import { aggregationToChartData } from '@ferlab/ui/core/layout/ResizableGridLayout/utils';
 import { INDEXES } from 'graphql/constants';
 import useParticipantResolvedSqon from 'graphql/participants/useParticipantResolvedSqon';
-import { DATA_CATEGORY_QUERY } from 'graphql/summary/queries';
+import { SAMPLE_TYPE_QUERY } from 'graphql/summary/queries';
 import { isEmpty } from 'lodash';
 import { ARRANGER_API_PROJECT_URL } from 'provider/ApolloProvider';
 import { DATA_EXPLORATION_QB_ID } from 'views/DataExploration/utils/constant';
@@ -23,23 +23,24 @@ const addToQuery = (field: string, key: string) =>
     queryBuilderId: DATA_EXPLORATION_QB_ID,
     field,
     value: [key.toLowerCase() === 'no data' ? ArrangerValues.missing : key],
-    index: INDEXES.FILE,
+    index: INDEXES.BIOSPECIMEN,
   });
 
-const DataCategoryGraphCard = () => {
+const SampleTypeGraphCard = () => {
   const { sqon } = useParticipantResolvedSqon(DATA_EXPLORATION_QB_ID);
   const { loading, result } = useApi<any>({
     config: {
       url: ARRANGER_API_PROJECT_URL,
       method: 'POST',
       data: {
-        query: DATA_CATEGORY_QUERY,
+        query: SAMPLE_TYPE_QUERY,
         variables: { sqon },
       },
     },
   });
-  const dataCategoryResults = aggregationToChartData(
-    result?.data?.participant?.aggregations?.files__data_category.buckets,
+
+  const sampleTypeResults = aggregationToChartData(
+    result?.data?.participant?.aggregations?.files__biospecimens__sample_type.buckets,
     result?.data?.participant?.hits?.total,
   );
 
@@ -51,16 +52,16 @@ const DataCategoryGraphCard = () => {
       loading={loading}
       loadingType="spinner"
       dictionary={getResizableGridDictionary()}
-      headerTitle={intl.get('screen.dataExploration.tabs.summary.availableData.dataCategoryTitle')}
+      headerTitle={intl.get('screen.dataExploration.tabs.summary.availableData.sampleTypeTitle')}
       tsvSettings={{
-        data: [dataCategoryResults],
+        data: [sampleTypeResults],
       }}
       modalContent={
         <BarChart
-          data={dataCategoryResults}
+          data={sampleTypeResults}
           axisLeft={{
             legend: intl.get(
-              'screen.dataExploration.tabs.summary.graphs.dataCategory.legendAxisLeft',
+              'screen.dataExploration.tabs.summary.graphs.sampleTypeGraph.legendAxisLeft',
             ),
             legendPosition: 'middle',
             legendOffset: -110,
@@ -69,7 +70,7 @@ const DataCategoryGraphCard = () => {
           tooltipLabel={(node: any) => node.data.id}
           axisBottom={{
             legend: intl.get(
-              'screen.dataExploration.tabs.summary.graphs.dataCategory.legendAxisBottom',
+              'screen.dataExploration.tabs.summary.graphs.sampleTypeGraph.legendAxisBottom',
             ),
             legendPosition: 'middle',
             legendOffset: 35,
@@ -89,14 +90,14 @@ const DataCategoryGraphCard = () => {
       }}
       content={
         <>
-          {isEmpty(dataCategoryResults) ? (
+          {isEmpty(sampleTypeResults) ? (
             <Empty imageType="grid" size="large" />
           ) : (
             <BarChart
-              data={dataCategoryResults}
+              data={sampleTypeResults}
               axisLeft={{
                 legend: intl.get(
-                  'screen.dataExploration.tabs.summary.graphs.dataCategory.legendAxisLeft',
+                  'screen.dataExploration.tabs.summary.graphs.sampleTypeGraph.legendAxisLeft',
                 ),
                 legendPosition: 'middle',
                 legendOffset: -110,
@@ -105,12 +106,12 @@ const DataCategoryGraphCard = () => {
               tooltipLabel={(node: any) => node.data.id}
               axisBottom={{
                 legend: intl.get(
-                  'screen.dataExploration.tabs.summary.graphs.dataCategory.legendAxisBottom',
+                  'screen.dataExploration.tabs.summary.graphs.sampleTypeGraph.legendAxisBottom',
                 ),
                 legendPosition: 'middle',
                 legendOffset: 35,
               }}
-              onClick={(datum: any) => addToQuery('data_category', datum.indexValue as string)}
+              onClick={(datum: any) => addToQuery('sample_type', datum.indexValue as string)}
               layout="horizontal"
               margin={{
                 bottom: 45,
@@ -126,4 +127,4 @@ const DataCategoryGraphCard = () => {
   );
 };
 
-export default DataCategoryGraphCard;
+export default SampleTypeGraphCard;

--- a/src/views/DataExploration/components/PageContent/tabs/Summary/utils/grid.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/utils/grid.tsx
@@ -8,6 +8,7 @@ import {
 import DataCategoryGraphCard from '../DataCategoryGraphCard';
 import DataTypeGraphCard from '../DataTypeGraphCard';
 import DemographicsGraphCard from '../DemographicGraphCard';
+import SampleTypeGraphCard from '../SampleType';
 import StudiesGraphCard from '../StudiesGraphCard';
 import SunburstGraphCard from '../SunburstGraphCard';
 
@@ -128,13 +129,13 @@ export const getDefaultLayouts = (): IResizableGridLayoutConfig[] => [
       minH: 2,
       minW: 2,
       h: 3,
-      w: 3,
+      w: 2,
       x: 0,
       y: 6,
     },
     lg: {
       h: 3,
-      w: 3,
+      w: 2,
       x: 0,
       y: 6,
     },
@@ -171,14 +172,14 @@ export const getDefaultLayouts = (): IResizableGridLayoutConfig[] => [
       minH: 2,
       minW: 2,
       h: 3,
-      w: 8,
-      x: 3,
+      w: 7,
+      x: 2,
       y: 6,
     },
     lg: {
       h: 3,
-      w: 8,
-      x: 3,
+      w: 7,
+      x: 2,
       y: 6,
     },
     md: {
@@ -189,7 +190,7 @@ export const getDefaultLayouts = (): IResizableGridLayoutConfig[] => [
     },
     sm: {
       h: 3,
-      w: 5,
+      w: 7,
       x: 3,
       y: 6,
     },
@@ -197,13 +198,56 @@ export const getDefaultLayouts = (): IResizableGridLayoutConfig[] => [
       h: 3,
       w: 6,
       x: 0,
-      y: 10,
+      y: 17,
     },
     xxs: {
       h: 3,
       w: 6,
       x: 0,
-      y: 10,
+      y: 17,
+    },
+  },
+  {
+    title: intl.get('screen.dataExploration.tabs.summary.availableData.sampleTypeTitle'),
+    id: 'sample_type',
+    component: <SampleTypeGraphCard />,
+    base: {
+      minH: 2,
+      minW: 2,
+      h: 3,
+      w: 7,
+      x: 9,
+      y: 6,
+    },
+    lg: {
+      h: 3,
+      w: 7,
+      x: 9,
+      y: 6,
+    },
+    md: {
+      h: 3,
+      w: 7,
+      x: 0,
+      y: 9,
+    },
+    sm: {
+      h: 3,
+      w: 7,
+      x: 0,
+      y: 9,
+    },
+    xs: {
+      h: 3,
+      w: 6,
+      x: 0,
+      y: 20,
+    },
+    xxs: {
+      h: 3,
+      w: 6,
+      x: 0,
+      y: 20,
     },
   },
 ];


### PR DESCRIPTION
# FEAT

- closes #[749](https://d3b.atlassian.net/browse/SJIP-749)

## Description

Goal: 

Add a horizontal bar chart for the different Sample Types to summary view 

Title: Participants by Sample Type

X axis= “Sample Type” , each bar will represent a different Sample Type

Y axis = “# of participants”

Hover: Sample type:number of participants with X sample type

Include the Download data, SVG, PNG features like the other charts.

https://d3b.atlassian.net/browse/SJIP-749


## Screenshot
![image](https://github.com/include-dcc/include-portal-ui/assets/65532894/7ff31038-b634-4e15-ae84-366eec45821a)
![image](https://github.com/include-dcc/include-portal-ui/assets/65532894/50ded9ce-a74d-4e4d-8891-8358caeb5509)
![image](https://github.com/include-dcc/include-portal-ui/assets/65532894/96f239d1-0b67-459f-b6ae-93913710b139)
![image](https://github.com/include-dcc/include-portal-ui/assets/65532894/6de1a458-8c1b-4be4-9048-02113f170211)
![image](https://github.com/include-dcc/include-portal-ui/assets/65532894/413ea467-a44e-4a3d-9c47-681f4d906bfd)
