### PR TITLE
fix(cavatica): SJIP-780 fix authorized files analyse

### DIFF
--- a/src/store/passport/thunks.ts
+++ b/src/store/passport/thunks.ts
@@ -228,12 +228,12 @@ export const beginCavaticaAnalyse = createAsyncThunk<
   }
 
   const { fences, passport } = thunkAPI.getState();
-  const acls: string[] = [];
+  let acls: string[] = [];
 
   for (const fenceKey in fences) {
     const key = fenceKey as FENCE_NAMES;
     if (fences[key].acl !== undefined) {
-      acls.concat(fences[key].acl);
+      acls = [...acls, ...fences[key].acl];
     }
   }
 


### PR DESCRIPTION
# FIX

- closes #[780](https://d3b.atlassian.net/browse/SJIP-780)

## Description
Despite being connected to the Auth Studies Fence and the Cavatica widget, the authorized unlock in the Data Files tab is displaying correctly, but when you attempt to analyze in Cavatica, it say the user does not have the authorization. This file should be authorized to move forward with the copy files to cavatica modal. 

For authorized Registered tier access files it seems like I can copy into Cavatica but for Controlled tier access files, i get this unauthorized modal. 


## Screenshot
![2024-04-10_09-15](https://github.com/include-dcc/include-portal-ui/assets/65532894/1da9251a-1fab-483a-afa6-f88555a32e8e)
![2024-04-10_09-15_1](https://github.com/include-dcc/include-portal-ui/assets/65532894/b3db479d-f3f3-4d05-8fe7-2d9372681f88)


