### PR TITLE
feat(study): SJIP-1215 update dataaccess display rules

### DIFF
--- a/src/views/StudyEntity/index.tsx
+++ b/src/views/StudyEntity/index.tsx
@@ -69,7 +69,7 @@ import { DATA_EXPLORATION_QB_ID } from '../DataExploration/utils/constant';
 import { getFlattenTree, TreeNode } from '../DataExploration/utils/OntologyTree';
 import { PhenotypeStore } from '../DataExploration/utils/PhenotypeStore';
 
-import getDataAccessDescriptions from './utils/dataAccess';
+import getDataAccessDescriptions, { getFlatDataset } from './utils/dataAccess';
 import getDatasetDescription from './utils/datasets';
 import getFileTables from './utils/file';
 import getSummaryDescriptions from './utils/summary';
@@ -180,6 +180,7 @@ const StudyEntity = () => {
         }),
       );
     });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Demography
@@ -253,8 +254,11 @@ const StudyEntity = () => {
   });
 
   const hasDataset = study?.datasets?.hits?.edges && study.datasets.hits.edges.length > 0;
+
+  const flatDataset = getFlatDataset(study?.datasets);
   const hasDataAccess =
-    hasDataset || (study?.contacts?.hits?.edges && study?.contacts?.hits?.edges.length > 0);
+    flatDataset?.accessLimitations.size || flatDataset?.accessRequirements.size ? true : false;
+
   const hasFiles = (study?.file_count ?? 0) > 0;
 
   const defaultLinks = [
@@ -609,7 +613,7 @@ const StudyEntity = () => {
 
         {hasDataAccess && (
           <EntityDescriptions
-            descriptions={getDataAccessDescriptions(study)}
+            descriptions={getDataAccessDescriptions(flatDataset)}
             header={intl.get('entities.study.data_access')}
             id={SectionId.DATA_ACCESS}
             loading={loading}

--- a/src/views/StudyEntity/utils/dataAccess.tsx
+++ b/src/views/StudyEntity/utils/dataAccess.tsx
@@ -4,10 +4,17 @@ import { TABLE_EMPTY_PLACE_HOLDER } from '@ferlab/ui/core/common/constants';
 import ExternalLink from '@ferlab/ui/core/components/ExternalLink';
 import { IArrangerResultsTree } from '@ferlab/ui/core/graphql/types';
 import { IEntityDescriptionsItem } from '@ferlab/ui/core/pages/EntityPage';
-import { IStudyDataset, IStudyEntity } from 'graphql/studies/models';
+import { IStudyDataset } from 'graphql/studies/models';
 import { extractDuoTitleAndCode } from 'views/DataExploration/utils/helper';
 
-const getFlatDataset = (dataset?: IArrangerResultsTree<IStudyDataset>) => {
+type TFlatDataset = {
+  accessLimitations: Set<string>;
+  accessRequirements: Set<string>;
+};
+
+export const getFlatDataset = (
+  dataset?: IArrangerResultsTree<IStudyDataset>,
+): TFlatDataset | undefined => {
   if (!dataset?.hits?.edges?.length) return undefined;
 
   const accessLimitations: string[] = [];
@@ -45,23 +52,19 @@ const renderAccess = (data?: Set<string>): ReactNode => {
   return <>{formattedData}</>;
 };
 
-const getDataAccessDescriptions = (study?: IStudyEntity): IEntityDescriptionsItem[] => {
-  const flatDataset = getFlatDataset(study?.datasets);
-
-  return [
-    {
-      label: intl.get('entities.study.access_limitation'),
-      value: flatDataset?.accessLimitations.size
-        ? renderAccess(flatDataset?.accessLimitations)
-        : TABLE_EMPTY_PLACE_HOLDER,
-    },
-    {
-      label: intl.get('entities.study.access_requirement'),
-      value: flatDataset?.accessRequirements.size
-        ? renderAccess(flatDataset.accessRequirements)
-        : TABLE_EMPTY_PLACE_HOLDER,
-    },
-  ];
-};
+const getDataAccessDescriptions = (flatDataset?: TFlatDataset): IEntityDescriptionsItem[] => [
+  {
+    label: intl.get('entities.study.access_limitation'),
+    value: flatDataset?.accessLimitations.size
+      ? renderAccess(flatDataset?.accessLimitations)
+      : TABLE_EMPTY_PLACE_HOLDER,
+  },
+  {
+    label: intl.get('entities.study.access_requirement'),
+    value: flatDataset?.accessRequirements.size
+      ? renderAccess(flatDataset.accessRequirements)
+      : TABLE_EMPTY_PLACE_HOLDER,
+  },
+];
 
 export default getDataAccessDescriptions;


### PR DESCRIPTION
# feat(study): update dataaccess display rules

- Closes SJIP-1215

## Description
 There are certain studies that don’t have data for many fields and it creates a rather empty table. Similar to what was done for the dataset section, hide the rows without values. 

Similarly, hide sections that don’t have data. This should technically already be implemented but it seems like the data access section is still present

## Links
- [JIRA](https://d3b.atlassian.net/browse/SJIP-1215)

## Screenshot or Video
![image](https://github.com/user-attachments/assets/58f0a5c1-da50-49fc-b78f-0d6074e20809)
![image](https://github.com/user-attachments/assets/190b3e06-8c00-4248-a3f2-b77a124b71a3)

