### PR TITLE
feat(studies): SJIP-765 update facets and columns

### DIFF
--- a/src/graphql/studies/queries.ts
+++ b/src/graphql/studies/queries.ts
@@ -26,6 +26,8 @@ export const GET_STUDIES = gql`
               }
             }
             controlled_access
+            description
+            domains
             part_lifespan_stages
             data_category
             data_source
@@ -37,6 +39,7 @@ export const GET_STUDIES = gql`
             family_count
             institutions
             investigator_names
+            is_harmonized
             program
             publications
             participant_count

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1212,11 +1212,18 @@ const en = {
       },
     },
     studies: {
-      title: 'Studies',
+      end: 'End',
+      harmonizedPopover: {
+        title: 'Harmonized Data',
+        content:
+          'Study data aligned with INCLUDE Data Hub clinical standards for facilitating integration and cross-study comparison.',
+      },
       searchLabel: {
         title: 'Search by study code, study name, dbGaP',
         placeholder: 'HTP, The Human Trisome Project, phs001138',
       },
+      start: 'Start',
+      title: 'Studies',
     },
   },
   facets: {
@@ -1573,22 +1580,27 @@ const en = {
         transcriptomicTooltip: 'Transcriptomic',
       },
       data_source: 'Clinical Data Source Type',
+      data_source_table: 'Data Source',
       date_collection_end: 'Date Collection End (Year)',
+      date_collection_end_year: 'Year of collection end',
       date_collection_start: 'Date Collection Start (Year)',
+      date_collection_start_year: 'Year of collection start',
       dbGaP: 'dbGaP Accession Number',
       dbgap: 'dbGaP',
       description: 'Description',
       domain: 'Research Domain',
+      domains: 'Domain',
       file: 'File',
       files: 'Files',
       harmonized: 'Harmonized',
+      harmonizedAbrv: 'H',
       harmonizedTooltip:
         'Harmonized data refers to the collection of raw data provided by a study that has been normalized to the INCLUDE data model so that a valid comparison can be made across these studies.',
       institution: 'Institution',
       name: 'Name',
       numberByDataTypes: 'File counts by Data Type',
       numberByExperimentalStrategy: 'File counts by Experimental Strategy',
-      participant_life_span: 'Participant Life Span',
+      participant_life_span: 'Participant Lifespan',
       population: 'Population',
       principal_investigator: 'Principal Investigator',
       program: 'Program',
@@ -1600,6 +1612,7 @@ const en = {
       study_code: 'Study Code',
       study_contact: 'Study Contact',
       study_design: 'Study Design',
+      study_designs_table: 'Design',
       study_name: 'Study Name',
       study_website: 'Study Website',
       statistic: {
@@ -1610,6 +1623,7 @@ const en = {
       },
       title: 'Data',
       unharmonized: 'Unharmonized',
+      unharmonizedAbrv: 'U',
       unharmonizedTooltip:
         'Unharmonized data refers to raw data from a study that has not been standardized to the INCLUDE data model, limiting direct comparison with other studies.',
       unharmonizedWarningTooltip:

--- a/src/utils/translation.ts
+++ b/src/utils/translation.ts
@@ -257,6 +257,9 @@ export const getFacetsDictionary = () => ({
     zygosity: 'Zygosity',
     transmission: 'Transmission',
   },
+  domains: 'Domain',
+  study_designs: 'Design',
+  part_lifespan_stages: 'Participant Lifespan Stage',
   start: 'Position',
   acl: 'ACL',
   sequencing_experiment: {

--- a/src/views/Studies/index.module.scss
+++ b/src/views/Studies/index.module.scss
@@ -1,4 +1,4 @@
-@import "src/style/themes/include/layout";
+@import 'src/style/themes/include/layout';
 
 .studiesPage {
   display: flex;
@@ -8,4 +8,3 @@
   width: 100%;
   padding: $default-page-content-padding;
 }
-

--- a/src/views/Studies/index.tsx
+++ b/src/views/Studies/index.tsx
@@ -1,11 +1,13 @@
 import intl from 'react-intl-universal';
 import { Link } from 'react-router-dom';
-import { CheckOutlined } from '@ant-design/icons';
+import { AuditOutlined, CheckOutlined } from '@ant-design/icons';
 import ExternalLink from '@ferlab/ui/core/components/ExternalLink';
 import { ProColumnType } from '@ferlab/ui/core/components/ProTable/types';
 import { addQuery } from '@ferlab/ui/core/components/QueryBuilder/utils/useQueryBuilderState';
+import ExpandableCell from '@ferlab/ui/core/components/tables/ExpandableCell';
 import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/utils';
 import ScrollContent from '@ferlab/ui/core/layout/ScrollContent';
+import { Tag, Tooltip } from 'antd';
 import { INDEXES } from 'graphql/constants';
 import { IStudyEntity } from 'graphql/studies/models';
 import { DATA_EXPLORATION_QB_ID } from 'views/DataExploration/utils/constant';
@@ -39,22 +41,26 @@ const hasDataCategory = (dataCategory: string[], category: DataCategory) =>
 const filterInfo: FilterInfo = {
   defaultOpenFacets: [
     'program',
+    'domains',
     'data_category',
     'part_lifespan_stages',
     'family_data',
     'data_source',
     'study_designs',
+    'is_harmonized',
     'controlled_access',
   ],
   groups: [
     {
       facets: [
         'program',
+        'domains',
         'data_category',
         'part_lifespan_stages',
         'family_data',
         'data_source',
         'study_designs',
+        'is_harmonized',
         'controlled_access',
       ],
     },
@@ -62,6 +68,28 @@ const filterInfo: FilterInfo = {
 };
 
 const getColumns = (): ProColumnType<any>[] => [
+  {
+    key: 'is_harmonized',
+    iconTitle: <AuditOutlined />,
+    title: intl.get('entities.study.harmonized'),
+    popoverProps: {
+      title: <b>{intl.get('screen.studies.harmonizedPopover.title')}</b>,
+      overlayStyle: { maxWidth: '400px' },
+      content: intl.get('screen.studies.harmonizedPopover.content'),
+    },
+    dataIndex: 'is_harmonized',
+    align: 'center',
+    render: (is_harmonized: boolean) =>
+      is_harmonized ? (
+        <Tooltip title={intl.get('entities.study.harmonized')}>
+          <Tag color="green">{intl.get('entities.study.harmonizedAbrv')}</Tag>
+        </Tooltip>
+      ) : (
+        <Tooltip title={intl.get('entities.study.unharmonized')}>
+          <Tag>{intl.get('entities.study.unharmonizedAbrv')}</Tag>
+        </Tooltip>
+      ),
+  },
   {
     key: 'study_id',
     title: intl.get('entities.study.code'),
@@ -89,6 +117,13 @@ const getColumns = (): ProColumnType<any>[] => [
     title: intl.get('entities.study.program'),
     dataIndex: 'program',
     render: (program: string) => program || TABLE_EMPTY_PLACE_HOLDER,
+  },
+  {
+    key: 'domains',
+    title: intl.get('entities.study.domains'),
+    dataIndex: 'domains',
+    render: (domains: string[]) => domains?.join(', ') || TABLE_EMPTY_PLACE_HOLDER,
+    width: 300,
   },
   {
     key: 'external_id',
@@ -217,6 +252,83 @@ const getColumns = (): ProColumnType<any>[] => [
     align: 'center',
     render: (record: IStudyEntity) =>
       hasDataCategory(record.data_category, DataCategory.METABOLOMIC),
+  },
+  {
+    key: 'description',
+    title: intl.get('entities.study.description'),
+    dataIndex: 'description',
+    defaultHidden: true,
+    render: (description: string) => description || TABLE_EMPTY_PLACE_HOLDER,
+  },
+  {
+    key: 'part_lifespan_stages',
+    title: intl.get('entities.study.participant_life_span'),
+    dataIndex: 'part_lifespan_stages',
+    defaultHidden: true,
+    render: (part_lifespan_stages: string[]) => (
+      <ExpandableCell
+        nOfElementsWhenCollapsed={2}
+        dataSource={part_lifespan_stages}
+        renderItem={(sourceText) => <div>{sourceText}</div>}
+      />
+    ),
+  },
+  {
+    key: 'data_source',
+    title: intl.get('entities.study.data_source_table'),
+    dataIndex: 'data_source',
+    defaultHidden: true,
+    render: (data_source: string[]) => (
+      <ExpandableCell
+        nOfElementsWhenCollapsed={2}
+        dataSource={data_source}
+        renderItem={(sourceText) => <div>{sourceText}</div>}
+      />
+    ),
+  },
+  {
+    key: 'study_designs',
+    title: intl.get('entities.study.study_designs_table'),
+    dataIndex: 'study_designs',
+    defaultHidden: true,
+    render: (study_designs: string[]) => (
+      <ExpandableCell
+        nOfElementsWhenCollapsed={2}
+        dataSource={study_designs}
+        renderItem={(sourceText) => <div>{sourceText}</div>}
+      />
+    ),
+  },
+  {
+    key: 'investigator_names',
+    title: intl.get('entities.study.principal_investigator'),
+    dataIndex: 'investigator_names',
+    defaultHidden: true,
+    render: (investigator_names: string[]) => (
+      <ExpandableCell
+        nOfElementsWhenCollapsed={2}
+        dataSource={investigator_names}
+        renderItem={(sourceText) => <div>{sourceText}</div>}
+      />
+    ),
+  },
+  {
+    key: 'date_collection_start_year',
+    title: intl.get('screen.studies.start'),
+    tooltip: intl.get('entities.study.date_collection_start_year'),
+    dataIndex: 'date_collection_start_year',
+    defaultHidden: true,
+    render: (date_collection_start_year: string) =>
+      date_collection_start_year || TABLE_EMPTY_PLACE_HOLDER,
+  },
+  {
+    key: 'date_collection_end_year',
+    title: intl.get('screen.studies.end'),
+    tooltip: intl.get('entities.study.date_collection_end_year'),
+    dataIndex: 'date_collection_end_year',
+    defaultHidden: true,
+    render: (date_collection_end_year: string) =>
+      date_collection_end_year || TABLE_EMPTY_PLACE_HOLDER,
   },
 ];
 


### PR DESCRIPTION
# FEAT : Update facets and columns

## Description

[SJIP-765](https://d3b.atlassian.net/browse/SJIP-765)

Acceptance Criterias

Facets
- Add “Harmonized Data”
- Add Domain
Update the following to the notion spec:
- Part Lifespan Stages → Participant Lifespan Stage
- Study Designs → Design

Columns
- Add Data Access column
- Add Harmonized column
- Column header popover : “Harmonized Data”
- Add Domain column
Add User-defined columns (hidden in the column selection tool)
- Description
-Participant Lifespan
-Data Source
-Design
-Principal Investigator
-Start (with tooltip)
-End (with tooltip)

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before

### After
<img width="310" alt="Capture d’écran, le 2024-04-10 à 11 13 08" src="https://github.com/include-dcc/include-portal-ui/assets/133775440/1d624efe-b5bb-47b3-9ac2-e7e1faa47379">
<img width="1027" alt="Capture d’écran, le 2024-04-10 à 11 12 10" src="https://github.com/include-dcc/include-portal-ui/assets/133775440/aaead4b3-e2c9-4e12-8c2d-286b0b7d01e6">
<img width="615" alt="Capture d’écran, le 2024-04-10 à 11 11 52" src="https://github.com/include-dcc/include-portal-ui/assets/133775440/6dfc77f8-a5ce-43a8-b89a-b3657e2082be">
<img width="615" alt="Capture d’écran, le 2024-04-10 à 11 11 47" src="https://github.com/include-dcc/include-portal-ui/assets/133775440/f6a9c36c-9230-4e79-a18c-80153c68c2ed">
