### PR TITLE
feat(cavatica): SJIP-806 add project creation analytics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@apollo/client": "^3.5.10",
         "@dnd-kit/core": "^4.0.3",
         "@dnd-kit/sortable": "^5.1.0",
-        "@ferlab/ui": "^9.14.0",
+        "@ferlab/ui": "^9.14.1",
         "@loadable/component": "^5.15.2",
         "@nivo/bar": "^0.84.0",
         "@nivo/pie": "^0.84.0",
@@ -2876,9 +2876,9 @@
       }
     },
     "node_modules/@ferlab/ui": {
-      "version": "9.14.0",
-      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-9.14.0.tgz",
-      "integrity": "sha512-W1jtIYMd/ZOw/0PGkn4Acn2YbHt70yAed/h0N11mspePwL+632szP73MjNy/oIqyOPMENG+TSKh7+kTY4yNKQQ==",
+      "version": "9.14.1",
+      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-9.14.1.tgz",
+      "integrity": "sha512-U17Mfbv1vUKFHCWmpp55n374wPnHChjD1Hs20485f4WAgiTWqvo9WfL+yGNLF/7GQjsY5qVYsmoV1ra5x67E/g==",
       "dependencies": {
         "@ant-design/icons": "^4.7.0",
         "@dnd-kit/core": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@apollo/client": "^3.5.10",
     "@dnd-kit/core": "^4.0.3",
     "@dnd-kit/sortable": "^5.1.0",
-    "@ferlab/ui": "^9.14.0",
+    "@ferlab/ui": "^9.14.1",
     "@loadable/component": "^5.15.2",
     "@nivo/bar": "^0.84.0",
     "@nivo/pie": "^0.84.0",

--- a/src/components/Cavatica/AnalyzeButton/index.tsx
+++ b/src/components/Cavatica/AnalyzeButton/index.tsx
@@ -4,6 +4,7 @@ import { useDispatch } from 'react-redux';
 import CavaticaAnalyse from '@ferlab/ui/core/components/Widgets/Cavatica/CavaticaAnalyse';
 import {
   CAVATICA_ANALYSE_STATUS,
+  CavaticaAnalyticsAction,
   PASSPORT_AUTHENTIFICATION_STATUS,
 } from '@ferlab/ui/core/components/Widgets/Cavatica/type';
 import { BooleanOperators } from '@ferlab/ui/core/data/sqon/operators';
@@ -94,7 +95,7 @@ const CavaticaAnalyzeButton: React.FC<OwnProps> = ({
         dispatch(passportActions.setCavaticaBulkImportDataStatus(CAVATICA_ANALYSE_STATUS.unknow));
       }}
       handleImportBulkData={(value) => {
-        trackCavaticaAction(index);
+        trackCavaticaAction(index, CavaticaAnalyticsAction.ANALYSE);
         dispatch(startBulkImportJob(value));
       }}
       createProjectModalProps={{
@@ -113,6 +114,9 @@ const CavaticaAnalyzeButton: React.FC<OwnProps> = ({
           dispatch(
             createCavaticaProjet({
               body: values,
+              callback: () => {
+                trackCavaticaAction(index, CavaticaAnalyticsAction.PROJECT_CREATED);
+              },
             }),
           );
         },

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -1,4 +1,5 @@
 import ReactGA from 'react-ga4';
+import { CavaticaAnalyticsAction } from '@ferlab/ui/core/components/Widgets/Cavatica/type';
 import EnvironmentVariables from 'helpers/EnvVariables';
 import { capitalize } from 'lodash';
 import { FilterActionType } from 'views/DataExploration/components/PageContent';
@@ -70,11 +71,24 @@ export const trackRequestBiospecimen = (action: string) => {
   }
 };
 
-export const trackCavaticaAction = (page: string) => {
+export const trackCavaticaAction = (page: string, action: string) => {
+  let message = '';
+  switch (action) {
+    case CavaticaAnalyticsAction.ANALYSE:
+      message = 'Analyse';
+      break;
+    case CavaticaAnalyticsAction.PROJECT_CREATED:
+      message = 'Project Created';
+      break;
+    default:
+      message = 'Unknown Action';
+      break;
+  }
+
   if (isGaActive) {
     ReactGA.event({
       category: 'Cavatica',
-      action: `Analyze -- ${capitalize(page)}`,
+      action: `${message} -- ${capitalize(page)}`,
     });
   }
 };

--- a/src/store/passport/thunks.ts
+++ b/src/store/passport/thunks.ts
@@ -188,15 +188,18 @@ export const createCavaticaProjet = createAsyncThunk<
   },
   {
     body: ICavaticaCreateProjectBody;
+    callback?: () => void;
   },
   { rejectValue: string; state: RootState }
 >('passport/cavatica/create/project', async (args, thunkAPI) => {
   const { data, error } = await CavaticaApi.createProject(args.body);
-
   return handleThunkApiResponse({
     error,
     reject: thunkAPI.rejectWithValue,
     onSuccess: () => {
+      if (args.callback) {
+        args.callback();
+      }
       thunkAPI.dispatch(
         globalActions.displayNotification({
           type: 'success',

--- a/src/views/Dashboard/components/DashboardCards/Cavatica/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/Cavatica/index.tsx
@@ -1,6 +1,7 @@
 import intl from 'react-intl-universal';
 import { useDispatch } from 'react-redux';
 import CavaticaWidget from '@ferlab/ui/core/components/Widgets/Cavatica';
+import { CavaticaAnalyticsAction } from '@ferlab/ui/core/components/Widgets/Cavatica/type';
 import EnvironmentVariables from 'helpers/EnvVariables';
 
 import { ICavaticaCreateProjectBody } from 'services/api/cavatica/models';
@@ -15,6 +16,7 @@ import {
 } from 'store/passport/thunks';
 import { SUPPORT_EMAIL } from 'store/report/thunks';
 
+import { trackCavaticaAction } from '../../../../../services/analytics';
 import { DashboardCardProps } from '..';
 
 const USER_BASE_URL = EnvironmentVariables.configFor('CAVATICA_USER_BASE_URL');
@@ -42,6 +44,9 @@ const Cavatica = ({ id, className = '' }: DashboardCardProps) => {
           dispatch(
             createCavaticaProjet({
               body: values,
+              callback: () => {
+                trackCavaticaAction('Dashboard', CavaticaAnalyticsAction.PROJECT_CREATED);
+              },
             }),
           );
         },


### PR DESCRIPTION
# FEAT

- closes #[806](https://d3b.atlassian.net/browse/SJIP-806)

## Description
Add tag for when users click/create a project successfully either through the dashboard widget, analyze in Cavatica modal (Data Exploration/File entity)

Tag name: Cavatica project created


