### PR TITLE
fix(transcriptomic): SJIP-1160 update fold change value in tooltip

### DIFF
--- a/src/views/Analytics/Transcriptomic/ScatterPlot/index.tsx
+++ b/src/views/Analytics/Transcriptomic/ScatterPlot/index.tsx
@@ -133,7 +133,7 @@ const ScatterPlotly = ({
             )}: %{customdata.ensembl_gene_id} <br>` +
             `${intl.get(
               'screen.analytics.transcriptomic.scatterPlot.fold_change',
-            )}: %{customdata.fold_change} <br>` +
+            )}: %{customdata.fold_change:.2f} <br>` +
             `${intl.get('screen.analytics.transcriptomic.scatterPlot.qvalue')}: %{text}`,
           customdata: group.data.map((e) => e),
           text: group.data.map((e) => formatPadj(e.padj)),

--- a/src/views/Analytics/Transcriptomic/ScatterPlot/index.tsx
+++ b/src/views/Analytics/Transcriptomic/ScatterPlot/index.tsx
@@ -133,7 +133,7 @@ const ScatterPlotly = ({
             )}: %{customdata.ensembl_gene_id} <br>` +
             `${intl.get(
               'screen.analytics.transcriptomic.scatterPlot.fold_change',
-            )}: %{y:.2f} <br>` +
+            )}: %{customdata.fold_change} <br>` +
             `${intl.get('screen.analytics.transcriptomic.scatterPlot.qvalue')}: %{text}`,
           customdata: group.data.map((e) => e),
           text: group.data.map((e) => formatPadj(e.padj)),


### PR DESCRIPTION
# fix(transcriptomic): update fold change value in tooltip

[SJIP-1160](https://d3b.atlassian.net/browse/SJIP-1160)

## Description
Tooltip doesn't display the good value for fold change.

## Acceptance Criterias
- Update fold change value in tooltip

## Screenshot or Video
### Before
<img width="654" alt="Capture d’écran, le 2025-01-10 à 15 00 33" src="https://github.com/user-attachments/assets/e114e242-0e1c-47ed-91da-36bf314f129e" />

### After
<img width="356" alt="Capture d’écran, le 2025-01-15 à 12 09 32" src="https://github.com/user-attachments/assets/be758c81-d886-46a4-bdb5-58351e67c3b0" />
