### PR TITLE
feat(study): SJIP-776 SJIP-771 add exploration button, disabled when not harmonized

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@apollo/client": "^3.5.10",
         "@dnd-kit/core": "^4.0.3",
         "@dnd-kit/sortable": "^5.1.0",
-        "@ferlab/ui": "^9.11.1",
+        "@ferlab/ui": "^9.11.2",
         "@loadable/component": "^5.15.2",
         "@nivo/bar": "^0.84.0",
         "@nivo/pie": "^0.84.0",
@@ -2876,9 +2876,9 @@
       }
     },
     "node_modules/@ferlab/ui": {
-      "version": "9.11.1",
-      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-9.11.1.tgz",
-      "integrity": "sha512-D3139lYLQ1wvovCzr1GbA/llje6twJ0SCG7QAUDUztZtq+HC/c7Qa9foID8cpeoo3aTkymskce8frHPHuk5LMw==",
+      "version": "9.11.2",
+      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-9.11.2.tgz",
+      "integrity": "sha512-5t3/SLgnkBkW/VilQdVKdkL5saEwKSNSXDrYhB5+D9zdn4FJ1VIEewShdSSaCTqEHzR18Smy/p72f9VvYE04aw==",
       "dependencies": {
         "@ant-design/icons": "^4.7.0",
         "@dnd-kit/core": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@apollo/client": "^3.5.10",
     "@dnd-kit/core": "^4.0.3",
     "@dnd-kit/sortable": "^5.1.0",
-    "@ferlab/ui": "^9.11.1",
+    "@ferlab/ui": "^9.11.2",
     "@loadable/component": "^5.15.2",
     "@nivo/bar": "^0.84.0",
     "@nivo/pie": "^0.84.0",

--- a/src/components/reports/DownloadClinicalDataDropdown/index.tsx
+++ b/src/components/reports/DownloadClinicalDataDropdown/index.tsx
@@ -13,18 +13,32 @@ interface OwnProps {
   participantIds?: string[];
   sqon?: ISqonGroupFilter;
   type?: 'default' | 'primary';
+  disabled?: boolean;
+  disabledTooltip?: string;
 }
 
 const DownloadClinicalDataDropdown = ({
   participantIds = [],
   sqon,
   type = 'default',
+  disabled = false,
+  disabledTooltip,
 }: OwnProps) => {
   const dispatch = useDispatch();
-
   const getCurrentSqon = (): any => sqon || generateSelectionSqon('participant_id', participantIds);
 
-  const disabledDropdown = sqon ? false : participantIds.length === 0;
+  let tooltipText = undefined;
+  let disabledDropdown = false;
+
+  if (disabled) {
+    disabledDropdown = true;
+    tooltipText = disabledTooltip;
+  } else if (sqon) {
+    disabledDropdown = false;
+  } else if (participantIds.length === 0) {
+    disabledDropdown = true;
+    tooltipText = intl.get('screen.dataExploration.itemSelectionTooltip');
+  }
 
   const menu = {
     onClick: (e: MenuInfo) =>
@@ -49,9 +63,7 @@ const DownloadClinicalDataDropdown = ({
   };
 
   return (
-    <Tooltip
-      title={disabledDropdown ? intl.get('screen.dataExploration.itemSelectionTooltip') : undefined}
-    >
+    <Tooltip title={tooltipText}>
       <div>
         <Dropdown
           key="actionDropdown"

--- a/src/components/uiKit/reports/DownloadFileManifestModal/index.tsx
+++ b/src/components/uiKit/reports/DownloadFileManifestModal/index.tsx
@@ -18,6 +18,7 @@ interface IDownloadFileManifestProps {
   sqon: ISyntheticSqon;
   type?: 'default' | 'primary';
   isDisabled?: boolean;
+  disabledTooltip?: string;
   hasTooManyFiles?: boolean;
 }
 
@@ -25,18 +26,25 @@ const DownloadFileManifestModal = ({
   sqon,
   type = 'default',
   isDisabled,
+  disabledTooltip,
   hasTooManyFiles,
 }: IDownloadFileManifestProps) => {
   const dispatch = useDispatch();
 
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [isFamilyChecked, setIsFamilyChecked] = useState(false);
+  let tooltipText = undefined;
+  if (isDisabled) {
+    if (disabledTooltip) {
+      tooltipText = disabledTooltip;
+    } else {
+      tooltipText = intl.get('screen.dataExploration.itemSelectionTooltip');
+    }
+  }
 
   return (
     <>
-      <Tooltip
-        title={isDisabled ? intl.get('screen.dataExploration.itemSelectionTooltip') : undefined}
-      >
+      <Tooltip title={tooltipText}>
         <Button
           icon={<DownloadOutlined />}
           onClick={() => setIsModalVisible(true)}

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -30,6 +30,7 @@ const en = {
     save: 'Save',
     pleaseDescribe: 'Please describe',
     connect: 'Connect',
+    viewInExploration: 'View in exploration',
     search: {
       genes: {
         emptyText: 'No gene found',
@@ -1611,6 +1612,8 @@ const en = {
       unharmonized: 'Unharmonized',
       unharmonizedTooltip:
         'Unharmonized data refers to raw data from a study that has not been standardized to the INCLUDE data model, limiting direct comparison with other studies.',
+      unharmonizedWarningTooltip:
+        'The data from this study has not been harmonized to the INCLUDE data model',
       virtual_biorepository_email: 'Virtual Biorepository Email',
       virtual_biorepository_url: 'Virtual Biorepository URL',
     },

--- a/src/views/StudyEntity/SummaryHeader/index.module.scss
+++ b/src/views/StudyEntity/SummaryHeader/index.module.scss
@@ -8,9 +8,14 @@
   gap: 12px;
 }
 
-.link {
-  display: flex;
+.tooltip {
   width: 100%;
+  height: 66px;
+}
+
+.item {
+  width: 100%;
+  height: 100%;
   align-items: baseline;
   justify-content: center;
 
@@ -21,8 +26,4 @@
   &:hover {
     background: $gray-1;
   }
-}
-
-.icon {
-  color: $gray-8;
 }

--- a/src/views/StudyEntity/SummaryHeader/index.tsx
+++ b/src/views/StudyEntity/SummaryHeader/index.tsx
@@ -1,11 +1,12 @@
 import intl from 'react-intl-universal';
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import BiospecimenIcon from '@ferlab/ui/core/components/Icons/Futuro/BiospecimenIcon';
 import FamilyIcon from '@ferlab/ui/core/components/Icons/Futuro/FamilyIcon';
 import FileIcon from '@ferlab/ui/core/components/Icons/Futuro/FileIcon';
 import { addQuery } from '@ferlab/ui/core/components/QueryBuilder/utils/useQueryBuilderState';
 import StatisticIcon from '@ferlab/ui/core/components/StatisticIcon';
 import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/utils';
+import { Button, Tooltip } from 'antd';
 import { INDEXES } from 'graphql/constants';
 import { IStudyEntity } from 'graphql/studies/models';
 import { DATA_EXPLORATION_QB_ID } from 'views/DataExploration/utils/constant';
@@ -19,87 +20,72 @@ interface ISummaryHeaderProps {
 }
 
 const SummaryHeader = ({ study }: ISummaryHeaderProps) => {
+  const navigate = useNavigate();
   const participantCount = study?.participant_count || 0;
   const fileCount = study?.file_count || 0;
   const biospecimenCount = study?.biospecimen_count || 0;
 
+  const items = [
+    {
+      route: STATIC_ROUTES.DATA_EXPLORATION_PARTICIPANTS,
+      icon: <FamilyIcon />,
+      label: intl.get('entities.participant.participants'),
+      count: participantCount,
+    },
+    {
+      route: STATIC_ROUTES.DATA_EXPLORATION_BIOSPECIMENS,
+      icon: <BiospecimenIcon />,
+      label: intl.get('entities.biospecimen.biospecimens'),
+      count: biospecimenCount,
+    },
+    {
+      route: STATIC_ROUTES.DATA_EXPLORATION_DATAFILES,
+      icon: <FileIcon />,
+      label: intl.get('entities.file.files'),
+      count: fileCount,
+    },
+  ];
+
   return (
     <div className={styles.container}>
-      <Link
-        to={STATIC_ROUTES.DATA_EXPLORATION_PARTICIPANTS}
-        className={styles.link}
-        onClick={() =>
-          addQuery({
-            queryBuilderId: DATA_EXPLORATION_QB_ID,
-            query: generateQuery({
-              newFilters: [
-                generateValueFilter({
-                  field: 'study.study_code',
-                  value: study ? [study.study_code] : [],
-                  index: INDEXES.STUDY,
-                }),
-              ],
-            }),
-            setAsActive: true,
-          })
-        }
-      >
-        <StatisticIcon
-          count={participantCount}
-          icon={<FamilyIcon className={styles.icon} />}
-          label={intl.get('entities.participant.participants')}
-        />
-      </Link>
-      <Link
-        to={STATIC_ROUTES.DATA_EXPLORATION_BIOSPECIMENS}
-        className={styles.link}
-        onClick={() =>
-          addQuery({
-            queryBuilderId: DATA_EXPLORATION_QB_ID,
-            query: generateQuery({
-              newFilters: [
-                generateValueFilter({
-                  field: 'study.study_code',
-                  value: study ? [study.study_code] : [],
-                  index: INDEXES.STUDY,
-                }),
-              ],
-            }),
-            setAsActive: true,
-          })
-        }
-      >
-        <StatisticIcon
-          count={biospecimenCount}
-          icon={<BiospecimenIcon className={styles.icon} />}
-          label={intl.get('entities.biospecimen.biospecimens')}
-        />
-      </Link>
-      <Link
-        to={STATIC_ROUTES.DATA_EXPLORATION_DATAFILES}
-        className={styles.link}
-        onClick={() =>
-          addQuery({
-            queryBuilderId: DATA_EXPLORATION_QB_ID,
-            query: generateQuery({
-              newFilters: [
-                generateValueFilter({
-                  field: 'study.study_code',
-                  value: study ? [study.study_code] : [],
-                  index: INDEXES.STUDY,
-                }),
-              ],
-            }),
-            setAsActive: true,
-          })
-        }
-      >
-        <StatisticIcon
-          count={fileCount}
-          icon={<FileIcon className={styles.icon} />}
-          label={intl.get('entities.file.files')}
-        />
-      </Link>
+      {items.map((item) => (
+        <Tooltip
+          title={
+            study?.is_harmonized ? undefined : intl.get('entities.study.unharmonizedWarningTooltip')
+          }
+          className={styles.tooltip}
+        >
+          <div>
+            <Button
+              disabled={!study?.is_harmonized}
+              className={styles.item}
+              onClick={() => {
+                addQuery({
+                  queryBuilderId: DATA_EXPLORATION_QB_ID,
+                  query: generateQuery({
+                    newFilters: [
+                      generateValueFilter({
+                        field: 'study.study_code',
+                        value: study ? [study.study_code] : [],
+                        index: INDEXES.STUDY,
+                      }),
+                    ],
+                  }),
+                  setAsActive: true,
+                });
+                navigate(item.route);
+              }}
+            >
+              <StatisticIcon
+                disabled={!study?.is_harmonized}
+                count={item.count}
+                icon={item.icon}
+                label={item.label}
+              />
+            </Button>
+          </div>
+        </Tooltip>
+      ))}
     </div>
   );
 };


### PR DESCRIPTION
# FEAT

- closes #[771](https://d3b.atlassian.net/browse/SJIP-771)
- closes #[776](https://d3b.atlassian.net/browse/SJIP-776)

## Description

A study can be considered to have Harmonized or Unharmonized data. Typically if it is Harmonized, the study will be available to explore in the Data Exploration page. Otherwise, it shouldn’t be explorable in the Data Exploration page. Therefore, we will disable certain buttons in the Study entity page that would redirect to the Data Exploration or have certains actions based on data in the Data Exploration.

If study.is_harmonized=false have the following buttons in the study entity page disabled and add a tooltip when hovering over the buttons:

View in exploration button at the top of the page in the: 

Statistics Section

Files section

Summary section (Participant, biospecimens, files redirect buttons)

Download clinical data

Manifest 

Disabled state Tooltip: “The data from this study has not been harmonized to the INCLUDE data model”

A study can be considered to have Harmonized or Unharmonized data. Typically if it is Harmonized, the study will be available to explore in the Data Exploration page. Otherwise, it shouldn’t be explorable in the Data Exploration page. Therefore, we will disable certain buttons in the Study entity page that would redirect to the Data Exploration or have certains actions based on data in the Data Exploration.

If study.is_harmonized=false have the following buttons in the study entity page disabled and add a tooltip when hovering over the buttons:

View in exploration button at the top of the page in the: 

Statistics Section

Files section

Summary section (Participant, biospecimens, files redirect buttons)

Download clinical data

Manifest 

Disabled state Tooltip: “The data from this study has not been harmonized to the INCLUDE data model”


## Screenshot
![2024-04-09_09-54](https://github.com/include-dcc/include-portal-ui/assets/65532894/bdcac53c-4565-4c75-8371-bff16d956bab)
![2024-04-09_09-54_1](https://github.com/include-dcc/include-portal-ui/assets/65532894/dc3d5b7f-5f64-4ced-b49c-8d62aed54ea0)
![2024-04-09_09-54_2](https://github.com/include-dcc/include-portal-ui/assets/65532894/8c14af87-cc3d-4c52-b058-9375e6112673)
![2024-04-09_09-54_3](https://github.com/include-dcc/include-portal-ui/assets/65532894/ce5fb606-0934-475b-b722-1a3cdc999294)
![2024-04-09_09-54_4](https://github.com/include-dcc/include-portal-ui/assets/65532894/46cbda7f-daea-46e5-a61f-c4105381c60e)
![2024-04-09_09-54_5](https://github.com/include-dcc/include-portal-ui/assets/65532894/8dc186cc-f784-441f-950d-4b8cafb6cf4d)
![2024-04-09_09-55](https://github.com/include-dcc/include-portal-ui/assets/65532894/b8c49797-f77c-45c5-9c4b-42e2872cd081)



https://github.com/include-dcc/include-portal-ui/assets/65532894/138a8a58-a2de-447c-83a4-6bb2f0a9f6e8


https://github.com/include-dcc/include-portal-ui/assets/65532894/89b8ac80-b7f8-4f6d-8f68-7845185a98fd



