### PR TITLE
feat(study): SJIP-1032 add multi external ids

### DIFF
--- a/src/graphql/studies/queries.ts
+++ b/src/graphql/studies/queries.ts
@@ -35,6 +35,7 @@ export const GET_STUDIES = gql`
             date_collection_end_year
             description
             external_id
+            external_ids
             family_count
             file_count
             guid

--- a/src/views/Studies/index.module.css
+++ b/src/views/Studies/index.module.css
@@ -11,3 +11,11 @@
   content: "";
   display: block;
 }
+
+.dbgapLink {
+  margin-right: 8px;
+}
+
+.dbgapLink:last-child {
+  margin-right: 0;
+}

--- a/src/views/Studies/index.tsx
+++ b/src/views/Studies/index.tsx
@@ -154,17 +154,22 @@ const getColumns = (): ProColumnType<any>[] => [
     key: 'external_id',
     title: intl.get('entities.study.dbgap'),
     sorter: { multiple: 1 },
-    dataIndex: 'external_id',
-    render: (external_id: string) =>
-      external_id ? (
+    dataIndex: 'external_ids',
+    render: (external_ids: string[]) => {
+      if (external_ids.length === 0) {
+        return TABLE_EMPTY_PLACE_HOLDER;
+      }
+
+      return external_ids.map((id) => (
         <ExternalLink
-          href={`https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=${external_id}`}
+          key={id}
+          className={styles.dbgapLink}
+          href={`https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=${id}`}
         >
-          {external_id}
+          {id}
         </ExternalLink>
-      ) : (
-        TABLE_EMPTY_PLACE_HOLDER
-      ),
+      ));
+    },
   },
   {
     key: 'participant_count',


### PR DESCRIPTION
# FEAT 

- closes #[TICKET_NUMBER](https://d3b.atlassian.net/browse/SJIP-1032)

## Description
Studies can have more than one dbGaP code but in the studies table we only see one. If you go to the study entity page, we see more than one. Therefore, we will update the studies table to be able to have more than one value. If more than 1 value is present, display the “See more” option to display the other values. 
[[JIRA LINK]](https://d3b.atlassian.net/browse/SJIP-1032)

## Screenshot
### Before
![image](https://github.com/user-attachments/assets/dbbb40d6-2ad7-48f3-b7e6-296b64d92f60)

### After
![image](https://github.com/user-attachments/assets/0a3bce2f-3da4-462e-9726-2d21067fe153)


