### PR TITLE
fix(study): SJIP-1000 dataset not display empty field

### DIFF
--- a/src/views/StudyEntity/utils/datasets.tsx
+++ b/src/views/StudyEntity/utils/datasets.tsx
@@ -87,13 +87,13 @@ const getDatasetDescription = (dataset: IStudyDataset): IEntityDescriptionsItem[
       ),
     });
 
-  if (dataset.access_limitations)
+  if (dataset.access_limitations?.length)
     items.push({
       label: intl.get('entities.study.dataset.access_limitations'),
       value: dataset.access_limitations?.join(', ') || TABLE_EMPTY_PLACE_HOLDER,
     });
 
-  if (dataset.access_requirements)
+  if (dataset.access_requirements?.length)
     items.push({
       label: intl.get('entities.study.dataset.access_requirements'),
       value: dataset.access_requirements?.join(', ') || TABLE_EMPTY_PLACE_HOLDER,


### PR DESCRIPTION
# fix(study): dataset not display empty field

[SJIP-1000](https://d3b.atlassian.net/browse/SJIP-1000)

## Acceptance Criterias
- Don't display empty fields

## Screenshot or Video
### Before
<img width="1523" alt="Capture d’écran, le 2025-01-09 à 12 32 05" src="https://github.com/user-attachments/assets/cb0842c2-dff7-4e1e-ad0a-285f7d82aec6" />

### After
<img width="1523" alt="Capture d’écran, le 2025-01-09 à 12 32 48" src="https://github.com/user-attachments/assets/4c9b5e37-bbd8-45cf-9482-d253db44b746" />
