### PR TITLE
fix(community): SJIP-1058 reset page on select usage filter

### DIFF
--- a/src/views/Community/components/Filters/Box/index.tsx
+++ b/src/views/Community/components/Filters/Box/index.tsx
@@ -104,10 +104,14 @@ const FiltersBox = ({
               placeholder={intl.get('screen.community.search.selectPlaceholder')}
               maxTagCount={1}
               value={usageFilter}
-              onSelect={(value: string) => setUsageFilter([...usageFilter, value])}
-              onDeselect={(value: string) =>
-                setUsageFilter((prev) => prev.filter((val) => val !== value))
-              }
+              onSelect={(value: string) => {
+                activeFilter.pageIndex = 0;
+                setUsageFilter([...usageFilter, value]);
+              }}
+              onDeselect={(value: string) => {
+                activeFilter.pageIndex = 0;
+                setUsageFilter((prev) => prev.filter((val) => val !== value));
+              }}
               options={[
                 ...usageOptions.map((option) => ({
                   label: option.label,


### PR DESCRIPTION
# FIX : Reset page index on select filter

## Description

[SJIP-1058](https://d3b.atlassian.net/browse/SJIP-1058)

Acceptance Criterias
- On another page than the first if I apply a filter I want to see the results

## Screenshot
### Before
https://github.com/user-attachments/assets/47241c80-3715-4f52-9855-a920d3a728ac

### After
https://github.com/user-attachments/assets/218691b9-0c27-4ade-bef3-1e38304122ab