### PR TITLE
fix(studies): SJIP-765 remove safari tooltip

### DIFF
--- a/src/views/Studies/index.module.scss
+++ b/src/views/Studies/index.module.scss
@@ -8,3 +8,8 @@
   width: 100%;
   padding: $default-page-content-padding;
 }
+
+.descriptionCell::after {
+  content: '';
+  display: block;
+}

--- a/src/views/Studies/index.tsx
+++ b/src/views/Studies/index.tsx
@@ -300,7 +300,11 @@ const getColumns = (): ProColumnType<any>[] => [
     defaultHidden: true,
     render: (description: string) =>
       description ? (
-        <Text style={{ width: '200px' }} ellipsis={{ tooltip: description }}>
+        <Text
+          style={{ width: '200px' }}
+          ellipsis={{ tooltip: description }}
+          className={styles.descriptionCell}
+        >
           {description}
         </Text>
       ) : (


### PR DESCRIPTION
# FIX : Remove double tooltip

## Description

[SJIP-765](https://d3b.atlassian.net/browse/SJIP-765)

Acceptance Criterias
- remove safari tooltip

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
<img width="771" alt="Capture d’écran, le 2024-04-11 à 09 20 47" src="https://github.com/include-dcc/include-portal-ui/assets/133775440/c0219191-8e0a-43bd-bddd-1d729f9f2e6c">

### After
<img width="771" alt="Capture d’écran, le 2024-04-11 à 09 20 35" src="https://github.com/include-dcc/include-portal-ui/assets/133775440/8b81d678-14f0-44ca-9978-46bd2733c303">

