### PR TITLE
fix(variant): SJIP-759 variant adjustments

### DIFF
--- a/src/style/themes/include/_theme.template.scss
+++ b/src/style/themes/include/_theme.template.scss
@@ -92,3 +92,6 @@ $prolabel-required-mark-color: $red-8;
 
 // UploadIds
 $file-upload-item-color: $blue-8;
+
+// Variant
+$canonical-icon-color: $blue-8;

--- a/src/views/VariantEntity/index.module.scss
+++ b/src/views/VariantEntity/index.module.scss
@@ -18,7 +18,7 @@
   font-size: 20px;
   line-height: 28px;
   padding-right: 8px;
-  color: $gray-8;
+  color: $gray-8 !important;
 }
 
 .noGene {
@@ -104,6 +104,7 @@
 
 .pickedIcon {
   padding-left: 8px;
+  color: $canonical-icon-color;
 }
 
 .functionalScores {
@@ -128,5 +129,11 @@
     table > tbody > tr > td {
       background-color: $gray-1;
     }
+  }
+}
+
+.contentWrapper {
+  :global(.ant-table-tbody > tr:nth-child(even):not(.ant-table-row-selected) td) {
+    background-color: $gray-1;
   }
 }

--- a/src/views/VariantEntity/index.tsx
+++ b/src/views/VariantEntity/index.tsx
@@ -83,7 +83,7 @@ export default function VariantEntity() {
       loading={loading}
       emptyText={intl.get('no.data.available')}
     >
-      <>
+      <div className={styles.contentWrapper}>
         <EntityTitle
           text={data?.hgvsg}
           icon={<LineStyleIcon className={styles.titleIcon} />}
@@ -167,7 +167,7 @@ export default function VariantEntity() {
           data={makeGenesOrderedRow(data?.genes)}
           columns={getGenePhenotypeColumns()}
         />
-      </>
+      </div>
     </EntityPageWrapper>
   );
 }

--- a/src/views/VariantEntity/utils/summary.tsx
+++ b/src/views/VariantEntity/utils/summary.tsx
@@ -119,7 +119,7 @@ const renderOmim = (pickedOmim: IArrangerEdge<IGeneOmim>[]) => {
         {omim.node.inheritance_code?.length > 0 &&
           omim.node.inheritance_code.map((code) => (
             <Tooltip key={code} title={intl.get(`screen.variants.table.inheritant.code.${code}`)}>
-              <Tag color="blue">{code}</Tag>
+              <Tag>{code}</Tag>
             </Tooltip>
           ))}
       </Space>


### PR DESCRIPTION
# FIX : Variant adjustments

## Description

[SJIP-759](https://d3b.atlassian.net/browse/SJIP-759)

Acceptance Criterias
- Le souligné du gène devrait être de la même couleur que le texte
- Le tag devrait être gris comme les autres
- L’icône devrait être de la même couleur que celui pour Canonical
- Tous les tableaux ne devraient pas avoir les lignes alternés gris/blanc

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before
<img width="1530" alt="Capture d’écran, le 2024-04-15 à 15 31 39" src="https://github.com/include-dcc/include-portal-ui/assets/133775440/a2fc6f9b-5548-4813-a94a-70e3c4baaf2b">

### After
<img width="1530" alt="Capture d’écran, le 2024-04-15 à 15 31 01" src="https://github.com/include-dcc/include-portal-ui/assets/133775440/b044f0ad-eb48-4056-94f1-dd58bd784f3c">

