### PR TITLE
feat(quickfilter): SJIP-983 add missing quickfilter fields

### DIFF
--- a/src/graphql/quickFilter/queries.ts
+++ b/src/graphql/quickFilter/queries.ts
@@ -23,12 +23,6 @@ export const GET_QUICK_FILTER_EXPLO = gql`
             doc_count
           }
         }
-        observed_phenotype__name {
-          buckets {
-            key
-            doc_count
-          }
-        }
         family_type {
           buckets {
             key
@@ -51,6 +45,32 @@ export const GET_QUICK_FILTER_EXPLO = gql`
           buckets {
             key
             doc_count
+          }
+        }
+        # Observed Phenotype
+        observed_phenotype__name {
+          buckets {
+            key
+            doc_count
+          }
+        }
+        # range
+        observed_phenotype__age_at_event_days {
+          stats {
+            count
+          }
+        }
+        # Outcomes
+        outcomes__vital_status {
+          buckets {
+            key
+            doc_count
+          }
+        }
+        # range
+        outcomes__age_at_event_days__value {
+          stats {
+            count
           }
         }
         # Biospecimen
@@ -97,6 +117,12 @@ export const GET_QUICK_FILTER_EXPLO = gql`
           }
         }
         # Data File
+        files__acl {
+          buckets {
+            key
+            doc_count
+          }
+        }
         files__controlled_access {
           buckets {
             key
@@ -125,6 +151,18 @@ export const GET_QUICK_FILTER_EXPLO = gql`
           buckets {
             key
             doc_count
+          }
+        }
+        # Diagnosis
+        diagnosis__source_text {
+          buckets {
+            key
+            doc_count
+          }
+        }
+        diagnosis__age_at_event_days {
+          stats {
+            count
           }
         }
       }

--- a/src/utils/translation.ts
+++ b/src/utils/translation.ts
@@ -279,10 +279,10 @@ export const getFacetsDictionary = () => ({
   variant_class: 'Variant Type',
   diagnosis: {
     affected_status: 'Clinical Status',
-    age_at_event_days: 'Age at Diagnosis',
+    age_at_event_days: 'Age at Diagnosis (days)',
     mondo_display_term: 'Diagnosis (MONDO)',
     ncit_id_diagnosis: 'Diagnosis (NCIT)',
-    source_text: 'Diagnosis (Source Text)',
+    source_text: 'Condition (Source Text)',
     source_text_tumor_location: 'Tumor Location (Source Text)',
   },
   mondo: {
@@ -291,16 +291,17 @@ export const getFacetsDictionary = () => ({
   outcomes: {
     vital_status: 'Vital Status',
     age_at_event_days: {
-      value: 'Age at Outcome',
+      value: 'Age at Vital Status (days)',
     },
   },
   phenotype: {
-    age_at_event_days: 'Age at Observed Phenotype',
+    age_at_event_days: 'Age at Observed Phenotype (days)',
     hpo_phenotype_observed: 'Observed Phenotype (HPO)',
     hpo_phenotype_not_observed: 'Not Observed Phenotype (HPO)',
   },
   observed_phenotype: {
     name: 'Phenotype (HPO)',
+    age_at_event_days: 'Age at Observed Phenotype (days)',
   },
   clinvar: {
     clin_sig: 'ClinVar',


### PR DESCRIPTION
# FEAT 

- closes #[TICKET_NUMBER](https://d3b.atlassian.net/browse/SJIP-983)

## Description

It seems like there are some fields missing to the Quick Filter. Add the following fields

Mutliselect type:

- Condition (Source Text)
- Vital Status
- Down Syndrome Status
- ACL


Range type:

- Age at Diagnosis (days)
- Age at Vital Status (days)
- Age at Observed Phenotype (days)


[[JIRA LINK]](https://d3b.atlassian.net/browse/SJIP-983)

## Screenshot
Condition (Source Text)
![image](https://github.com/user-attachments/assets/dfc34a39-fd2a-4a60-909c-6d7e2d7b699c)

Vital Status
![image](https://github.com/user-attachments/assets/7aefa9f3-8c62-4c03-8977-84b15a953450)

Down Syndrome Status
![image](https://github.com/user-attachments/assets/39d4af2b-231f-4daa-a3ce-e718c7a8599e)

ACL
![image](https://github.com/user-attachments/assets/d37b849f-e12c-4946-a011-ae67d0f8042c)

Age at Diagnosis (days)
Age at Vital Status (days)
Age at Observed Phenotype (days)
![2024-10-16_13-24](https://github.com/user-attachments/assets/cb10f82f-b37c-4179-9e57-e2eeaafae8e5)

