### PR TITLE
fix(transcriptomics): SJIP-1124 add tooltip

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1531,6 +1531,8 @@ const en = {
           download: 'Download data',
           notification:
             'Please wait while we generate your report. This process may take a few moments.',
+          diffGeneTooltip: 'Download differential gene expression across all genes',
+          sampleTooltip: 'Download gene expression data across all genes',
         },
         about: {
           title: 'About this dataset',

--- a/src/views/Analytics/Transcriptomic/Footer/DownloadTranscriptomics/index.module.css
+++ b/src/views/Analytics/Transcriptomic/Footer/DownloadTranscriptomics/index.module.css
@@ -1,0 +1,3 @@
+.overlayTooltip {
+  max-width: 400px;
+}

--- a/src/views/Analytics/Transcriptomic/Footer/DownloadTranscriptomics/index.tsx
+++ b/src/views/Analytics/Transcriptomic/Footer/DownloadTranscriptomics/index.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import intl from 'react-intl-universal';
 import { useDispatch } from 'react-redux';
 import { DownloadOutlined } from '@ant-design/icons';
-import { Button } from 'antd';
+import { Button, Tooltip } from 'antd';
 import { BaseButtonProps } from 'antd/lib/button/button';
 import axios from 'axios';
 import saveAs from 'file-saver';
@@ -11,58 +11,68 @@ import { getBlobFromResponse } from 'common/downloader';
 import { ApiResponse } from 'services/api';
 import { globalActions } from 'store/global';
 
+import styles from './index.module.css';
+
 type TDownloadTranscriptomics = BaseButtonProps & {
   handleUrl: () => Promise<ApiResponse<{ url: string }>>;
   filename: string;
   displayNotification?: boolean;
+  tooltip: string;
 };
 
 const DownloadTranscriptomics = ({
   handleUrl,
   filename,
   displayNotification = false,
+  tooltip,
   ...props
 }: TDownloadTranscriptomics) => {
   const [loading, setLoading] = useState<boolean>(false);
   const dispatch = useDispatch();
   return (
-    <Button
-      loading={loading}
-      icon={<DownloadOutlined />}
-      onClick={async () => {
-        setLoading(true);
-        const response = await handleUrl();
-
-        if (displayNotification) {
-          dispatch(
-            globalActions.displayMessage({
-              type: 'loading',
-              key: filename,
-              content: intl.get('screen.analytics.transcriptomic.footer.notification'),
-              duration: 0,
-            }),
-          );
-        }
-
-        await axios({
-          url: response.data?.url ?? '',
-          method: 'GET',
-          responseType: 'blob',
-          headers: {
-            'Content-Type': 'application/json',
-            Accept: '*/*',
-          },
-        }).then((response) => {
-          const blob = getBlobFromResponse(response, 'blob');
-          saveAs(blob, filename);
-          setLoading(false);
-          dispatch(globalActions.destroyMessages([filename]));
-        });
-      }}
-      {...props}
+    <Tooltip
+      title={tooltip}
+      overlayClassName={styles.overlayTooltip}
+      overlayInnerStyle={{ textAlign: 'center' }}
     >
-      {intl.get('screen.analytics.transcriptomic.footer.download')}
-    </Button>
+      <Button
+        loading={loading}
+        icon={<DownloadOutlined />}
+        onClick={async () => {
+          setLoading(true);
+          const response = await handleUrl();
+
+          if (displayNotification) {
+            dispatch(
+              globalActions.displayMessage({
+                type: 'loading',
+                key: filename,
+                content: intl.get('screen.analytics.transcriptomic.footer.notification'),
+                duration: 0,
+              }),
+            );
+          }
+
+          await axios({
+            url: response.data?.url ?? '',
+            method: 'GET',
+            responseType: 'blob',
+            headers: {
+              'Content-Type': 'application/json',
+              Accept: '*/*',
+            },
+          }).then((response) => {
+            const blob = getBlobFromResponse(response, 'blob');
+            saveAs(blob, filename);
+            setLoading(false);
+            dispatch(globalActions.destroyMessages([filename]));
+          });
+        }}
+        {...props}
+      >
+        {intl.get('screen.analytics.transcriptomic.footer.download')}
+      </Button>
+    </Tooltip>
   );
 };
 

--- a/src/views/Analytics/Transcriptomic/Footer/index.tsx
+++ b/src/views/Analytics/Transcriptomic/Footer/index.tsx
@@ -105,6 +105,7 @@ const TranscriptomicFooter = ({
     <div className={styles.footer}>
       <div className={styles.gene}>
         <DownloadTranscriptomics
+          tooltip={intl.get('screen.analytics.transcriptomic.footer.diffGeneTooltip')}
           filename="htp-dge-data"
           handleUrl={TranscriptomicsApi.fetchExportUrlDiffGeneExp}
           disabled={loading}
@@ -112,6 +113,7 @@ const TranscriptomicFooter = ({
       </div>
       <div className={styles.sample}>
         <DownloadTranscriptomics
+          tooltip={intl.get('screen.analytics.transcriptomic.footer.sampleTooltip')}
           filename="htp-rnaseq-data"
           displayNotification
           handleUrl={TranscriptomicsApi.fetchExportUrlSampleGeneExp}


### PR DESCRIPTION
# fix(transcriptomics): add tooltip

- Closes SJIP-1124

## Description
We can perhaps do Download gene expression data across all genes for the button under the boxplot.

If we think it would be to also have a tooltip for the download button under the volcano plot we can simply do Download differential gene expression across all genes

## Links
- [JIRA](https://d3b.atlassian.net/browse/SJIP-1124)

## Screenshot or Video
![image](https://github.com/user-attachments/assets/7a7804e8-5851-4947-a36f-e4f298a2b174)
![image](https://github.com/user-attachments/assets/b55e621d-a640-4f0e-b781-e67c7f4f4bcc)
