### PR TITLE
feat(transcriptomic): SJIP-1078 add saved set to biospecimen

### DIFF
--- a/src/views/Analytics/Transcriptomic/SwarmPlot/index.tsx
+++ b/src/views/Analytics/Transcriptomic/SwarmPlot/index.tsx
@@ -89,7 +89,6 @@ const SwarmPlotly = ({
   sampleGeneExp,
   loading,
 }: TTranscriptomicsSwarmPlot) => {
-  const isFilterEnabled = getIsFilterEnabled(fpkm, ages, sex, sampleGeneExp);
   const memoizedData = useMemo<SwarmPlotData[]>(() => {
     const data = sampleGeneExp?.data ?? [];
     const isValidSampleFunc = getIsValidSamplesFunc(fpkm, ages, sex);
@@ -182,6 +181,10 @@ const SwarmPlotly = ({
     });
 
   useEffect(() => {
+    if (!getIsFilterEnabled(fpkm, ages, sex, sampleGeneExp)) {
+      handleFilteredSamples([]);
+      return;
+    }
     const filteredSamples: TTranscriptomicsSwarmPlotData[] = [];
     memoizedData.forEach((group) => {
       group.selectedpoints.forEach((index) => {
@@ -190,7 +193,8 @@ const SwarmPlotly = ({
     });
 
     handleFilteredSamples(filteredSamples);
-  }, [handleFilteredSamples, isFilterEnabled, memoizedData]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fpkm, ages, sex]);
 
   if (loading) {
     return <ChartSkeleton />;


### PR DESCRIPTION
# FEAT 

- closes #[TICKET_NUMBER](https://d3b.atlassian.net/browse/SJIP-1078)

## Description
Add Save biospecimen set button as it is done in the Data Exploration page
- opens the dropdown to create, add, remove biospecimens to a set
- If ≥ 10,000 in the selection, process the first 10k as it currently is already done in the Data Exploration page
- If no facets are applied, the saved set would represent all the samples used in the plot for that gene
- If facet is applied, the saved set would represent the resulting samples highlighted

[[JIRA LINK]](https://d3b.atlassian.net/browse/SJIP-1078)

## Screenshot
![image](https://github.com/user-attachments/assets/8f1111dc-f1ed-4ac5-92e5-defc09e41863)

![image](https://github.com/user-attachments/assets/ec761b50-fc6c-4f9a-9a33-e265fa9e394c)
![image](https://github.com/user-attachments/assets/39bb4ca0-1fc7-4ae0-a391-86948142cbec)
![image](https://github.com/user-attachments/assets/989d8871-91ad-45d8-bfef-640f7c281d6d)
![image](https://github.com/user-attachments/assets/96b3fdf7-1c67-4f56-b9cf-ba63e00a528c)
![image](https://github.com/user-attachments/assets/11d5f16b-d3ce-4348-821c-5a1c7ccfb0df)
