### PR TITLE
fix(summary): SJIP-805 various fixes in graphs

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1222,7 +1222,7 @@ const en = {
             dataTypeTitle: 'Participants by Data Type',
             studiesTitle: 'Participants by Study',
             sampleTypeTitle: 'Participants by Sample Type',
-            mostFrequentPhenotypes: 'Most Frequent Phenotypes (HPO) ',
+            mostFrequentPhenotypes: 'Most Frequent Phenotypes (HPO)',
             mostFrequentDiagnoses: 'Most Frequent Diagnoses (MONDO)',
           },
           sampleType: {

--- a/src/views/DataExploration/components/PageContent/tabs/Summary/MostFrequentDiagnosisGraphCard/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/MostFrequentDiagnosisGraphCard/index.tsx
@@ -36,7 +36,7 @@ const excludes = [
   'trisomy 21 (MONDO:0700126)',
 ];
 
-const filterMondoData = (data: any[], key = 'id') => {
+const filterMondoData = (data: any[], key = 'label') => {
   let result = data as any[];
 
   // Exclude zero value
@@ -94,7 +94,9 @@ const MostFrequentDiagnosisGraphCard = () => {
         'screen.dataExploration.tabs.summary.availableData.mostFrequentDiagnoses',
       )}
       tsvSettings={{
+        contentMap: ['label', 'value'],
         data: [mondo],
+        headers: ['Value', 'Count'],
       }}
       modalContent={
         <BarChart

--- a/src/views/DataExploration/components/PageContent/tabs/Summary/MostFrequentPhenotypesGraphCard/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/MostFrequentPhenotypesGraphCard/index.tsx
@@ -26,7 +26,7 @@ const addToQuery = (field: string, key: string) =>
     index: INDEXES.PARTICIPANT,
   });
 
-const filterPhenotypesData = (data: any[], key = 'id') => {
+const filterPhenotypesData = (data: any[], key = 'label') => {
   let result = data as any[];
 
   // Exclude zero value
@@ -81,7 +81,9 @@ const MostFrequentPhenotypesGraphCard = () => {
         'screen.dataExploration.tabs.summary.availableData.mostFrequentPhenotypes',
       )}
       tsvSettings={{
+        contentMap: ['label', 'value'],
         data: [phenotypes],
+        headers: ['Value', 'Count'],
       }}
       modalContent={
         <BarChart

--- a/src/views/DataExploration/components/PageContent/tabs/Summary/utils/grid.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/utils/grid.tsx
@@ -39,7 +39,7 @@ export const getDefaultLayouts = (): IResizableGridLayoutConfig[] => [
     ...mondoDefaultGridConfig,
   },
   {
-    title: intl.get('screen.dataExploration.tabs.summary.mostFrequentPhenotypes.cardTitle'),
+    title: intl.get('screen.dataExploration.tabs.summary.availableData.mostFrequentPhenotypes'),
     id: MOST_FREQUENT_PHENOTYPES_ID,
     component: <MostFrequentPhenotypesGraphCard />,
     base: {
@@ -81,7 +81,7 @@ export const getDefaultLayouts = (): IResizableGridLayoutConfig[] => [
     },
   },
   {
-    title: intl.get('screen.dataExploration.tabs.summary.mostFrequentDiagnoses.cardTitle'),
+    title: intl.get('screen.dataExploration.tabs.summary.availableData.mostFrequentDiagnoses'),
     id: MOST_FREQUENT_DIAGNOSES_ID,
     component: <MostFrequentDiagnosisGraphCard />,
     base: {


### PR DESCRIPTION
# FIX : Various fixes in summary view HPO and MONDO graph

## Description

[SJIP-805](https://d3b.atlassian.net/browse/SJIP-805)

Acceptance Criterias
1. Le titre des graphs est manquant dans le menu pour personnaliser les colonnes
2. Il semble y avoir des doublons dans les deux graphs
3. Il y a un espace avant le « .png » dans la modal du preview pour le graph HPO
4. La colonne Frequency est vide au download des data des deux graphs

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before

### After
<img width="310" alt="Capture d’écran, le 2024-05-01 à 09 53 11" src="https://github.com/include-dcc/include-portal-ui/assets/133775440/74e5ef
<img width="1464" alt="Capture d’écran, le 2024-05-01 à 09 51 48" src="https://github.com/include-dcc/include-portal-ui/assets/133775440/41f523c4-153b-40ab-adab-a2f9f2471110">

<img width="814" alt="Capture d’écran, le 2024-05-01 à 09 52 04" src="https://github.com/include-dcc/include-portal-ui/assets/133775440/aceff94a-51a4-4e53-b0b6-1dea36394898">
8f-6eec-48ce-9ed7-e351941060d9">

<img width="1000" alt="Capture d’écran, le 2024-05-01 à 09 52 38" src="https://github.com/include-dcc/include-portal-ui/assets/133775440/c91c58cf-18a4-4d56-b642-172baad4031d">


