### PR TITLE
fix(savedfilter): SJIP-814 manage error when sharing saved filter

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -118,6 +118,7 @@ const en = {
           title: 'Query not found',
           content:
             'We were unable to load your query. Please try again or <a href="{href}" style="text-decoration: underline;" target="_blank">contact support</a>.',
+          okText: 'Close',
         },
       },
     },

--- a/src/store/savedFilter/slice.ts
+++ b/src/store/savedFilter/slice.ts
@@ -59,9 +59,8 @@ const savedFilterSlice = createSlice({
       sharedSavedFilter: action.payload,
       isLoading: false,
     }));
-    builder.addCase(fetchSharedSavedFilter.rejected, (state, action) => ({
+    builder.addCase(fetchSharedSavedFilter.rejected, (state) => ({
       ...state,
-      fetchingError: action.payload,
       isLoading: false,
     }));
     // Create

--- a/src/store/savedFilter/thunks.ts
+++ b/src/store/savedFilter/thunks.ts
@@ -1,6 +1,7 @@
 import intl from 'react-intl-universal';
 import { setQueryBuilderState } from '@ferlab/ui/core/components/QueryBuilder/utils/useQueryBuilderState';
 import { createAsyncThunk } from '@reduxjs/toolkit';
+import { Modal } from 'antd';
 import { isEmpty } from 'lodash';
 import { v4 } from 'uuid';
 
@@ -13,6 +14,8 @@ import {
 } from 'services/api/savedFilter/models';
 import { globalActions } from 'store/global';
 import { handleThunkApiResponse } from 'store/utils';
+
+import { SUPPORT_EMAIL } from '../report/thunks';
 
 const fetchSavedFilters = createAsyncThunk<
   TUserSavedFilter[],
@@ -44,6 +47,14 @@ const fetchSharedSavedFilter = createAsyncThunk<
 
   return handleThunkApiResponse({
     error,
+    onError: () =>
+      Modal.error({
+        content: intl.getHTML('global.errors.query.notFound.content', {
+          href: `mailto:${SUPPORT_EMAIL}`,
+        }),
+        okText: intl.get('global.errors.query.notFound.okText'),
+        title: intl.get('global.errors.query.notFound.title'),
+      }),
     data: data,
     reject: thunkAPI.rejectWithValue,
   });

--- a/src/store/savedSet/thunks.ts
+++ b/src/store/savedSet/thunks.ts
@@ -154,7 +154,7 @@ const fetchSharedBiospecimenRequest = createAsyncThunk<
         content: intl.getHTML('global.errors.query.notFound.content', {
           href: `mailto:${SUPPORT_EMAIL}`,
         }),
-        okText: 'Close',
+        okText: intl.get('global.errors.query.notFound.okText'),
         title: intl.get('global.errors.query.notFound.title'),
       }),
     data: data,


### PR DESCRIPTION
# FIX

- closes #[814](https://d3b.atlassian.net/browse/SJIP-814)

## Description
Ça été fixé pour les Biospecimen Requests mais pas pour les Saved Filters.


## Screenshot

[Peek 2024-04-23 08-16.webm](https://github.com/include-dcc/include-portal-ui/assets/65532894/d8d1bdd7-658c-4feb-9956-042c7a56e97f)
