### PR TITLE
feat(grid): SJIP-828 make most frequent resizable

### DIFF
--- a/src/views/DataExploration/components/PageContent/tabs/Summary/utils/grid.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/utils/grid.tsx
@@ -44,10 +44,11 @@ export const getDefaultLayouts = (): IResizableGridLayoutConfig[] => [
     component: <MostFrequentPhenotypesGraphCard />,
     base: {
       h: 4,
-      isResizable: false,
       w: 8,
       x: 0,
       y: 4,
+      minH: 3,
+      minW: 3,
     },
     lg: {
       h: 4,
@@ -86,10 +87,11 @@ export const getDefaultLayouts = (): IResizableGridLayoutConfig[] => [
     component: <MostFrequentDiagnosisGraphCard />,
     base: {
       h: 4,
-      isResizable: false,
       w: 8,
       x: 8,
       y: 4,
+      minH: 3,
+      minW: 3,
     },
     lg: {
       h: 4,


### PR DESCRIPTION
# FEAT 

- closes #[TICKET_NUMBER](https://d3b.atlassian.net/browse/SJIP-828)

## Description

Goal: Adjust Most Frequent Diagnoses/Phenotypes to be adjustable in size like the other graphs

Add drag icon to allow resizing of the graph with a click and drag action

set minimum sizing to ensure the graph can still be readable when reduced in size

[[JIRA LINK]](https://d3b.atlassian.net/browse/SJIP-828)

## Screenshot

![image](https://github.com/user-attachments/assets/fcbf9c7d-1b13-4c5e-aa9f-1bf7ae7648d2)



