### PR TITLE
fix(exploration): SJIP-937 show both mondo and hpo conditions

### DIFF
--- a/src/graphql/participants/queries.ts
+++ b/src/graphql/participants/queries.ts
@@ -76,6 +76,20 @@ export const SEARCH_PARTICIPANT_QUERY = gql`
                 }
               }
             }
+
+            phenotype {
+              hits {
+                edges {
+                  node {
+                    age_at_event_days
+                    fhir_id
+                    hpo_phenotype_observed
+                    observed
+                    source_text
+                  }
+                }
+              }
+            }
           }
         }
       }

--- a/src/views/DataExploration/components/PageContent/tabs/Participants/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Participants/index.tsx
@@ -23,6 +23,7 @@ import { useParticipants } from 'graphql/participants/actions';
 import {
   FamilyType,
   IParticipantDiagnosis,
+  IParticipantEntity,
   IParticipantObservedPhenotype,
   ITableParticipantEntity,
   Sex,
@@ -180,10 +181,11 @@ const getDefaultColumns = (): ProColumnType[] => [
   {
     key: 'diagnosis.source_text',
     title: intl.get('entities.participant.source_text'),
-    dataIndex: 'diagnosis',
     defaultHidden: true,
-    render: (mondo: ArrangerResultsTree<IParticipantDiagnosis>) => {
-      const sourceTexts = mondo?.hits?.edges.map((m) => m.node.source_text);
+    render: (participant: IParticipantEntity) => {
+      const mondoSourceTexts = participant.diagnosis?.hits?.edges.map((m) => m.node.source_text);
+      const hpoSourceTexts = participant.phenotype?.hits?.edges.map((m) => m.node.source_text);
+      const sourceTexts = [...mondoSourceTexts, ...hpoSourceTexts];
 
       if (!sourceTexts || sourceTexts.length === 0) {
         return TABLE_EMPTY_PLACE_HOLDER;


### PR DESCRIPTION
# FIX

- closes [#TICKET_NUMBER](https://d3b.atlassian.net/browse/SJIP-937)

## Description

Although there seems to only be 1 condition source text in the table for Trisomy 21, we actually have some for two other phenotypes. Verify why not all the condition source text are appearing in the data exploration participant table. 

[[JIRA LINK]](https://d3b.atlassian.net/browse/SJIP-937)

## Screenshot
### Before
![image](https://github.com/user-attachments/assets/a89667e7-1304-4ebe-b356-a8c62d56d668)

### After
![image](https://github.com/user-attachments/assets/cfa37eef-02cd-4cca-b9c5-4489464afdb3)



