### PR TITLE
fix: SJIP-803 add include prefix to charts and data download in Study Entity

### DIFF
--- a/src/views/StudyEntity/index.tsx
+++ b/src/views/StudyEntity/index.tsx
@@ -330,7 +330,7 @@ const StudyEntity = () => {
           ]}
           dictionary={{
             download: {
-              fileNameTemplate: '%name-%extra-%type-%date',
+              fileNameTemplate: 'include-%name-%extra-%type-%date',
               fileNameAdditionalInfo: study?.study_code,
             },
             phenotype: {


### PR DESCRIPTION
# FIX : add include prefix to charts and data download in Study Entity

- closes [#SJIP-803](https://d3b.atlassian.net/browse/SJIP-803)
