### PR TITLE
feat: SKFP-905 ignore injury as root node

### DIFF
--- a/src/views/DataExploration/utils/constant.ts
+++ b/src/views/DataExploration/utils/constant.ts
@@ -10,7 +10,7 @@ export const DATA_EXPLORATION_QB_ID = 'data-exploration-repo-key';
 export const DEFAULT_PAGE_INDEX = 1;
 export const DEFAULT_PAGE_SIZE = 20;
 
-export const EXCLUDED_MONDO_ROOTS = ['MONDO:0042489'];
+export const EXCLUDED_MONDO_ROOTS = ['MONDO:0042489', 'MONDO:0021178'];
 
 export const CAVATICA_FILE_BATCH_SIZE = 10000;
 


### PR DESCRIPTION
Add MONDO:0021178 in ignored root because it was under Human Disease before and now it's a "new" root. But it's not the root we want to take
<img width="1677" alt="Capture d’écran, le 2024-10-24 à 12 25 27" src="https://github.com/user-attachments/assets/f727e7f6-201d-49e5-8841-5fe885188844">
