### PR TITLE
fix(summary): SJIP-802 remove padding from no data message

### DIFF
--- a/src/views/DataExploration/components/PageContent/tabs/Summary/DataCategoryGraphCard/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/DataCategoryGraphCard/index.tsx
@@ -90,7 +90,7 @@ const DataCategoryGraphCard = () => {
       content={
         <>
           {isEmpty(dataCategoryResults) ? (
-            <Empty imageType="grid" size="large" />
+            <Empty imageType="grid" size="large" noPadding />
           ) : (
             <BarChart
               data={dataCategoryResults}

--- a/src/views/DataExploration/components/PageContent/tabs/Summary/DataTypeGraphCard/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/DataTypeGraphCard/index.tsx
@@ -90,7 +90,7 @@ const DataTypeGraphCard = () => {
       content={
         <>
           {isEmpty(dataTypeResults) ? (
-            <Empty imageType="grid" size="large" />
+            <Empty imageType="grid" size="large" noPadding />
           ) : (
             <BarChart
               data={dataTypeResults}

--- a/src/views/DataExploration/components/PageContent/tabs/Summary/SampleType/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/SampleType/index.tsx
@@ -91,7 +91,7 @@ const SampleTypeGraphCard = () => {
       content={
         <>
           {isEmpty(sampleTypeResults) ? (
-            <Empty imageType="grid" size="large" />
+            <Empty imageType="grid" size="large" noPadding />
           ) : (
             <BarChart
               data={sampleTypeResults}

--- a/src/views/DataExploration/components/PageContent/tabs/Summary/StudiesGraphCard/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/StudiesGraphCard/index.tsx
@@ -90,7 +90,7 @@ const StudiesGraphCard = () => {
         <Row className={styles.graphRowWrapper}>
           <Col md={24}>
             {isEmpty(data) ? (
-              <Empty imageType="grid" />
+              <Empty imageType="grid" size="large" noPadding />
             ) : (
               <PieChart
                 data={data}

--- a/src/views/DataExploration/components/PageContent/tabs/Summary/SunburstGraphCard/GraphContent/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/SunburstGraphCard/GraphContent/index.tsx
@@ -93,6 +93,7 @@ const SunburstGraph = ({ field, previewMode = false, width = 335, height = 335 }
         imageType="grid"
         size="large"
         description={intl.get(`screen.dataExploration.tabs.summary.${field}.empty`)}
+        noPadding
       />
     );
   }


### PR DESCRIPTION
# FIX

- closes #[802](https://d3b.atlassian.net/browse/SJIP-802)

## Description
 It seems like the No data does not scale for certain charts (Participant by Data Category and Participants by sample type). It should be centered like the other charts. 
[[JIRA LINK]](https://d3b.atlassian.net/browse/SJIP-802)

## Screenshot
### Before
![image](https://github.com/include-dcc/include-portal-ui/assets/65532894/d6d24150-d154-4b47-9058-56540deb14c0)

### After
![2024-04-15_15-46](https://github.com/include-dcc/include-portal-ui/assets/65532894/e54b75a0-490f-4b9a-ac27-2ff681249303)
![image](https://github.com/include-dcc/include-portal-ui/assets/65532894/bc668f00-ff2a-4235-ae53-e709acee85af)


