### PR TITLE
fix(summary): SJIP-915 center no data in demographic graphs

### DIFF
--- a/src/views/DataExploration/components/PageContent/tabs/Summary/DemographicGraphCard/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/DemographicGraphCard/index.tsx
@@ -152,7 +152,7 @@ const DemographicsGraphCard = () => {
         <Row gutter={[12, 24]} className={styles.graphRowWrapper}>
           <Col sm={12} md={12} lg={8}>
             {isEmpty(sexData) ? (
-              <Empty imageType="grid" />
+              <Empty imageType="grid" noPadding />
             ) : (
               <PieChart
                 title={intl.get('screen.dataExploration.tabs.summary.demographic.sexTitle')}
@@ -165,7 +165,7 @@ const DemographicsGraphCard = () => {
           </Col>
           <Col sm={12} md={12} lg={8}>
             {isEmpty(ethnicityData) ? (
-              <Empty imageType="grid" />
+              <Empty imageType="grid" noPadding />
             ) : (
               <PieChart
                 title={intl.get('screen.dataExploration.tabs.summary.demographic.ethnicityTitle')}
@@ -178,7 +178,7 @@ const DemographicsGraphCard = () => {
           </Col>
           <Col sm={12} md={12} lg={8}>
             {isEmpty(raceData) ? (
-              <Empty imageType="grid" />
+              <Empty imageType="grid" noPadding />
             ) : (
               <PieChart
                 title={intl.get('screen.dataExploration.tabs.summary.demographic.raceTitle')}


### PR DESCRIPTION
# fix(summary): center no data in demographic graphs

[SJIP-915](https://d3b.atlassian.net/browse/SJIP-915)

## Description
Center no data logo for Demographic graphs

## Acceptance Criterias
- Center no data logo 

## Screenshot or Video
### Before
<img width="1718" alt="Capture d’écran, le 2024-12-09 à 12 02 15" src="https://github.com/user-attachments/assets/ce0fabc2-e332-4131-8f0d-788e09542f6e">

### After
<img width="1718" alt="Capture d’écran, le 2024-12-09 à 11 36 47" src="https://github.com/user-attachments/assets/0aa79c0b-8bf2-4b22-bffb-8e282b000991">

