### PR TITLE
fix(facet): SJIP-1069 search by empty options on close

### DIFF
--- a/src/components/uiKit/search/GlobalSearch/Search/index.tsx
+++ b/src/components/uiKit/search/GlobalSearch/Search/index.tsx
@@ -1,13 +1,14 @@
 import { useState } from 'react';
+import { BooleanOperators } from '@ferlab/ui/core/data/sqon/operators';
+import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/utils';
+import { DocumentNode } from 'graphql';
+import { INDEXES } from 'graphql/constants';
+
 import SearchAutocomplete, {
   ISearchAutocomplete,
   OptionsType,
 } from 'components/uiKit/search/GlobalSearch/Search/SearchAutocomplete';
-import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/utils';
-import { INDEXES } from 'graphql/constants';
-import { BooleanOperators } from '@ferlab/ui/core/data/sqon/operators';
 import { ArrangerApi } from 'services/api/arranger';
-import { DocumentNode } from 'graphql';
 
 interface IGlobalSearch<T> {
   query: DocumentNode;
@@ -66,6 +67,7 @@ const Search = <T,>({
       onSelect={onSelect}
       options={options}
       selectedItems={selectedItems}
+      onClose={() => setOptions([])}
       {...props}
     />
   );


### PR DESCRIPTION
# FIX : Reset auto complete options when we lost focus

## Description

[SJIP-1069](https://d3b.atlassian.net/browse/SJIP-1069)

Acceptance Criterias
- when the search text is empty we don't have suggestions

## Screenshot
### Before
https://github.com/user-attachments/assets/1b21f83a-1cdd-45ef-a694-d5f5eea7ad41

### After
https://github.com/user-attachments/assets/53aeffac-3d18-467b-9dba-db4e3ad8990d
