### PR TITLE
feat(dataexplo): SJIP-805 add graphs to summary

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1177,6 +1177,16 @@ const en = {
               legendAxisLeft: 'Sample Types',
               legendAxisBottom: '# of participants',
             },
+            mostFrequentDiagnoses: {
+              cardTitle: 'Most Frequent Diagnoses (MONDO)',
+              legendAxisLeft: 'Diagnoses (MONDO)',
+              legendAxisBottom: '# of participants',
+            },
+            mostFrequentPhenotypes: {
+              cardTitle: 'Most Frequent Phenotypes (HPO)',
+              legendAxisLeft: 'Phenotypes (HPO)',
+              legendAxisBottom: '# of participants',
+            },
           },
           download: {
             fileNameTemplate: 'include-%name-%type-%date%extension',
@@ -1198,6 +1208,8 @@ const en = {
             dataTypeTitle: 'Participants by Data Type',
             studiesTitle: 'Participants by Study',
             sampleTypeTitle: 'Participants by Sample Type',
+            mostFrequentPhenotypes: 'Most Frequent Phenotypes (HPO) ',
+            mostFrequentDiagnoses: 'Most Frequent Diagnoses (MONDO)',
           },
           sampleType: {
             cardTitle: 'Sample Type',

--- a/src/views/DataExploration/components/PageContent/tabs/Summary/MostFrequentDiagnosisGraphCard/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/MostFrequentDiagnosisGraphCard/index.tsx
@@ -1,0 +1,182 @@
+import { useEffect, useRef, useState } from 'react';
+import intl from 'react-intl-universal';
+import BarChart from '@ferlab/ui/core/components/Charts/Bar';
+import Empty from '@ferlab/ui/core/components/Empty';
+import { updateActiveQueryField } from '@ferlab/ui/core/components/QueryBuilder/utils/useQueryBuilderState';
+import { ArrangerValues } from '@ferlab/ui/core/data/arranger/formatting';
+import ResizableGridCard from '@ferlab/ui/core/layout/ResizableGridLayout/ResizableGridCard';
+import { treeNodeToChartData } from '@ferlab/ui/core/layout/ResizableGridLayout/utils';
+import { INDEXES } from 'graphql/constants';
+import useParticipantResolvedSqon from 'graphql/participants/useParticipantResolvedSqon';
+import { isEmpty, uniqBy } from 'lodash';
+import { DATA_EXPLORATION_QB_ID } from 'views/DataExploration/utils/constant';
+import { getFlattenTree, TreeNode } from 'views/DataExploration/utils/OntologyTree';
+import { PhenotypeStore } from 'views/DataExploration/utils/PhenotypeStore';
+
+import { truncateString } from 'utils/string';
+import { getResizableGridDictionary } from 'utils/translation';
+
+import { MOST_FREQUENT_DIAGNOSES_ID, UID } from '../utils/grid';
+
+const addToQuery = (field: string, key: string) =>
+  updateActiveQueryField({
+    queryBuilderId: DATA_EXPLORATION_QB_ID,
+    field: `${field}.name`,
+    value: [key.toLowerCase() === 'no data' ? ArrangerValues.missing : key],
+    index: INDEXES.PARTICIPANT,
+  });
+
+const excludes = [
+  'complete trisomy 21 (MONDO:0700030)',
+  'Down syndrome (MONDO:0008608)',
+  'mosaic translocation Down syndrome (MONDO:0700129)',
+  'mosaic trisomy 21 (MONDO:0700127)',
+  'partial segmental duplication (MONDO:0700130)',
+  'translocation Down syndrome (MONDO:0700128)',
+  'trisomy 21 (MONDO:0700126)',
+];
+
+const filterMondoData = (data: any[], key = 'id') => {
+  let result = data as any[];
+
+  // Exclude zero value
+  result = result.filter((item) => item.value > 0);
+
+  // Excludes some values
+  result = result.filter((item) => !excludes.includes((item as any)[key]));
+
+  // Unique
+  result = uniqBy(result, key);
+
+  // Total
+  result = result.slice(0, 10);
+
+  return result;
+};
+
+const MostFrequentDiagnosisGraphCard = () => {
+  const [mondo, setMondo] = useState<any[]>([]);
+  const [mondoLoading, setMondoLoading] = useState<boolean>(true);
+
+  const { sqon } = useParticipantResolvedSqon(DATA_EXPLORATION_QB_ID);
+
+  // TODO: we should change that after phenotype store refact
+  const phenotypeStore = useRef<PhenotypeStore | undefined>(new PhenotypeStore());
+
+  useEffect(() => {
+    setMondoLoading(true);
+    phenotypeStore.current?.fetch({ field: 'mondo', sqon }).then(() => {
+      setMondoLoading(false);
+      const flattenMondoTree = getFlattenTree(phenotypeStore.current?.tree as TreeNode).sort(
+        (a, b) => {
+          if ((a.exactTagCount ?? 0) > (b.exactTagCount ?? 0)) {
+            return -1;
+          }
+          if ((a.exactTagCount ?? 0) < (b.exactTagCount ?? 0)) {
+            return 1;
+          }
+          return 0;
+        },
+      );
+      setMondo(filterMondoData(treeNodeToChartData(flattenMondoTree)));
+    });
+  }, [JSON.stringify(sqon)]);
+
+  return (
+    <ResizableGridCard
+      gridUID={UID}
+      id={MOST_FREQUENT_DIAGNOSES_ID}
+      theme="shade"
+      loading={mondoLoading}
+      loadingType="spinner"
+      dictionary={getResizableGridDictionary()}
+      headerTitle={intl.get(
+        'screen.dataExploration.tabs.summary.availableData.mostFrequentDiagnoses',
+      )}
+      tsvSettings={{
+        data: [mondo],
+      }}
+      modalContent={
+        <BarChart
+          data={mondo}
+          axisLeft={{
+            legend: intl.get(
+              'screen.dataExploration.tabs.summary.graphs.mostFrequentDiagnoses.legendAxisLeft',
+            ),
+            legendPosition: 'middle',
+            legendOffset: -120,
+            format: (label: string) => {
+              const title = label
+                .replace(/\(MONDO:\d+\)/g, '')
+                .split('-')
+                .pop();
+              return truncateString(title ?? '', 15);
+            },
+          }}
+          tooltipLabel={(node: any) => node.data.label}
+          axisBottom={{
+            legend: intl.get(
+              'screen.dataExploration.tabs.summary.graphs.mostFrequentDiagnoses.legendAxisBottom',
+            ),
+            legendPosition: 'middle',
+            legendOffset: 35,
+          }}
+          layout="horizontal"
+          margin={{
+            bottom: 45,
+            left: 130,
+            right: 12,
+            top: 12,
+          }}
+        />
+      }
+      modalSettings={{
+        width: 800,
+        height: 300,
+      }}
+      content={
+        <>
+          {isEmpty(mondo) ? (
+            <Empty imageType="grid" size="large" noPadding />
+          ) : (
+            <BarChart
+              data={mondo}
+              axisLeft={{
+                legend: intl.get(
+                  'screen.dataExploration.tabs.summary.graphs.mostFrequentDiagnoses.legendAxisLeft',
+                ),
+                legendPosition: 'middle',
+                legendOffset: -120,
+                format: (label: string) => {
+                  const title = label
+                    .replace(/\(MONDO:\d+\)/g, '')
+                    .split('-')
+                    .pop();
+                  return truncateString(title ?? '', 15);
+                },
+              }}
+              tooltipLabel={(node: any) => node.data.label}
+              axisBottom={{
+                legend: intl.get(
+                  'screen.dataExploration.tabs.summary.graphs.mostFrequentDiagnoses.legendAxisBottom',
+                ),
+                legendPosition: 'middle',
+                legendOffset: 35,
+              }}
+              layout="horizontal"
+              onClick={(datum: any) => addToQuery('mondo', datum.data.label as string)}
+              margin={{
+                bottom: 45,
+                left: 130,
+                right: 12,
+                top: 12,
+              }}
+            />
+          )}
+        </>
+      }
+    />
+  );
+};
+
+export default MostFrequentDiagnosisGraphCard;

--- a/src/views/DataExploration/components/PageContent/tabs/Summary/MostFrequentPhenotypesGraphCard/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/MostFrequentPhenotypesGraphCard/index.tsx
@@ -1,0 +1,169 @@
+import { useEffect, useRef, useState } from 'react';
+import intl from 'react-intl-universal';
+import BarChart from '@ferlab/ui/core/components/Charts/Bar';
+import Empty from '@ferlab/ui/core/components/Empty';
+import { updateActiveQueryField } from '@ferlab/ui/core/components/QueryBuilder/utils/useQueryBuilderState';
+import { ArrangerValues } from '@ferlab/ui/core/data/arranger/formatting';
+import ResizableGridCard from '@ferlab/ui/core/layout/ResizableGridLayout/ResizableGridCard';
+import { treeNodeToChartData } from '@ferlab/ui/core/layout/ResizableGridLayout/utils';
+import { INDEXES } from 'graphql/constants';
+import useParticipantResolvedSqon from 'graphql/participants/useParticipantResolvedSqon';
+import { isEmpty, uniqBy } from 'lodash';
+import { DATA_EXPLORATION_QB_ID } from 'views/DataExploration/utils/constant';
+import { getFlattenTree, TreeNode } from 'views/DataExploration/utils/OntologyTree';
+import { PhenotypeStore } from 'views/DataExploration/utils/PhenotypeStore';
+
+import { truncateString } from 'utils/string';
+import { getResizableGridDictionary } from 'utils/translation';
+
+import { MOST_FREQUENT_PHENOTYPES_ID, UID } from '../utils/grid';
+
+const addToQuery = (field: string, key: string) =>
+  updateActiveQueryField({
+    queryBuilderId: DATA_EXPLORATION_QB_ID,
+    field: `${field}.name`,
+    value: [key.toLowerCase() === 'no data' ? ArrangerValues.missing : key],
+    index: INDEXES.PARTICIPANT,
+  });
+
+const filterPhenotypesData = (data: any[], key = 'id') => {
+  let result = data as any[];
+
+  // Exclude zero value
+  result = result.filter((item) => item.value > 0);
+
+  // Unique
+  result = uniqBy(result, key);
+
+  // Total
+  result = result.slice(0, 10);
+
+  return result;
+};
+
+const MostFrequentPhenotypesGraphCard = () => {
+  const [phenotypes, setPhenotypes] = useState<any>([]);
+  const [phenotypesLoading, setPhenotypesLoading] = useState<boolean>(true);
+
+  const { sqon } = useParticipantResolvedSqon(DATA_EXPLORATION_QB_ID);
+
+  // TODO: we should change that after phenotype store refact
+  const phenotypeStore = useRef<PhenotypeStore | undefined>(new PhenotypeStore());
+
+  useEffect(() => {
+    setPhenotypesLoading(true);
+    phenotypeStore.current?.fetch({ field: 'observed_phenotype', sqon }).then(() => {
+      setPhenotypesLoading(false);
+      const flattenHPOTree = getFlattenTree(phenotypeStore.current?.tree as TreeNode).sort(
+        (a, b) => {
+          if ((a.exactTagCount ?? 0) > (b.exactTagCount ?? 0)) {
+            return -1;
+          }
+          if ((a.exactTagCount ?? 0) < (b.exactTagCount ?? 0)) {
+            return 1;
+          }
+          return 0;
+        },
+      );
+      setPhenotypes(filterPhenotypesData(treeNodeToChartData(flattenHPOTree)));
+    });
+  }, [JSON.stringify(sqon)]);
+
+  return (
+    <ResizableGridCard
+      gridUID={UID}
+      id={MOST_FREQUENT_PHENOTYPES_ID}
+      theme="shade"
+      loading={phenotypesLoading}
+      loadingType="spinner"
+      dictionary={getResizableGridDictionary()}
+      headerTitle={intl.get(
+        'screen.dataExploration.tabs.summary.availableData.mostFrequentPhenotypes',
+      )}
+      tsvSettings={{
+        data: [phenotypes],
+      }}
+      modalContent={
+        <BarChart
+          data={phenotypes}
+          axisLeft={{
+            legend: intl.get(
+              'screen.dataExploration.tabs.summary.graphs.mostFrequentPhenotypes.legendAxisLeft',
+            ),
+            legendPosition: 'middle',
+            legendOffset: -120,
+            format: (label: string) => {
+              const title = label
+                .replace(/\(HP:\d+\)/g, '')
+                .split('-')
+                .pop();
+              return truncateString(title ?? '', 15);
+            },
+          }}
+          tooltipLabel={(node: any) => node.data.label}
+          axisBottom={{
+            legend: intl.get(
+              'screen.dataExploration.tabs.summary.graphs.mostFrequentPhenotypes.legendAxisBottom',
+            ),
+            legendPosition: 'middle',
+            legendOffset: 35,
+          }}
+          layout="horizontal"
+          margin={{
+            bottom: 45,
+            left: 130,
+            right: 12,
+            top: 12,
+          }}
+        />
+      }
+      modalSettings={{
+        width: 800,
+        height: 300,
+      }}
+      content={
+        <>
+          {isEmpty(phenotypes) ? (
+            <Empty imageType="grid" size="large" noPadding />
+          ) : (
+            <BarChart
+              data={phenotypes}
+              axisLeft={{
+                legend: intl.get(
+                  'screen.dataExploration.tabs.summary.graphs.mostFrequentPhenotypes.legendAxisLeft',
+                ),
+                legendPosition: 'middle',
+                legendOffset: -120,
+                format: (label: string) => {
+                  const title = label
+                    .replace(/\(HP:\d+\)/g, '')
+                    .split('-')
+                    .pop();
+                  return truncateString(title ?? '', 15);
+                },
+              }}
+              tooltipLabel={(node: any) => node.data.label}
+              axisBottom={{
+                legend: intl.get(
+                  'screen.dataExploration.tabs.summary.graphs.mostFrequentPhenotypes.legendAxisBottom',
+                ),
+                legendPosition: 'middle',
+                legendOffset: 35,
+              }}
+              layout="horizontal"
+              onClick={(datum: any) => addToQuery('observed_phenotype', datum.data.label as string)}
+              margin={{
+                bottom: 45,
+                left: 130,
+                right: 12,
+                top: 12,
+              }}
+            />
+          )}
+        </>
+      }
+    />
+  );
+};
+
+export default MostFrequentPhenotypesGraphCard;

--- a/src/views/DataExploration/components/PageContent/tabs/Summary/utils/grid.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/utils/grid.tsx
@@ -8,6 +8,8 @@ import {
 import DataCategoryGraphCard from '../DataCategoryGraphCard';
 import DataTypeGraphCard from '../DataTypeGraphCard';
 import DemographicsGraphCard from '../DemographicGraphCard';
+import MostFrequentDiagnosisGraphCard from '../MostFrequentDiagnosisGraphCard';
+import MostFrequentPhenotypesGraphCard from '../MostFrequentPhenotypesGraphCard';
 import SampleTypeGraphCard from '../SampleType';
 import StudiesGraphCard from '../StudiesGraphCard';
 import SunburstGraphCard from '../SunburstGraphCard';
@@ -15,6 +17,8 @@ import SunburstGraphCard from '../SunburstGraphCard';
 export const UID = 'summary';
 export const OBSERVED_PHENOTYPE_ID = 'observed_phenotype';
 export const MONDO_ID = 'mondo';
+export const MOST_FREQUENT_DIAGNOSES_ID = 'most_frequent_disagnoses';
+export const MOST_FREQUENT_PHENOTYPES_ID = 'most_frequent_phenotypes';
 export const DEMOGRAPHICS_GRAPH_CARD_ID = 'demographics-graph-card';
 export const AGE_AT_DIAGNOSIS_GRAPH_CARD_ID = 'age-at-diagnosis-graph-card';
 export const DATA_CATEGORY_GRAPH_CARD_ID = 'data-category-graph-card';
@@ -35,6 +39,90 @@ export const getDefaultLayouts = (): IResizableGridLayoutConfig[] => [
     ...mondoDefaultGridConfig,
   },
   {
+    title: intl.get('screen.dataExploration.tabs.summary.mostFrequentPhenotypes.cardTitle'),
+    id: MOST_FREQUENT_PHENOTYPES_ID,
+    component: <MostFrequentPhenotypesGraphCard />,
+    base: {
+      h: 4,
+      isResizable: false,
+      w: 8,
+      x: 0,
+      y: 4,
+    },
+    lg: {
+      h: 4,
+      w: 8,
+      x: 0,
+      y: 4,
+    },
+    md: {
+      h: 4,
+      w: 6,
+      x: 0,
+      y: 4,
+    },
+    sm: {
+      h: 4,
+      w: 5,
+      x: 0,
+      y: 4,
+    },
+    xs: {
+      h: 6,
+      w: 6,
+      x: 0,
+      y: 12,
+    },
+    xxs: {
+      h: 6,
+      w: 4,
+      x: 0,
+      y: 12,
+    },
+  },
+  {
+    title: intl.get('screen.dataExploration.tabs.summary.mostFrequentDiagnoses.cardTitle'),
+    id: MOST_FREQUENT_DIAGNOSES_ID,
+    component: <MostFrequentDiagnosisGraphCard />,
+    base: {
+      h: 4,
+      isResizable: false,
+      w: 8,
+      x: 8,
+      y: 4,
+    },
+    lg: {
+      h: 4,
+      w: 8,
+      x: 8,
+      y: 4,
+    },
+    md: {
+      h: 4,
+      w: 6,
+      x: 6,
+      y: 4,
+    },
+    sm: {
+      h: 4,
+      w: 5,
+      x: 5,
+      y: 4,
+    },
+    xs: {
+      h: 6,
+      w: 6,
+      x: 0,
+      y: 12,
+    },
+    xxs: {
+      h: 6,
+      w: 4,
+      x: 0,
+      y: 12,
+    },
+  },
+  {
     title: intl.get('screen.dataExploration.tabs.summary.demographic.cardTitle'),
     id: DEMOGRAPHICS_GRAPH_CARD_ID,
     component: <DemographicsGraphCard />,
@@ -44,38 +132,38 @@ export const getDefaultLayouts = (): IResizableGridLayoutConfig[] => [
       minW: 4,
       w: 8,
       x: 0,
-      y: 4,
+      y: 8,
       isDraggable: false,
     },
     lg: {
       h: 2,
       w: 8,
       x: 0,
-      y: 4,
+      y: 8,
     },
     md: {
       h: 2,
       w: 6,
       x: 0,
-      y: 4,
+      y: 8,
     },
     sm: {
       h: 2,
       w: 5,
       x: 0,
-      y: 4,
+      y: 8,
     },
     xs: {
       h: 2,
       w: 6,
       x: 0,
-      y: 8,
+      y: 24,
     },
     xxs: {
       h: 2,
       w: 4,
       x: 0,
-      y: 8,
+      y: 24,
     },
   },
   {
@@ -88,37 +176,37 @@ export const getDefaultLayouts = (): IResizableGridLayoutConfig[] => [
       minW: 4,
       w: 8,
       x: 8,
-      y: 4,
+      y: 8,
     },
     lg: {
       h: 2,
       w: 8,
       x: 8,
-      y: 4,
+      y: 8,
     },
     md: {
       h: 2,
       w: 6,
       x: 6,
-      y: 4,
+      y: 8,
     },
     sm: {
       h: 2,
       w: 5,
       x: 5,
-      y: 4,
+      y: 8,
     },
     xs: {
       h: 2,
       w: 6,
       x: 0,
-      y: 12,
+      y: 26,
     },
     xxs: {
       h: 2,
       w: 4,
       x: 0,
-      y: 12,
+      y: 26,
     },
   },
   {
@@ -131,37 +219,37 @@ export const getDefaultLayouts = (): IResizableGridLayoutConfig[] => [
       h: 3,
       w: 2,
       x: 0,
-      y: 6,
+      y: 10,
     },
     lg: {
       h: 3,
       w: 2,
       x: 0,
-      y: 6,
+      y: 10,
     },
     md: {
       h: 3,
       w: 3,
       x: 0,
-      y: 6,
+      y: 10,
     },
     sm: {
       h: 3,
       w: 3,
       x: 0,
-      y: 6,
+      y: 10,
     },
     xs: {
       h: 3,
       w: 6,
       x: 0,
-      y: 14,
+      y: 28,
     },
     xxs: {
       h: 3,
       w: 4,
       x: 0,
-      y: 14,
+      y: 28,
     },
   },
   {
@@ -174,37 +262,37 @@ export const getDefaultLayouts = (): IResizableGridLayoutConfig[] => [
       h: 3,
       w: 7,
       x: 2,
-      y: 6,
+      y: 10,
     },
     lg: {
       h: 3,
       w: 7,
       x: 2,
-      y: 6,
+      y: 10,
     },
     md: {
       h: 3,
       w: 6,
       x: 3,
-      y: 6,
+      y: 10,
     },
     sm: {
       h: 3,
       w: 7,
       x: 3,
-      y: 6,
+      y: 10,
     },
     xs: {
       h: 3,
       w: 6,
       x: 0,
-      y: 17,
+      y: 31,
     },
     xxs: {
       h: 3,
       w: 6,
       x: 0,
-      y: 17,
+      y: 31,
     },
   },
   {
@@ -217,37 +305,37 @@ export const getDefaultLayouts = (): IResizableGridLayoutConfig[] => [
       h: 3,
       w: 7,
       x: 9,
-      y: 6,
+      y: 13,
     },
     lg: {
       h: 3,
       w: 7,
       x: 9,
-      y: 6,
+      y: 13,
     },
     md: {
       h: 3,
       w: 7,
       x: 0,
-      y: 9,
+      y: 13,
     },
     sm: {
       h: 3,
       w: 7,
       x: 0,
-      y: 9,
+      y: 13,
     },
     xs: {
       h: 3,
       w: 6,
       x: 0,
-      y: 20,
+      y: 34,
     },
     xxs: {
       h: 3,
       w: 6,
       x: 0,
-      y: 20,
+      y: 34,
     },
   },
 ];


### PR DESCRIPTION
# FEAT : Add graphs to Summary view

## Description

[SJIP-805](https://d3b.atlassian.net/browse/SJIP-805)

Acceptance Criterias
- Add Most Frequent Diagnoses/Phenotype graphs to the Summary View as it was done in the Study Entity page.

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before

### After
<img width="1509" alt="Capture d’écran, le 2024-04-23 à 11 17 37" src="https://github.com/include-dcc/include-portal-ui/assets/133775440/72cea4af-53cb-43f9-ac4a-3f9814923e32">



