### PR TITLE
fix(participant): SJIP-1155 manage 0 display for age

### DIFF
--- a/src/views/ParticipantEntity/AgeCell/index.tsx
+++ b/src/views/ParticipantEntity/AgeCell/index.tsx
@@ -10,6 +10,9 @@ interface OwnProps {
 }
 
 const AgeCell = ({ ageInDays }: OwnProps) => {
+  if (ageInDays == 0) {
+    return <>{ageInDays}</>;
+  }
   if (!ageInDays) {
     return <>{TABLE_EMPTY_PLACE_HOLDER}</>;
   }


### PR DESCRIPTION
# fix(participant): manage 0 display for age

[SJIP-1155](https://d3b.atlassian.net/browse/SJIP-1155)

## Description
no data must return only null value not 0

## Acceptance Criterias
- manage 0 in age cell

## Screenshot or Video
### Before<img width="731" alt="Capture d’écran, le 2025-01-10 à 09 00 17" src="https://github.com/user-attachments/assets/1b0c14a0-34d5-42c2-b714-9df50f5de8b4" />

### After
<img width="731" alt="Capture d’écran, le 2025-01-10 à 08 55 38" src="https://github.com/user-attachments/assets/ad0711c2-0cb7-4cb9-9f99-53c6d39b7fe6" />
<img width="731" alt="Capture d’écran, le 2025-01-10 à 08 55 14" src="https://github.com/user-attachments/assets/334bec0e-e6e8-49dc-b575-e771e246f918" />
<img width="731" alt="Capture d’écran, le 2025-01-10 à 08 54 55" src="https://github.com/user-attachments/assets/50d6ac61-2aba-402c-8b8e-240db2f853b1" />
<img width="731" alt="Capture d’écran, le 2025-01-10 à 08 54 44" src="https://github.com/user-attachments/assets/26ade2eb-c42a-4dca-91b8-5fbd2e99d2f9" />
