### PR TITLE
fix(study): SJIP-711 fix typos

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@apollo/client": "^3.5.10",
         "@dnd-kit/core": "^4.0.3",
         "@dnd-kit/sortable": "^5.1.0",
-        "@ferlab/ui": "^9.9.2",
+        "@ferlab/ui": "^9.9.5",
         "@loadable/component": "^5.15.2",
         "@nivo/bar": "^0.84.0",
         "@nivo/pie": "^0.84.0",
@@ -2876,9 +2876,9 @@
       }
     },
     "node_modules/@ferlab/ui": {
-      "version": "9.9.2",
-      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-9.9.2.tgz",
-      "integrity": "sha512-nP5Wb6die//0Tf10BfcN1UJ1TK6R5Zg/mQ8z7Y7oyoQVn9WKnoDGXcbGtieHxqe3YX5nfsollT1gaCCGVewTsQ==",
+      "version": "9.9.5",
+      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-9.9.5.tgz",
+      "integrity": "sha512-Hlqt40+gWG1ITEk10/zDEr1/AkICCZHlx3uCRfqTg9uL6cH03WKTGCq8HIgUdc+sYTBjCc8Tj37oMTHpYi36aQ==",
       "dependencies": {
         "@ant-design/icons": "^4.7.0",
         "@dnd-kit/core": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@apollo/client": "^3.5.10",
     "@dnd-kit/core": "^4.0.3",
     "@dnd-kit/sortable": "^5.1.0",
-    "@ferlab/ui": "^9.9.2",
+    "@ferlab/ui": "^9.9.5",
     "@loadable/component": "^5.15.2",
     "@nivo/bar": "^0.84.0",
     "@nivo/pie": "^0.84.0",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1064,7 +1064,7 @@ const en = {
           title: 'Summary',
           graphs: {
             dataCategory: {
-              legendAxisLeft: 'Data Category',
+              legendAxisLeft: 'Data Categories',
               legendAxisBottom: '# of participants',
             },
             dataTypeGraph: {
@@ -1108,6 +1108,7 @@ const en = {
           },
           observed_phenotype: {
             cardTitle: 'Observed Phenotypes (HPO)',
+            legendAxisLeft: 'Phenotypes (HPO)',
             legendAxisBottom: '# of participants',
             phenotypeTree: {
               nbParticipant: '{count} participants (including descendant terms on this path)',
@@ -1118,6 +1119,7 @@ const en = {
           },
           mondo: {
             cardTitle: ' Diagnosis (MONDO)',
+            legendAxisLeft: 'Diagnoses (MONDO)',
             legendAxisBottom: '# of participants',
             phenotypeTree: {
               nbParticipant: '{count} participants (including descendant terms on this path)',

--- a/src/views/StudyEntity/index.tsx
+++ b/src/views/StudyEntity/index.tsx
@@ -270,14 +270,16 @@ const StudyEntity = () => {
           dictionary={{
             phenotype: {
               headerTitle: intl.get('entities.study.statistic.phenotype'),
-              legendAxisLeft: intl.get('entities.study.statistic.phenotype'),
+              legendAxisLeft: intl.get(
+                'screen.dataExploration.tabs.summary.observed_phenotype.legendAxisLeft',
+              ),
               legendAxisBottom: intl.get(
                 'screen.dataExploration.tabs.summary.observed_phenotype.legendAxisBottom',
               ),
             },
             mondo: {
               headerTitle: intl.get('entities.study.statistic.mondo'),
-              legendAxisLeft: intl.get('entities.study.statistic.mondo'),
+              legendAxisLeft: intl.get('screen.dataExploration.tabs.summary.mondo.legendAxisLeft'),
               legendAxisBottom: intl.get(
                 'screen.dataExploration.tabs.summary.mondo.legendAxisBottom',
               ),


### PR DESCRIPTION
# FIX 

- closes #[711](https://d3b.atlassian.net/browse/SJIP-711)

## Description

1. Le titre de l’axe des X pour les graphs HPO et MONDO n’est pas conforme à l’analyse
2. Les valeurs de l’axe des X ne devrait pas contenir « (HPO: 123056) » 
3. Mettre aux pluriels pour les axes des X, Phenotypes (HPO), Diagnoses (MONDO), Data Categories, Data Types

https://d3b.atlassian.net/browse/SJIP-711


## Screenshot
![image](https://github.com/include-dcc/include-portal-ui/assets/65532894/617b1955-e8bf-4c0c-a77b-79d1eb48e5af)


