### PR TITLE
feat(transcriptomic): SJIP-1131 add redirection to boxplot when clicking on heatmap element

### DIFF
--- a/src/store/analytics/slice.ts
+++ b/src/store/analytics/slice.ts
@@ -30,7 +30,12 @@ export const AnalyticsState: initialState = {
 const analyticsSlice = createSlice({
   name: 'analytics',
   initialState: AnalyticsState,
-  reducers: {},
+  reducers: {
+    resetTranscriptomicsSampleGeneExp: (state) => {
+      state.transcriptomics.sampleGeneExp.loading = true;
+      state.transcriptomics.sampleGeneExp.error = false;
+    },
+  },
   extraReducers: (builder) => {
     // Facets
     builder.addCase(fetchTranscriptomicsFacets.pending, (state) => {

--- a/src/views/Analytics/Transcriptomic/Heatmaps/index.tsx
+++ b/src/views/Analytics/Transcriptomic/Heatmaps/index.tsx
@@ -1,8 +1,10 @@
 import intl from 'react-intl-universal';
 import Plot from 'react-plotly.js';
+import { useDispatch } from 'react-redux';
 import { formatPadj } from 'views/Analytics/Transcriptomic/utils';
 
 import { TTranscriptomicsDatum } from 'services/api/transcriptomics/models';
+import { analyticsActions } from 'store/analytics/slice';
 
 import styles from './index.module.css';
 
@@ -10,6 +12,7 @@ const MAX_LABEL_THRESHOLD = 40;
 
 export type TTranscriptomicHeatmaps = {
   selectedGenes: TTranscriptomicsDatum[];
+  handleGenesSelection: (gene: TTranscriptomicsDatum[]) => void;
 };
 
 /**
@@ -19,7 +22,8 @@ export type TTranscriptomicHeatmaps = {
  * y = label
  * z = data
  */
-const Heatmaps = ({ selectedGenes }: TTranscriptomicHeatmaps) => {
+const Heatmaps = ({ selectedGenes, handleGenesSelection }: TTranscriptomicHeatmaps) => {
+  const dispatch = useDispatch();
   const padj: any = [];
   const label: string[] = [];
   const data: any = [];
@@ -69,6 +73,15 @@ const Heatmaps = ({ selectedGenes }: TTranscriptomicHeatmaps) => {
           'pan2d',
           'select2d',
         ],
+      }}
+      onClick={(event: Readonly<Plotly.PlotMouseEvent>) => {
+        if (event.points.length > 0) {
+          const gene = selectedGenes.find((gene) => gene.gene_symbol === event.points[0].y);
+          if (gene) {
+            handleGenesSelection([gene]);
+            dispatch(analyticsActions.resetTranscriptomicsSampleGeneExp());
+          }
+        }
       }}
       layout={{
         title: {

--- a/src/views/Analytics/Transcriptomic/index.tsx
+++ b/src/views/Analytics/Transcriptomic/index.tsx
@@ -216,7 +216,12 @@ export const Transcriptomic = () => {
                         sampleGeneExp={sampleGeneExp.data}
                       />
                     )}
-                    {selectedGenes.length > 1 && <Heatmaps selectedGenes={selectedGenes} />}
+                    {selectedGenes.length > 1 && (
+                      <Heatmaps
+                        selectedGenes={selectedGenes}
+                        handleGenesSelection={handleSearchByGeneSelection}
+                      />
+                    )}
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
# feat(transcriptomic): add redirection to boxplot when clicking on heatmap element

- Closes SJIP-1131

## Description
If user clicks on a gene, it will open the Sample Gene Expression Plot for that gene

## Links
- [JIRA](https://d3b.atlassian.net/browse/SJIP-1131)

## Screenshot or Video

https://github.com/user-attachments/assets/ec5ef253-1852-4652-b1ff-5cf967443b50


