### PR TITLE
feat(files): SJIP-829 undetermined authorization

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1330,6 +1330,11 @@ const en = {
               disabledButtonTooltip: 'You must select at least 1 item',
             },
           },
+          undeterminedAuthorization: {
+            popoverTitle: 'Undetermined Authorization',
+            popoverContent:
+              'We are unable to determine the authorization status of these files. Depending on your dbGaP authorization status, the files in this dataset may or may not be accessible in your Cavatica project. Read more on <a href="{href}" style="color:#0369a1;text-decoration-line:underline;" target="_blank">applying for data access</a>.',
+          },
         },
       },
     },

--- a/src/views/DataExploration/components/PageContent/tabs/DataFiles/index.module.scss
+++ b/src/views/DataExploration/components/PageContent/tabs/DataFiles/index.module.scss
@@ -1,17 +1,21 @@
-@import "src/style/themes/include/colors";
+@import 'src/style/themes/include/colors';
 
 .dataFilesTabWrapper {
-    display: flex;
+  display: flex;
 
-    :global(.ant-pagination) {
-        margin-bottom: 0;
-    }
+  :global(.ant-pagination) {
+    margin-bottom: 0;
+  }
 
-    .unauthorizedLock {
-        color: $gray-6
-    }
+  .unauthorizedLock {
+    color: $gray-6;
+  }
 
-    .authorizedLock {
-        color: $green-7
-    }
+  .authorizedLock {
+    color: $green-7;
+  }
+
+  .authorizedUndetermined {
+    color: $orange-7;
+  }
 }

--- a/src/views/DataExploration/components/PageContent/tabs/DataFiles/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/DataFiles/index.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import intl from 'react-intl-universal';
 import { useDispatch } from 'react-redux';
 import { Link } from 'react-router-dom';
-import { LockOutlined, SafetyOutlined, UnlockFilled } from '@ant-design/icons';
+import { LockOutlined, SafetyOutlined, UnlockFilled, WarningOutlined } from '@ant-design/icons';
 import ProTable from '@ferlab/ui/core/components/ProTable';
 import { PaginationViewPerQuery } from '@ferlab/ui/core/components/ProTable/Pagination/constants';
 import { ProColumnType } from '@ferlab/ui/core/components/ProTable/types';
@@ -16,7 +16,7 @@ import { ISqonGroupFilter } from '@ferlab/ui/core/data/sqon/types';
 import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/utils';
 import { SortDirection } from '@ferlab/ui/core/graphql/constants';
 import { numberWithCommas } from '@ferlab/ui/core/utils/numberUtils';
-import { Tag, Tooltip } from 'antd';
+import { Popover, Tag, Tooltip } from 'antd';
 import { INDEXES } from 'graphql/constants';
 import { useDataFiles } from 'graphql/files/actions';
 import { FileAccessType, IFileEntity, ITableFileEntity } from 'graphql/files/models';
@@ -70,6 +70,29 @@ const getDefaultColumns = (
     iconTitle: <LockOutlined />,
     align: 'center',
     render: (record: IFileEntity) => {
+      if (
+        record.controlled_access.toLowerCase() === FileAccessType.CONTROLLED.toLowerCase() &&
+        record.access_urls.startsWith('drs://cavatica-ga4gh-api.sbgenomics.com/')
+      ) {
+        return (
+          <Popover
+            placement="top"
+            overlayStyle={{ maxWidth: '420px' }}
+            title={intl.get(
+              'screen.dataExploration.tabs.datafiles.undeterminedAuthorization.popoverTitle',
+            )}
+            content={intl.getHTML(
+              'screen.dataExploration.tabs.datafiles.undeterminedAuthorization.popoverContent',
+              {
+                href: 'https://help.includedcc.org/docs/applying-for-access',
+              },
+            )}
+          >
+            <WarningOutlined className={styles.authorizedUndetermined} />
+          </Popover>
+        );
+      }
+
       const hasAccess = userHasAccessToFile(
         record,
         fenceAcls,


### PR DESCRIPTION
# FEAT : Display Undetermined Authorization

## Description

[SJIP-829](https://d3b.atlassian.net/browse/SJIP-829)

Acceptance Criterias
- Display specific icon in authorization column for files controlled with DRS Cavatica 

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before

### After
<img width="1622" alt="Capture d’écran, le 2024-05-01 à 15 36 28" src="https://github.com/include-dcc/include-portal-ui/assets/133775440/2a1680a5-1aef-4370-b255-b5b9d7aa3eab">


