### PR TITLE
feat(study): SJIP-751 fix table row key

### DIFF
--- a/src/views/Studies/components/PageContent/index.tsx
+++ b/src/views/Studies/components/PageContent/index.tsx
@@ -170,7 +170,7 @@ const PageContent = ({ defaultColumns = [] }: OwnProps) => {
               },
             }}
             size="small"
-            dataSource={data.map((i) => ({ ...i, key: i.id }))}
+            dataSource={data.map((i) => ({ ...i, key: i.study_code }))}
             dictionary={getProTableDictionary()}
           />
         }

--- a/src/views/Studies/index.tsx
+++ b/src/views/Studies/index.tsx
@@ -38,7 +38,6 @@ const hasDataCategory = (dataCategory: string[], category: DataCategory) =>
 const filterInfo: FilterInfo = {
   defaultOpenFacets: [
     'program',
-    'domain',
     'data_category',
     'experimental_strategy',
     'part_lifespan_stage',
@@ -51,7 +50,6 @@ const filterInfo: FilterInfo = {
     {
       facets: [
         'program',
-        'domain',
         'data_category',
         'experimental_strategy',
         'part_lifespan_stage',
@@ -222,7 +220,6 @@ const columns: ProColumnType<any>[] = [
 
 const Studies = () => {
   const studiesMappingResults = useGetExtendedMappings(INDEXES.STUDY);
-
   return (
     <div className={styles.studiesPage}>
       <SideBarFacet


### PR DESCRIPTION
# FIX 

- closes #[751](https://d3b.atlassian.net/browse/SJIP-751)

## Description
1. La liste des facettes et leurs titres ne sont pas conformes à l’analyse
Retire la facette domain, mais les titres doivent être changé du côté de l'api

2. Le key des lignes du tableau devrait être le Study Code (C'était comme ça avant). Ex. ici data-row-key="HTP"

[[JIRA LINK]](https://d3b.atlassian.net/browse/SJIP-751)

## Screenshot
### Before
![image](https://github.com/include-dcc/include-portal-ui/assets/65532894/04e66dcb-706f-4205-b6d3-b5a763a51653)
![image](https://github.com/include-dcc/include-portal-ui/assets/65532894/96a128db-4adc-4fcd-96d4-291b173d87b0)


### After

![image](https://github.com/include-dcc/include-portal-ui/assets/65532894/0efeedb2-66e6-43e9-a308-f684f43e6389)
![image](https://github.com/include-dcc/include-portal-ui/assets/65532894/a81a9b2e-55c6-4273-b7ed-0fa2ef08393b)


