### PR TITLE
feat(participant): SJIP-1155 add age at first patient engagement

### DIFF
--- a/src/graphql/participants/models.ts
+++ b/src/graphql/participants/models.ts
@@ -119,6 +119,7 @@ export interface IParticipantEntity {
   family: IParticipantFamily;
   families_id: string;
   biospecimens: ArrangerResultsTree<IParticipantBiospecimen>;
+  age_at_first_patient_engagement?: { value?: number; unit?: string };
 }
 
 export type ITableParticipantEntity = IParticipantEntity & {

--- a/src/graphql/participants/queries.ts
+++ b/src/graphql/participants/queries.ts
@@ -118,6 +118,10 @@ export const GET_PARTICIPANT_ENTITY = gql`
         edges {
           node {
             id
+            age_at_first_patient_engagement {
+              unit
+              value
+            }
             diagnosis {
               hits {
                 edges {

--- a/src/graphql/participants/queries.ts
+++ b/src/graphql/participants/queries.ts
@@ -34,6 +34,10 @@ export const SEARCH_PARTICIPANT_QUERY = gql`
             race
             nb_files
             nb_biospecimens
+            age_at_first_patient_engagement {
+              unit
+              value
+            }
 
             files {
               hits {

--- a/src/graphql/quickFilter/queries.ts
+++ b/src/graphql/quickFilter/queries.ts
@@ -72,6 +72,11 @@ export const GET_QUICK_FILTER_EXPLO = gql`
           stats {
             count
           }
+        } # range
+        age_at_first_patient_engagement__value {
+          stats {
+            count
+          }
         }
         # Biospecimen
         files__biospecimens__sample_type {

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1614,6 +1614,7 @@ const en = {
       age_at_event_days: 'Age at Observed Phenotype',
     },
     age_at_data_collection: 'Age at data collection',
+    age_at_first_patient_engagement: { value: 'Age At First Patient Engagement (days)' },
     family_type: 'Family Unit',
     family: {
       family_id: 'Family ID',
@@ -1841,6 +1842,8 @@ const en = {
     },
     participant: {
       age: 'Age',
+      age_at_first_patient_engagement: 'Age',
+      age_at_first_patient_engagement_tooltip: 'Age at First Patient Engagement',
       age_tooltip_diagnosis: 'Age at Diagnosis',
       age_tooltip_phenotype: 'Age at Phenotype',
       biospecimens: 'Biospecimens',

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1843,6 +1843,7 @@ const en = {
     participant: {
       age: 'Age',
       age_at_first_patient_engagement: 'Age',
+      age_at_first_patient_engagement_complete: 'Age at First Patient Engagement',
       age_at_first_patient_engagement_tooltip: 'Age at First Patient Engagement',
       age_tooltip_diagnosis: 'Age at Diagnosis',
       age_tooltip_phenotype: 'Age at Phenotype',

--- a/src/utils/translation.ts
+++ b/src/utils/translation.ts
@@ -285,6 +285,7 @@ export const getFacetsDictionary = () => ({
     source_text: 'Condition (Source Text)',
     source_text_tumor_location: 'Tumor Location (Source Text)',
   },
+  age_at_first_patient_engagement: { value: 'Age At First Patient Engagement (days)' },
   mondo: {
     name: 'Diagnosis (MONDO)',
   },

--- a/src/views/DataExploration/components/PageContent/tabs/Participants/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Participants/index.tsx
@@ -46,6 +46,7 @@ import {
   extractPhenotypeTitleAndCode,
 } from 'views/DataExploration/utils/helper';
 import { generateSelectionSqon } from 'views/DataExploration/utils/selectionSqon';
+import AgeCell from 'views/ParticipantEntity/AgeCell';
 import { DEFAULT_OFFSET } from 'views/Variants/utils/constants';
 
 import DownloadClinicalDataDropdown from 'components/reports/DownloadClinicalDataDropdown';
@@ -158,6 +159,15 @@ const getDefaultColumns = (): ProColumnType[] => [
       multiple: 1,
     },
     render: (ethnicity: string) => ethnicity || TABLE_EMPTY_PLACE_HOLDER,
+  },
+  {
+    key: 'age_at_first_patient_engagement.value',
+    title: intl.get('entities.participant.age_at_first_patient_engagement'),
+    tooltip: intl.get('entities.participant.age_at_first_patient_engagement_tooltip'),
+    defaultHidden: true,
+    render: (participant: IParticipantEntity) => (
+      <AgeCell ageInDays={participant?.age_at_first_patient_engagement?.value} />
+    ),
   },
   {
     key: 'external_id',

--- a/src/views/DataExploration/index.tsx
+++ b/src/views/DataExploration/index.tsx
@@ -116,6 +116,7 @@ export const filterGroups: {
           'diagnosis__age_at_event_days',
           'outcomes__age_at_event_days__value',
           'observed_phenotype__age_at_event_days',
+          'age_at_first_patient_engagement__value',
           'family_type',
           'sex',
           'race',

--- a/src/views/ParticipantEntity/AgeCell/index.tsx
+++ b/src/views/ParticipantEntity/AgeCell/index.tsx
@@ -17,8 +17,12 @@ const AgeCell = ({ ageInDays }: OwnProps) => {
   const { years, days } = readableDistanceByDays(ageInDays);
   return (
     <>
-      {`${years} `}
-      <span className={styles.timeUnitText}>{intl.get('date.years', { years })}</span>
+      {years != 0 && (
+        <>
+          {`${years} `}
+          <span className={styles.timeUnitText}>{intl.get('date.years', { years })}</span>
+        </>
+      )}
       {` ${days} `}
       <span className={styles.timeUnitText}>{intl.get('date.days', { days })}</span>{' '}
     </>

--- a/src/views/ParticipantEntity/utils/getProfileItems.tsx
+++ b/src/views/ParticipantEntity/utils/getProfileItems.tsx
@@ -4,6 +4,8 @@ import { Tag, Tooltip } from 'antd';
 import { IParticipantEntity, Sex } from 'graphql/participants/models';
 import { capitalize } from 'lodash';
 
+import AgeCell from '../AgeCell';
+
 import styles from '../styles/styles.module.css';
 
 const getProfileItems = (participant?: IParticipantEntity): IEntityDescriptionsItem[] => [
@@ -46,6 +48,10 @@ const getProfileItems = (participant?: IParticipantEntity): IEntityDescriptionsI
       </Tooltip>
     ),
     value: participant?.down_syndrome_status,
+  },
+  {
+    label: intl.get('entities.participant.age_at_first_patient_engagement_complete'),
+    value: <AgeCell ageInDays={participant?.age_at_first_patient_engagement?.value} />,
   },
 ];
 


### PR DESCRIPTION
# feat(participant): add age in profile section

[SJIP-1155](https://d3b.atlassian.net/browse/SJIP-1155)

## Description
Add age at first patient engagement

## Acceptance Criterias
- Data exploration add facet (QF too), column and export
- Participant entity add in profile section

## Screenshot or Video
### Before
NA

### After
#### Data explo facet and column
<img width="865" alt="Capture d’écran, le 2025-01-06 à 15 57 53" src="https://github.com/user-attachments/assets/c993aa6c-11db-42c6-9abf-1682a7c82397" />

#### Data explo Quick Filter
<img width="475" alt="Capture d’écran, le 2025-01-06 à 15 58 15" src="https://github.com/user-attachments/assets/02d90335-bf88-47d8-89b4-e35e4611b51d" />
<img width="988" alt="Capture d’écran, le 2025-01-06 à 15 58 23" src="https://github.com/user-attachments/assets/951b7b75-5152-4258-b832-3f8a79e55662" />

#### Export TSV Data explo
<img width="1220" alt="Capture d’écran, le 2025-01-06 à 16 14 38" src="https://github.com/user-attachments/assets/ca768ada-344e-45b5-be00-67d02ec6f5d3" />

#### Participant entity
<img width="988" alt="Capture d’écran, le 2025-01-06 à 16 07 04" src="https://github.com/user-attachments/assets/3256449a-5012-4326-8716-18f3a3569c75" />
