### PR TITLE
fix(quickfilter): SJIP-1093 map icon to facet

### DIFF
--- a/src/views/DataExploration/index.tsx
+++ b/src/views/DataExploration/index.tsx
@@ -47,6 +47,7 @@ import {
   TAB_IDS,
 } from 'views/DataExploration/utils/constant';
 import {
+  getFieldCategoryIcon,
   getFieldWithoutPrefix,
   getIndexFromQFValueFacet,
   getSelectedOptionsByQuery,
@@ -375,7 +376,7 @@ const DataExploration = () => {
       headerTooltip: false,
       dictionary: getFacetsDictionary(),
       noDataInputOption: false,
-      categoryIcon: <UserOutlined className={styles.categoryIcon} />,
+      categoryIcon: getFieldCategoryIcon(option.key, { className: styles.categoryIcon }),
     });
 
     const filters =

--- a/src/views/DataExploration/utils/quickFilter.tsx
+++ b/src/views/DataExploration/utils/quickFilter.tsx
@@ -1,3 +1,5 @@
+import { ExperimentOutlined, FileTextOutlined, UserOutlined } from '@ant-design/icons';
+import { AntdIconProps } from '@ant-design/icons/lib/components/AntdIcon';
 import { VisualType } from '@ferlab/ui/core/components/filters/types';
 import { CheckboxQFOption } from '@ferlab/ui/core/components/SidebarMenu/QuickFilter';
 import {
@@ -7,6 +9,17 @@ import {
 } from '@ferlab/ui/core/data/sqon/types';
 import { INDEXES } from 'graphql/constants';
 import { cloneDeep } from 'lodash';
+
+export const getFieldCategoryIcon = (facetKey: string, props: AntdIconProps): React.ReactNode => {
+  if (facetKey.startsWith('files__biospecimens__')) {
+    return <ExperimentOutlined {...props} />;
+  }
+  if (facetKey.startsWith('files__')) {
+    return <FileTextOutlined {...props} />;
+  }
+
+  return <UserOutlined {...props} />;
+};
 
 export const getIndexFromQFValueFacet = (facetKey: string): INDEXES => {
   if (facetKey.startsWith('files__biospecimens__')) return INDEXES.BIOSPECIMEN;


### PR DESCRIPTION
# fix(quickfilter): map icon to facet

- Closes SJIP-1093

## Description
Il semble que le compte affiché n’est pas celui des participants. L’icône dans le Quick Filter devrait donc refléter la bonne catégorie de données.

## Links
- [JIRA](https://d3b.atlassian.net/browse/SJIP-1093)


## Screenshot or Video
### Before
![image](https://github.com/user-attachments/assets/b630d1fc-2ed9-450d-a4a5-939bc649bf1d)


### After
![image](https://github.com/user-attachments/assets/d964eaef-5d7b-436b-ae21-4d8ba4f1693f)
![image](https://github.com/user-attachments/assets/4cc128ff-941f-48d4-bf8d-883342731bd8)


