### PR TITLE
fix(study): SJIP-1004 manifest family checkbox removed only in study

### DIFF
--- a/cypress/e2e/ManifestButton/Dataset.cy.ts
+++ b/cypress/e2e/ManifestButton/Dataset.cy.ts
@@ -88,8 +88,8 @@ describe('Dataset d\'une étude - Télécharger le manifest', {retries: {runMode
     cy.waitUntilFile(oneMinute);
   });
 
-  it('Valider le nom du fichier [SJIP-1186]', () => {
-    cy.validateFileName('include_HTP WGS (2021 X01)_manifest_'+`${strDate.slice(0, 4)}${strDate.slice(4, 6)}${strDate.slice(6, 8)}`+'T*.tsv');
+  it('Valider le nom du fichier', () => {
+    cy.validateFileName('include_HTP-WGS-2021-X01_manifest_'+`${strDate.slice(0, 4)}${strDate.slice(4, 6)}${strDate.slice(6, 8)}`+'T*.tsv');
   });
 
   it('Valider les en-têtes du fichier', () => {

--- a/cypress/e2e/ManifestButton/PageDataExploration.cy.ts
+++ b/cypress/e2e/ManifestButton/PageDataExploration.cy.ts
@@ -17,7 +17,7 @@ describe('Page Data Exploration (Data Files) - Bouton Manifest', () => {
     cy.get('[class*="Header_ProTableHeader"] button[class*="ant-btn-default"]').eq(1).click({force: true});
   });
 
-  it('Vérifier les informations affichées - Modal [SJIP-1182]', () => {
+  it('Vérifier les informations affichées - Modal', () => {
     cy.get('[class="ant-modal-title"]').contains('File manifest').should('exist');
     cy.get('[class="ant-modal-body"]').contains('Download a manifest of the selected files which can be used for bulk downloading using Cavatica’s ').should('exist');
     cy.get('[class="ant-modal-body"]').contains('Import from an GA4GH Data Repository Service (DRS)').should('exist');
@@ -85,7 +85,7 @@ describe('Page Data Exploration (Data Files) - Télécharger le manifest (checkb
     cy.waitUntilFile(oneMinute);
   });
 
-  it('Valider le nom du fichier [SJIP-1182]', () => {
+  it('Valider le nom du fichier', () => {
     cy.validateFileName('include_familyManifest_'+`${strDate.slice(0, 4)}${strDate.slice(4, 6)}${strDate.slice(6, 8)}`+'T*.tsv');
   });
 

--- a/cypress/e2e/ManifestButton/PageFile.cy.ts
+++ b/cypress/e2e/ManifestButton/PageFile.cy.ts
@@ -16,7 +16,7 @@ describe('Page d\'un fichier - Bouton Manifest', () => {
     cy.get('[class*="EntityTitle"] button[class*="ant-btn-default"]').click({force: true});
   });
 
-  it('Vérifier les informations affichées - Modal [SJIP-1182]', () => {
+  it('Vérifier les informations affichées - Modal', () => {
     cy.get('[class="ant-modal-title"]').contains('File manifest').should('exist');
     cy.get('[class="ant-modal-body"]').contains('Download a manifest of the selected files which can be used for bulk downloading using Cavatica’s ').should('exist');
     cy.get('[class="ant-modal-body"]').contains('Import from an GA4GH Data Repository Service (DRS)').should('exist');
@@ -83,7 +83,7 @@ describe('Page d\'un fichier - Télécharger le manifest (checkbox)', () => {
     cy.waitUntilFile(oneMinute);
   });
 
-  it('Valider le nom du fichier [SJIP-1182]', () => {
+  it('Valider le nom du fichier', () => {
     cy.validateFileName('include_familyManifest_'+`${strDate.slice(0, 4)}${strDate.slice(4, 6)}${strDate.slice(6, 8)}`+'T*.tsv');
   });
 

--- a/src/components/uiKit/reports/DownloadFileManifestModal/index.tsx
+++ b/src/components/uiKit/reports/DownloadFileManifestModal/index.tsx
@@ -3,7 +3,7 @@ import intl from 'react-intl-universal';
 import { useDispatch } from 'react-redux';
 import { DownloadOutlined } from '@ant-design/icons';
 import { ISyntheticSqon } from '@ferlab/ui/core/data/sqon/types';
-import { Button, Modal, Tooltip } from 'antd';
+import { Button, Checkbox, Modal, Tooltip } from 'antd';
 import { SizeType } from 'antd/lib/config-provider/SizeContext';
 
 import { ReportType } from 'services/api/reports/models';
@@ -19,6 +19,7 @@ interface IDownloadFileManifestProps {
   sqon: ISyntheticSqon;
   className?: string;
   disabledTooltip?: string;
+  familyCheckbox?: boolean;
   fileName?: string;
   hasTooManyFiles?: boolean;
   isDisabled?: boolean;
@@ -30,6 +31,7 @@ const DownloadFileManifestModal = ({
   sqon,
   className = '',
   disabledTooltip,
+  familyCheckbox = true,
   fileName,
   hasTooManyFiles,
   isDisabled,
@@ -39,6 +41,7 @@ const DownloadFileManifestModal = ({
   const dispatch = useDispatch();
 
   const [isModalVisible, setIsModalVisible] = useState(false);
+  const [isFamilyChecked, setIsFamilyChecked] = useState(false);
   let tooltipText = undefined;
   if (isDisabled) {
     if (disabledTooltip) {
@@ -81,8 +84,10 @@ const DownloadFileManifestModal = ({
             fetchReport({
               data: {
                 name: ReportType.FILE_MANIFEST,
-                fileName: fileName || ReportType.FILE_MANIFEST,
+                fileName:
+                  fileName || (isFamilyChecked ? `familyManifest` : ReportType.FILE_MANIFEST),
                 sqon,
+                withFamily: isFamilyChecked,
               },
               callback: () => setIsModalVisible(false),
             }),
@@ -91,6 +96,11 @@ const DownloadFileManifestModal = ({
         className={styles.modal}
       >
         <p>{intl.getHTML('api.report.fileManifest.text')}</p>
+        {familyCheckbox && (
+          <Checkbox checked={isFamilyChecked} onChange={() => setIsFamilyChecked(!isFamilyChecked)}>
+            {intl.get('api.report.fileManifest.textCheckbox')}
+          </Checkbox>
+        )}
         {hasTooManyFiles && <TooMuchFilesAlert />}
         {!hasTooManyFiles && isModalVisible && <FilesTable sqon={sqon} />}
       </Modal>

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -270,6 +270,7 @@ const en = {
         cancel: 'Cancel',
         text: `Download a manifest of the selected files which can be used for bulk downloading using Cavatica’s <a target="_blank" href="https://docs.cavatica.org/docs/import-from-a-drs-server" style="text-decoration: underline;">Import from an GA4GH Data Repository Service (DRS)</a>. This manifest also includes additional information, including the participant and samples associated with these files.`,
         subText: 'In development and will be available soon.',
+        textCheckbox: `Include data files of the same type for the participants' related family members for this selection.`,
         summary: 'Summary',
         dataType: 'Data Type',
         participants: 'Participants',

--- a/src/views/StudyEntity/index.tsx
+++ b/src/views/StudyEntity/index.tsx
@@ -662,10 +662,10 @@ const StudyEntity = () => {
                   <DownloadFileManifestModal
                     className={style.datasetBtn}
                     familyCheckbox={false}
-                    fileName="datasetName_manifest"
+                    fileName={`${dataset.external_dataset_id}_manifest`}
                     hasTooManyFiles={false}
                     isDisabled={false}
-                    key="file-entity-dataset-manifest"
+                    key="study-entity-dataset-manifest"
                     size="small"
                     sqon={generateSqonForFile(dataset)}
                   />,

--- a/src/views/StudyEntity/index.tsx
+++ b/src/views/StudyEntity/index.tsx
@@ -388,11 +388,12 @@ const StudyEntity = () => {
               )}
               {study && (
                 <DownloadFileManifestModal
+                  disabledTooltip={intl.get('entities.study.unharmonizedWarningTooltip')}
+                  familyCheckbox={false}
+                  isDisabled={!study?.is_harmonized}
                   key="download-file-manifest"
                   sqon={fileSqon}
                   type="primary"
-                  isDisabled={!study?.is_harmonized}
-                  disabledTooltip={intl.get('entities.study.unharmonizedWarningTooltip')}
                 />
               )}
             </Space>
@@ -660,6 +661,7 @@ const StudyEntity = () => {
                 titleExtra.push(
                   <DownloadFileManifestModal
                     className={style.datasetBtn}
+                    familyCheckbox={false}
                     fileName="datasetName_manifest"
                     hasTooManyFiles={false}
                     isDisabled={false}


### PR DESCRIPTION
# fix(study): manifest family checkbox removed only in study and update filename

[SJIP-1004](https://d3b.atlassian.net/browse/SJIP-1004)

## Description
Do not removed family checkbox in all pages, only in study entity.
Specify dataset in manifest filename.

## Acceptance Criterias
- Conditional display of family checkbox, not for study page.
- add external id in manifest filename

## Screenshot or Video
### Before
Checkbox removed for all instances.

### After

#### Checkbox displayed in File entity and Data Exploration / Files tab
<img width="1537" alt="Capture d’écran, le 2025-01-10 à 14 26 52" src="https://github.com/user-attachments/assets/dfb278af-9651-4180-ae02-408ca5ac412a" />
<img width="1537" alt="Capture d’écran, le 2025-01-10 à 14 26 41" src="https://github.com/user-attachments/assets/2b6728c9-5ab3-44c1-b70c-b11509b01a69" />

#### Checkbox not display in study entity global and dataset section
<img width="1537" alt="Capture d’écran, le 2025-01-10 à 14 26 23" src="https://github.com/user-attachments/assets/9b701cf9-4824-468a-9b93-443dfb0f358b" />
<img width="1537" alt="Capture d’écran, le 2025-01-10 à 14 26 13" src="https://github.com/user-attachments/assets/8ccf552b-7de9-4451-b1d5-10161de39f96" />

#### Manifest filename
<img width="1233" alt="Capture d’écran, le 2025-01-13 à 08 47 30" src="https://github.com/user-attachments/assets/4c50a2c4-0a9e-4036-b17b-d8a810b85a77" />
