### PR TITLE
fix(study): SJIP-1162 remove copy icon for no pub med

### DIFF
--- a/src/components/Publication/NoPubMed.tsx
+++ b/src/components/Publication/NoPubMed.tsx
@@ -1,42 +1,12 @@
 import { ReactElement } from 'react';
-import intl from 'react-intl-universal';
-import { useDispatch } from 'react-redux';
-import { CopyOutlined } from '@ant-design/icons';
 import ExternalLink from '@ferlab/ui/core/components/ExternalLink';
-import { Tooltip } from 'antd';
-import copy from 'copy-to-clipboard';
-
-import { globalActions } from 'store/global';
-
-import style from './index.module.css';
 
 interface NoPubMedProps {
   publication: string;
 }
 
-const NoPubMed = ({ publication }: NoPubMedProps): ReactElement => {
-  const dispatch = useDispatch();
-  return (
-    <>
-      <ExternalLink href={publication}>{publication}</ExternalLink>
-      <Tooltip title={intl.get('entities.study.publicationDetails.copyTooltip')}>
-        <a
-          onClick={() => {
-            copy(publication);
-            dispatch(
-              globalActions.displayMessage({
-                content: intl.get('entities.study.publicationDetails.copyMessage'),
-                type: 'success',
-              }),
-            );
-          }}
-          className={style.copy}
-        >
-          <CopyOutlined />
-        </a>
-      </Tooltip>
-    </>
-  );
-};
+const NoPubMed = ({ publication }: NoPubMedProps): ReactElement => (
+  <ExternalLink href={publication}>{publication}</ExternalLink>
+);
 
 export default NoPubMed;


### PR DESCRIPTION
# fix(study): remove copy icon for no pub med

[SJIP-1162](https://d3b.atlassian.net/browse/SJIP-1162)

## Description
Remove copy icon on no pub med

## Acceptance Criterias
- Remove copy icon on no pub med

## Screenshot or Video
### Before
<img width="976" alt="Capture d’écran, le 2025-01-09 à 10 49 58" src="https://github.com/user-attachments/assets/17fae3eb-03ff-43d6-9724-f5a9c3986329" />

### After
<img width="976" alt="Capture d’écran, le 2025-01-09 à 10 49 23" src="https://github.com/user-attachments/assets/4a25254c-f480-49aa-9995-f1ab74d34976" />
