### PR TITLE
feat(entity): SJIP-778 update view in data exploration design

### DIFF
--- a/src/views/FileEntity/BiospecimenTable/index.tsx
+++ b/src/views/FileEntity/BiospecimenTable/index.tsx
@@ -1,9 +1,11 @@
 import intl from 'react-intl-universal';
 import { useDispatch } from 'react-redux';
+import { useNavigate } from 'react-router';
 import ExternalLinkIcon from '@ferlab/ui/core/components/ExternalLink/ExternalLinkIcon';
 import { addQuery } from '@ferlab/ui/core/components/QueryBuilder/utils/useQueryBuilderState';
 import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/utils';
-import { EntityTable, EntityTableRedirectLink } from '@ferlab/ui/core/pages/EntityPage';
+import { EntityTable } from '@ferlab/ui/core/pages/EntityPage';
+import { Button } from 'antd';
 import { INDEXES } from 'graphql/constants';
 import { IFileEntity } from 'graphql/files/models';
 import { DATA_EXPLORATION_QB_ID } from 'views/DataExploration/utils/constant';
@@ -23,6 +25,7 @@ interface OwnProps {
 }
 
 const BiospecimenTable = ({ file, loading }: OwnProps) => {
+  const navigate = useNavigate();
   const { userInfo } = useUser();
   const dispatch = useDispatch();
 
@@ -49,10 +52,9 @@ const BiospecimenTable = ({ file, loading }: OwnProps) => {
       total={biospecimens.length}
       title={intl.get('entities.file.participant_sample')}
       titleExtra={[
-        <EntityTableRedirectLink
-          key="1"
-          to={STATIC_ROUTES.DATA_EXPLORATION_PARTICIPANTS}
-          onClick={() =>
+        <Button
+          size="small"
+          onClick={() => {
             addQuery({
               queryBuilderId: DATA_EXPLORATION_QB_ID,
               query: generateQuery({
@@ -65,12 +67,13 @@ const BiospecimenTable = ({ file, loading }: OwnProps) => {
                 ],
               }),
               setAsActive: true,
-            })
-          }
-          icon={<ExternalLinkIcon />}
+            });
+            navigate(STATIC_ROUTES.DATA_EXPLORATION_PARTICIPANTS);
+          }}
         >
-          {intl.get('global.viewInDataExploration')}
-        </EntityTableRedirectLink>,
+          {intl.get('global.viewInExploration')}
+          <ExternalLinkIcon />
+        </Button>,
       ]}
       header={intl.get('entities.file.participant_sample')}
       columns={biospecimensDefaultColumns}

--- a/src/views/ParticipantEntity/BiospecimenTable/index.tsx
+++ b/src/views/ParticipantEntity/BiospecimenTable/index.tsx
@@ -1,8 +1,10 @@
 import intl from 'react-intl-universal';
 import { useDispatch } from 'react-redux';
+import { useNavigate } from 'react-router';
 import { addQuery } from '@ferlab/ui/core/components/QueryBuilder/utils/useQueryBuilderState';
 import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/utils';
-import { EntityTable, EntityTableRedirectLink } from '@ferlab/ui/core/pages/EntityPage';
+import { EntityTable } from '@ferlab/ui/core/pages/EntityPage';
+import { Button } from 'antd';
 import { INDEXES } from 'graphql/constants';
 import { IParticipantEntity } from 'graphql/participants/models';
 import { DATA_EXPLORATION_QB_ID } from 'views/DataExploration/utils/constant';
@@ -27,6 +29,7 @@ interface OwnProps {
 }
 
 const BiospecimenTable = ({ participant, loading }: OwnProps) => {
+  const navigate = useNavigate();
   const { userInfo } = useUser();
   const dispatch = useDispatch();
 
@@ -53,11 +56,9 @@ const BiospecimenTable = ({ participant, loading }: OwnProps) => {
       data={biospecimens}
       title={intl.get('entities.biospecimen.biospecimen')}
       titleExtra={[
-        <EntityTableRedirectLink
-          key="1"
-          to={STATIC_ROUTES.DATA_EXPLORATION_BIOSPECIMENS}
-          icon={<ExternalLinkIcon width={14} />}
-          onClick={() =>
+        <Button
+          size="small"
+          onClick={() => {
             addQuery({
               queryBuilderId: DATA_EXPLORATION_QB_ID,
               query: generateQuery({
@@ -70,11 +71,13 @@ const BiospecimenTable = ({ participant, loading }: OwnProps) => {
                 ],
               }),
               setAsActive: true,
-            })
-          }
+            });
+            navigate(STATIC_ROUTES.DATA_EXPLORATION_BIOSPECIMENS);
+          }}
         >
-          {intl.get('global.viewInDataExploration')}
-        </EntityTableRedirectLink>,
+          {intl.get('global.viewInExploration')}
+          <ExternalLinkIcon />
+        </Button>,
       ]}
       total={total}
       header={intl.get('entities.biospecimen.biospecimen')}

--- a/src/views/ParticipantEntity/FileTable/index.tsx
+++ b/src/views/ParticipantEntity/FileTable/index.tsx
@@ -1,7 +1,9 @@
 import intl from 'react-intl-universal';
+import { useNavigate } from 'react-router';
 import { addQuery } from '@ferlab/ui/core/components/QueryBuilder/utils/useQueryBuilderState';
 import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/utils';
-import { EntityTableMultiple, EntityTableRedirectLink } from '@ferlab/ui/core/pages/EntityPage';
+import { EntityTableMultiple } from '@ferlab/ui/core/pages/EntityPage';
+import { Button } from 'antd';
 import { INDEXES } from 'graphql/constants';
 import { IFileEntity } from 'graphql/files/models';
 import { useDataFileAgg } from 'graphql/participants/actions';
@@ -24,6 +26,7 @@ interface IFilesTableProps {
 }
 
 const FileTable = ({ participant, loading: participantLoading }: IFilesTableProps) => {
+  const navigate = useNavigate();
   const participantId = participant?.participant_id || '';
 
   const files: IFileEntity[] = participant?.files?.hits.edges.map(({ node }) => node) || [];
@@ -54,10 +57,9 @@ const FileTable = ({ participant, loading: participantLoading }: IFilesTableProp
         loading={participantLoading || dataFileLoading}
         title={intl.get('entities.file.file')}
         titleExtra={[
-          <EntityTableRedirectLink
-            key="1"
-            to={STATIC_ROUTES.DATA_EXPLORATION_DATAFILES}
-            onClick={() =>
+          <Button
+            size="small"
+            onClick={() => {
               addQuery({
                 queryBuilderId: DATA_EXPLORATION_QB_ID,
                 query: generateQuery({
@@ -70,12 +72,13 @@ const FileTable = ({ participant, loading: participantLoading }: IFilesTableProp
                   ],
                 }),
                 setAsActive: true,
-              })
-            }
-            icon={<ExternalLinkIcon width={14} />}
+              });
+              navigate(STATIC_ROUTES.DATA_EXPLORATION_DATAFILES);
+            }}
           >
-            {intl.get('global.viewInDataExploration')}
-          </EntityTableRedirectLink>,
+            {intl.get('global.viewInExploration')}
+            <ExternalLinkIcon />
+          </Button>,
         ]}
         header={intl.get('entities.file.file')}
         tables={[


### PR DESCRIPTION
# FEAT 

- closes #[778](https://d3b.atlassian.net/browse/SJIP-778)

## Description

We updated the design of the view in exploration button. See in figma design (recently done in Study). Update the design in the Participant Entity page – Biospecimen section and File entity page – Participant/sample section.



## Screenshot
### Before
![image](https://github.com/include-dcc/include-portal-ui/assets/65532894/483e4e48-db07-4e94-90ba-262be8768306)

### After
![2024-04-09_15-45](https://github.com/include-dcc/include-portal-ui/assets/65532894/40b9f62b-db81-4bc8-821b-6345aee894c1)
![2024-04-09_15-47](https://github.com/include-dcc/include-portal-ui/assets/65532894/e2d9ecfe-6745-4a92-9a65-c7bcc887e387)


https://github.com/include-dcc/include-portal-ui/assets/65532894/d5c2d7c2-d602-4eb7-9309-62acfa1f31b4


https://github.com/include-dcc/include-portal-ui/assets/65532894/c833ae10-2d0d-424d-beae-9cd20b3f4692


