### PR TITLE
fix(study): SJIP-786 fix data access display

### DIFF
--- a/src/views/StudyEntity/index.tsx
+++ b/src/views/StudyEntity/index.tsx
@@ -214,17 +214,27 @@ const StudyEntity = () => {
   });
 
   const hasDataset = study?.dataset?.hits?.edges && study.dataset.hits.edges.length > 0;
+  const hasDataAccess =
+    hasDataset || (study?.contacts?.hits?.edges && study?.contacts?.hits?.edges.length > 0);
 
   const defaultLinks = [
     { href: `#${SectionId.SUMMARY}`, title: intl.get('entities.global.summary') },
     { href: `#${SectionId.STATISTIC}`, title: intl.get('entities.study.statistic.title') },
   ];
+
+  if (hasDataAccess) {
+    defaultLinks.push({
+      href: `#${SectionId.DATA_ACCESS}`,
+      title: intl.get('entities.study.data_access'),
+    });
+  }
+
   let datasetLength = 0;
   if (hasDataset) {
-    defaultLinks.push(
-      { href: `#${SectionId.DATA_ACCESS}`, title: intl.get('entities.study.data_access') },
-      { href: `#${SectionId.DATASET}`, title: intl.get('entities.study.dataset.title') },
-    );
+    defaultLinks.push({
+      href: `#${SectionId.DATASET}`,
+      title: intl.get('entities.study.dataset.title'),
+    });
     datasetLength = study?.dataset?.hits.edges.length || 0;
   }
 
@@ -461,7 +471,7 @@ const StudyEntity = () => {
           }}
         />
 
-        {hasDataset && (
+        {hasDataAccess && (
           <EntityDescriptions
             descriptions={getDataAccessDescriptions(study)}
             header={intl.get('entities.study.data_access')}


### PR DESCRIPTION
# FIX

- closes #[786](https://d3b.atlassian.net/browse/SJIP-786)

## Description

Goal: It seems like the Data Access section doesn’t appear for certain studies. They should be still displayed if there is a value in either one of the following fields. Currently the following have Study Contact information: DS-Nexus, DS-Sleep, BRi-DSR

Fields:

Access Limitation	

access_limitation in study.dataset


Access Requirement	

access_requirement in study.dataset


Study Contact	 

study.contact_name;
study.contact_email


## Screenshot

![2024-04-10_09-49_1](https://github.com/include-dcc/include-portal-ui/assets/65532894/a406ed84-cffa-4b9a-9988-63db212130ea)
![2024-04-10_09-49_2](https://github.com/include-dcc/include-portal-ui/assets/65532894/d58e2878-bd56-420e-9ebf-c38628a3fb8d)

