### PR TITLE
fix(biospecimen): SJIP-814 catch deleted biospecimen request url

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -113,6 +113,13 @@ const en = {
       404: 'Sorry, the page you visited does not exist.',
       500: 'Sorry, something went wrong.',
       backHome: 'Back home',
+      query: {
+        notFound: {
+          title: 'Query not found',
+          content:
+            'We were unable to load your query. Please try again or <a href="{href}" style="text-decoration: underline;" target="_blank">contact support</a>.',
+        },
+      },
     },
     notification: {
       genericError: 'An error occured',

--- a/src/store/savedFilter/slice.ts
+++ b/src/store/savedFilter/slice.ts
@@ -1,6 +1,8 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
 import { TUserSavedFilter } from 'services/api/savedFilter/models';
 import { initialState } from 'store/savedFilter/types';
+
 import {
   createSavedFilter,
   deleteSavedFilter,

--- a/src/store/savedSet/slice.ts
+++ b/src/store/savedSet/slice.ts
@@ -57,9 +57,8 @@ const savedSetSlice = createSlice({
       sharedBiospecimenRequest: action.payload,
       isLoading: false,
     }));
-    builder.addCase(fetchSharedBiospecimenRequest.rejected, (state, action) => ({
+    builder.addCase(fetchSharedBiospecimenRequest.rejected, (state) => ({
       ...state,
-      fetchingError: action.payload,
       isLoading: false,
     }));
     // Create

--- a/src/store/savedSet/thunks.ts
+++ b/src/store/savedSet/thunks.ts
@@ -3,6 +3,7 @@ import { addQuery } from '@ferlab/ui/core/components/QueryBuilder/utils/useQuery
 import { SET_ID_PREFIX } from '@ferlab/ui/core/data/sqon/types';
 import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/utils';
 import { createAsyncThunk } from '@reduxjs/toolkit';
+import { Modal } from 'antd';
 import { DATA_EXPLORATION_QB_ID } from 'views/DataExploration/utils/constant';
 
 import { SavedSetApi } from 'services/api/savedSet';
@@ -15,6 +16,8 @@ import {
 } from 'services/api/savedSet/models';
 import { globalActions } from 'store/global';
 import { handleThunkApiResponse } from 'store/utils';
+
+import { SUPPORT_EMAIL } from '../report/thunks';
 
 import { getSetFieldId } from '.';
 
@@ -146,6 +149,14 @@ const fetchSharedBiospecimenRequest = createAsyncThunk<
 
   return handleThunkApiResponse({
     error,
+    onError: () =>
+      Modal.error({
+        content: intl.getHTML('global.errors.query.notFound.content', {
+          href: `mailto:${SUPPORT_EMAIL}`,
+        }),
+        okText: 'Close',
+        title: intl.get('global.errors.query.notFound.title'),
+      }),
     data: data,
     reject: thunkAPI.rejectWithValue,
   });


### PR DESCRIPTION
# FIX 

- closes #[814](https://d3b.atlassian.net/browse/SJIP-814)

## Description
J’ai copié l’url d’un Biospecimen Requests à partir du widget.

J’ai supprimé ce Biospecimen Requests.

J’ai pasté l’url dans le browser.

J’ai cliqué sur l’onglet Dashboard.

Les Saved Sets et Biospecimen Requests sont en erreur.


## Screenshot
### Before
![image](https://github.com/include-dcc/include-portal-ui/assets/65532894/b6973fd2-6ae5-4c38-b38c-50a06d8517ef)

### After
[Peek 2024-04-22 10-54.webm](https://github.com/include-dcc/include-portal-ui/assets/65532894/5ac03880-06ba-4826-ad70-78ea6e69002d)


