### PR TITLE
fix(summary): SJIP-1114 only filter data in grid

### DIFF
--- a/src/views/DataExploration/components/PageContent/tabs/Summary/DataCategoryGraphCard/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/DataCategoryGraphCard/index.tsx
@@ -41,7 +41,9 @@ const DataCategoryGraphCard = () => {
   const dataCategoryResults = aggregationToChartData(
     result?.data?.participant?.aggregations?.files__data_category.buckets,
     result?.data?.participant?.hits?.total,
-  );
+  )
+    .sort((a, b) => a.value - b.value)
+    .slice(0, 10);
 
   return (
     <ResizableGridCard

--- a/src/views/DataExploration/components/PageContent/tabs/Summary/DataTypeGraphCard/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/DataTypeGraphCard/index.tsx
@@ -41,7 +41,9 @@ const DataTypeGraphCard = () => {
   const dataTypeResults = aggregationToChartData(
     result?.data?.participant?.aggregations?.files__data_type.buckets,
     result?.data?.participant?.hits?.total,
-  );
+  )
+    .sort((a, b) => a.value - b.value)
+    .slice(0, 10);
 
   return (
     <ResizableGridCard

--- a/src/views/DataExploration/components/PageContent/tabs/Summary/SampleType/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/SampleType/index.tsx
@@ -42,7 +42,9 @@ const SampleTypeGraphCard = () => {
   const sampleTypeResults = aggregationToChartData(
     result?.data?.participant?.aggregations?.files__biospecimens__sample_type.buckets,
     result?.data?.participant?.hits?.total,
-  );
+  )
+    .sort((a, b) => a.value - b.value)
+    .slice(0, 10);
 
   return (
     <ResizableGridCard


### PR DESCRIPTION
# fix(summary): only filter data in grid

- Closes SJIP-1114

## Description
 Across all horizontal bar charts set the max bars to 10. This is meant to improve visibility of the charts as it can become difficult to read the entries if there are too many bars. Generally, users will use these graphs to get a high level overview and not specifically look for those smaller bars. 

## Links
- [JIRA](https://d3b.atlassian.net/browse/SJIP-1114)

## Screenshot or Video
![image](https://github.com/user-attachments/assets/b240d540-9145-406f-a683-b51ab9e112b9)

