### PR TITLE
fix: SJIP-838 adjust landing page mondo chart

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -600,7 +600,7 @@ const en = {
       mondoChart: {
         title: 'Most Frequent Co-occurring Conditions (MONDO)',
         bottomAxis: '# of participants',
-        leftAxis: 'MONDO diagnosis term',
+        leftAxis: 'Diagnoses (MONDO)',
       },
       studies: {
         title: 'Studies',

--- a/src/views/Login/TopBanner/MondoChart/index.tsx
+++ b/src/views/Login/TopBanner/MondoChart/index.tsx
@@ -35,7 +35,7 @@ const TopBanner = () => {
           colors={{ scheme: 'paired' }}
           defs={undefined}
           axisBottom={{
-            tickValues: [0, 500, 1000, 1500, 2000, 2500, 3000, 3500, 4000],
+            tickValues: 10,
             legend: intl.get('screen.loginPage.mondoChart.bottomAxis'),
             legendOffset: 35,
             legendPosition: 'middle',


### PR DESCRIPTION
# FIX : adjust landing page mondo chart

- closes [#SJIP-838](https://d3b.atlassian.net/browse/SJIP-838)

Now: 

![image](https://github.com/include-dcc/include-portal-ui/assets/156684667/c768e094-c4c8-489d-85d2-fcc50151c57a)