### PR TITLE
feat(sets): SJIP-1089 display notifications error with legacy sets

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -405,6 +405,8 @@ const en = {
           cancelText: 'Cancel',
         },
         errors: {
+          updateMsg:
+            'Following a recent software update, please rename your set name using the following valid characters: A-Z a-z 0-9 ()[]-_:|.,',
           permittedCharacters: 'Permitted characters: A-Z a-z 0-9 ()[]-_:|.,',
         },
       },

--- a/src/views/Dashboard/components/DashboardCards/SavedSets/CreateEditModal/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/SavedSets/CreateEditModal/index.tsx
@@ -11,6 +11,7 @@ import { SetActionType } from 'views/DataExploration/components/SetsManagementDr
 import filtersToName from 'common/sqonToName';
 import { trackSetActions } from 'services/analytics';
 import { IUserSetOutput, SetType } from 'services/api/savedSet/models';
+import { globalActions } from 'store/global';
 import { PROJECT_ID, useSavedSet } from 'store/savedSet';
 import { createSavedSet, updateSavedSet } from 'store/savedSet/thunks';
 
@@ -18,6 +19,8 @@ import styles from './index.module.css';
 
 const FORM_NAME = 'save-set';
 const SET_NAME_KEY = 'nameSet';
+
+export const PERMITTED_CHARACTERS_REGEX = new RegExp(/^[a-zA-Z0-9 ()[\]\-_:|.,]+$/i);
 
 type OwnProps = {
   title: string;
@@ -55,6 +58,19 @@ const CreateEditModal = ({
   useEffect(() => {
     if (visible !== isVisible) {
       setIsVisible(visible);
+    }
+
+    if (visible) {
+      if (!PERMITTED_CHARACTERS_REGEX.exec(getSetDefaultName(form.getFieldValue(SET_NAME_KEY)))) {
+        dispatch(
+          globalActions.displayNotification({
+            type: 'error',
+            message: '',
+            description: intl.get('components.savedSets.modal.errors.updateMsg'),
+            duration: 5,
+          }),
+        );
+      }
     }
     // eslint-disable-next-line
   }, [visible]);
@@ -180,7 +196,7 @@ const CreateEditModal = ({
             },
             {
               type: 'string',
-              pattern: new RegExp(/^[a-zA-Z0-9 ()[\]\-_:|.,]+$/i),
+              pattern: PERMITTED_CHARACTERS_REGEX,
               message: intl.get('components.savedSets.modal.errors.permittedCharacters'),
             },
             {

--- a/src/views/DataExploration/components/SetsManagementDropdown/AddRemoveSaveSetModal.tsx
+++ b/src/views/DataExploration/components/SetsManagementDropdown/AddRemoveSaveSetModal.tsx
@@ -1,12 +1,14 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import intl from 'react-intl-universal';
 import { useDispatch } from 'react-redux';
 import { ISqonGroupFilter } from '@ferlab/ui/core/data/sqon/types';
 import { Form, Modal } from 'antd';
 import { Store } from 'antd/lib/form/interface';
+import { PERMITTED_CHARACTERS_REGEX } from 'views/Dashboard/components/DashboardCards/SavedSets/CreateEditModal';
 
 import { trackSetActions } from 'services/analytics';
 import { IUserSetOutput, SetType } from 'services/api/savedSet/models';
+import { globalActions } from 'store/global';
 import { PROJECT_ID, useSavedSet } from 'store/savedSet';
 import { updateSavedSet } from 'store/savedSet/thunks';
 
@@ -101,6 +103,25 @@ const AddRemoveSaveSetModal = ({
     setIsVisible(false);
     hideModalCb();
   };
+
+  useEffect(() => {
+    if (isVisible) {
+      const invalidSets = userSets
+        .filter((s) => s.setType === type)
+        .filter((s) => !PERMITTED_CHARACTERS_REGEX.test(s.tag));
+
+      if (invalidSets.length > 0) {
+        dispatch(
+          globalActions.displayNotification({
+            type: 'error',
+            message: '',
+            description: intl.get('components.savedSets.modal.errors.updateMsg'),
+            duration: 5,
+          }),
+        );
+      }
+    }
+  }, [isVisible]);
 
   return (
     <Modal


### PR DESCRIPTION
# feat(sets): display notifications error with legacy sets

- Closes SJIP-1089

## Description
Pour les sets legacy qui contiennent des caractères interdits (e.g. 10/11/24 - Biospecimen sets) déclencheront une notification d'erreur pour avertir l'utilisateur de renommer leur set.

## Links
- [JIRA](https://d3b.atlassian.net/browse/SJIP-1089)

## Screenshot or Video
![image](https://github.com/user-attachments/assets/2818716a-16e9-4e91-8632-1de46e71a691)

