### PR TITLE
fix(transcriptomics): SJIP-1051 fix typo

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1466,9 +1466,9 @@ const en = {
         },
         heatmap: {
           title: 'Fold Change with T21',
-          fold_change: 'Fold Change',
+          fold_change: 'Fold change',
           qvalue: 'q-value',
-          gene_symbol: 'Gene',
+          gene_symbol: 'Gene symbol',
         },
         filter: {
           genes: {

--- a/src/views/Analytics/Transcriptomic/Heatmaps/index.tsx
+++ b/src/views/Analytics/Transcriptomic/Heatmaps/index.tsx
@@ -47,8 +47,8 @@ const Heatmaps = ({ selectedGenes }: TTranscriptomicHeatmaps) => {
           },
           hovertemplate: `${intl.get(
             'screen.analytics.transcriptomic.heatmap.gene_symbol',
-          )} %{y}<br>${intl.get('screen.analytics.transcriptomic.heatmap.fold_change')} %{z}
-          <br>${intl.get('screen.analytics.transcriptomic.heatmap.qvalue')} %{customdata}`,
+          )} : %{y}<br>${intl.get('screen.analytics.transcriptomic.heatmap.fold_change')} : %{z}
+          <br>${intl.get('screen.analytics.transcriptomic.heatmap.qvalue')} : %{customdata}`,
           colorbar: {
             title: 'log<sub>2</sub>(Fold Change)', // using intl.getHTML will make plotty crash
           },


### PR DESCRIPTION
# fix(transcriptomics): fix typo

- Closes SJIP-1051

## Description
Le tooltip devrait être:
```
Gene symbol: POFUT2
Fold change: 1.593246
q-value: 1.89e-19
```


## Links
- [JIRA](https://d3b.atlassian.net/browse/SJIP-1051)


## Extra Validation
- [ ] Reviewer video or screenshots attached
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot or Video
### Before
![image](https://github.com/user-attachments/assets/14d4697f-4867-4f4d-9fd5-bc4ae7408549)

### After
![image](https://github.com/user-attachments/assets/9876cf18-b2eb-4cc5-a145-9585d132dbb1)


## QA
### Steps to validate
1. Go to transcriptomics
2. Select multiples genes
3. Hover on heatmap
