### PR TITLE
fix(transcriptomics): SJIP-1124 disable download data when loading genes

### DIFF
--- a/src/views/Analytics/Transcriptomic/Footer/index.tsx
+++ b/src/views/Analytics/Transcriptomic/Footer/index.tsx
@@ -29,6 +29,7 @@ import { STATIC_ROUTES } from 'utils/routes';
 import styles from './index.module.css';
 
 type TTranscriptomicFooter = {
+  loading: boolean;
   selectedGenes: TTranscriptomicsDatum[];
   sampleGeneExpData?: TTranscriptomicsSwarmPlotData[];
   selectedSamples: TTranscriptomicsSwarmPlotData[];
@@ -36,6 +37,7 @@ type TTranscriptomicFooter = {
 };
 
 const TranscriptomicFooter = ({
+  loading,
   sampleGeneExpData,
   selectedGenes: selectedGeneIds,
   selectedSamples,
@@ -105,6 +107,7 @@ const TranscriptomicFooter = ({
         <DownloadTranscriptomics
           filename="htp-dge-data"
           handleUrl={TranscriptomicsApi.fetchExportUrlDiffGeneExp}
+          disabled={loading}
         />
       </div>
       <div className={styles.sample}>
@@ -112,6 +115,7 @@ const TranscriptomicFooter = ({
           filename="htp-rnaseq-data"
           displayNotification
           handleUrl={TranscriptomicsApi.fetchExportUrlSampleGeneExp}
+          disabled={loading}
         />
         <SetsManagementDropdown
           idField={BIOSPECIMENS_SAVED_SETS_FIELD}

--- a/src/views/Analytics/Transcriptomic/index.tsx
+++ b/src/views/Analytics/Transcriptomic/index.tsx
@@ -140,6 +140,7 @@ export const Transcriptomic = () => {
             contentClassName={styles.gridCardContent}
             footer={
               <TranscriptomicFooter
+                loading={diffGeneExp.loading}
                 selectedGenes={selectedGenes}
                 sampleGeneExpData={sampleGeneExp.data?.data}
                 selectedSamples={selectedSamples}


### PR DESCRIPTION
# fix(transcriptomics): disable download data when loading genes

- Closes SJIP-1124

## Description
Griser le bouton si le graphique Gene expression n’est pas affiché

## Screenshot or Video
https://github.com/user-attachments/assets/ded9d321-72d0-4aa5-891d-2bfc1aabe37a

