### PR TITLE
feat(study): SJIP-788 add pmid link in dataset

### DIFF
--- a/src/views/StudyEntity/utils/datasets.tsx
+++ b/src/views/StudyEntity/utils/datasets.tsx
@@ -1,9 +1,12 @@
 import intl from 'react-intl-universal';
 import { TABLE_EMPTY_PLACE_HOLDER } from '@ferlab/ui/core/common/constants';
 import ExternalLink from '@ferlab/ui/core/components/ExternalLink';
+import ExpandableCell from '@ferlab/ui/core/components/tables/ExpandableCell';
 import { IEntityDescriptionsItem } from '@ferlab/ui/core/pages/EntityPage';
 import { Tag } from 'antd';
 import { IStudyDataset } from 'graphql/studies/models';
+
+import styles from '../index.module.scss';
 
 const getDatasetDescription = (dataset: IStudyDataset): IEntityDescriptionsItem[] => [
   {
@@ -31,11 +34,18 @@ const getDatasetDescription = (dataset: IStudyDataset): IEntityDescriptionsItem[
   {
     label: intl.get('entities.study.dataset.publication'),
     value: dataset.publications?.length ? (
-      <>
-        {dataset.publications.map((pub: string, index) => (
-          <div key={index}>{pub}</div>
-        ))}
-      </>
+      <ExpandableCell
+        nOfElementsWhenCollapsed={2}
+        dataSource={dataset.publications}
+        renderItem={(sourceText) => (
+          <ExternalLink
+            className={styles.externalLink}
+            href={`https://pubmed.ncbi.nlm.nih.gov/${sourceText.replace('PMID: ', '')}`}
+          >
+            {sourceText}
+          </ExternalLink>
+        )}
+      />
     ) : (
       TABLE_EMPTY_PLACE_HOLDER
     ),


### PR DESCRIPTION
# FEAT : Add PMID link in dataset section

## Description

[SJIP-788](https://d3b.atlassian.net/browse/SJIP-788)

Acceptance Criterias
- add pmid link in dataset

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before

### After
<img width="956" alt="Capture d’écran, le 2024-04-10 à 11 33 42" src="https://github.com/include-dcc/include-portal-ui/assets/133775440/e1c90930-0215-42d8-8952-8cb920eb3f4c">

