### PR TITLE
feat(cavatica): SJIP-1095 add warning modal when more than 10 000 are…

### DIFF
--- a/src/components/Cavatica/AnalyzeButton/index.tsx
+++ b/src/components/Cavatica/AnalyzeButton/index.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect } from 'react';
 import intl from 'react-intl-universal';
 import { useDispatch } from 'react-redux';
+import { ExclamationCircleOutlined } from '@ant-design/icons';
 import CavaticaAnalyse from '@ferlab/ui/core/components/Widgets/Cavatica/CavaticaAnalyse';
 import {
   CAVATICA_ANALYSE_STATUS,
@@ -10,6 +11,7 @@ import {
 import { BooleanOperators } from '@ferlab/ui/core/data/sqon/operators';
 import { ISqonGroupFilter } from '@ferlab/ui/core/data/sqon/types';
 import { ISort } from '@ferlab/ui/core/graphql/types';
+import { Modal } from 'antd';
 import { CAVATICA_FILE_BATCH_SIZE } from 'views/DataExploration/utils/constant';
 
 import { trackCavaticaAction } from 'services/analytics';
@@ -33,6 +35,7 @@ interface OwnProps {
   sqon?: ISqonGroupFilter;
   sort?: ISort[];
   type?: 'default' | 'primary';
+  maxFileReached?: boolean;
   disabled?: boolean;
   index: string;
 }
@@ -41,6 +44,7 @@ const CavaticaAnalyzeButton: React.FC<OwnProps> = ({
   fileIds,
   sqon,
   sort = [],
+  maxFileReached,
   type = 'default',
   disabled = false,
   index,
@@ -69,18 +73,41 @@ const CavaticaAnalyzeButton: React.FC<OwnProps> = ({
 
   useEffect(() => {
     if (
+      !maxFileReached &&
       cavatica.authentification.status === PASSPORT_AUTHENTIFICATION_STATUS.connected &&
       cavatica.bulkImportData.status === CAVATICA_ANALYSE_STATUS.pending_analyse
     ) {
       onBeginAnalyse();
     }
-  }, [cavatica.authentification.status, cavatica.bulkImportData.status, onBeginAnalyse]);
+  }, [
+    cavatica.authentification.status,
+    cavatica.bulkImportData.status,
+    onBeginAnalyse,
+    maxFileReached,
+  ]);
 
   return (
     <CavaticaAnalyse
       disabled={disabled}
       type={type}
-      handleBeginAnalyse={onBeginAnalyse}
+      handleBeginAnalyse={() => {
+        if (maxFileReached) {
+          Modal.confirm({
+            title: intl.get('screen.dataExploration.tabs.datafiles.cavatica.maxFileReached.title'),
+            icon: <ExclamationCircleOutlined />,
+            okText: intl.get(
+              'screen.dataExploration.tabs.datafiles.cavatica.maxFileReached.okText',
+            ),
+            closable: true,
+            cancelButtonProps: { style: { display: 'none' } },
+            content: intl.get(
+              'screen.dataExploration.tabs.datafiles.cavatica.maxFileReached.description',
+            ),
+          });
+          return;
+        }
+        onBeginAnalyse();
+      }}
       handleFilesAndFolders={CavaticaApi.listFilesAndFolders}
       cavatica={cavatica}
       loading={cavatica.bulkImportData.loading}

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1353,6 +1353,12 @@ const en = {
           title: 'Data Files ({count})',
           cavatica: {
             analyseInCavatica: 'Analyze in Cavatica',
+            maxFileReached: {
+              title: 'Maximum number exceeded',
+              description:
+                'A maximum of 10,000 items can be copied at a time. Please narrow your selection and try again.',
+              okText: 'Close',
+            },
             bulkImportLimit: {
               title: 'Maximum file count exceeded',
               description:

--- a/src/views/DataExploration/components/PageContent/tabs/DataFiles/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/DataFiles/index.tsx
@@ -447,6 +447,7 @@ const DataFilesTab = ({ sqon }: OwnProps) => {
               fileIds={selectedAllResults ? [] : selectedKeys}
               sqon={sqon}
               sort={queryConfig.sort ?? DEFAULT_FILE_QUERY_SORT}
+              maxFileReached={hasTooManyFiles}
               key="file-cavatica-upload"
               index={INDEXES.FILE}
             />,


### PR DESCRIPTION
# feat(cavatica): add warning modal when more than 10 000 are selected

- Closes SJIP-1095

## Description
Currently, users who attempt to copy >10,000 files to cavatica have it capped at 10,000. Therefore we will add a modal prior to clicking the analyze in cavatica modal if their selection is >10,000 items in the Data Exploration – Data files tab.

Modal Details:

Title: Maximum number exceeded

Text: A maximum of 10,000 items can be copied at a time. Please narrow your selection and try again.

Button Label: Close
## Links
- [JIRA](https://d3b.atlassian.net/browse/SJIP-1095)

## Screenshot or Video
![2024-11-26_15-04_1](https://github.com/user-attachments/assets/6887b98e-4f6d-404c-924e-7b4610db1e7e)
![2024-11-26_15-04](https://github.com/user-attachments/assets/ebd65201-4102-482b-b711-922df23d3d53)

