### PR TITLE
fix: SJIP-815 enable svg download on studies chart

### DIFF
--- a/src/views/DataExploration/components/PageContent/tabs/Summary/StudiesGraphCard/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/StudiesGraphCard/index.tsx
@@ -54,7 +54,7 @@ const StudiesGraphCard = () => {
       gridUID={UID}
       id={STUDIES_GRAPH_CARD_ID}
       dictionary={getResizableGridDictionary()}
-      downloadSettings={{ png: true, svg: false, tsv: true }}
+      downloadSettings={{ png: true, svg: true, tsv: true }}
       contentClassName={styles.graphContentWrapper}
       theme="shade"
       loading={loading}


### PR DESCRIPTION
# FIX : enable svg download on studies chart

- closes [#SJIP-815](https://d3b.atlassian.net/browse/SJIP-815)

## Description

![image](https://github.com/include-dcc/include-portal-ui/assets/156684667/43472530-972e-4a06-abf5-c31053d703e6)