### PR TITLE
fix(upset): SJIP-1228 adjust theme

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1303,6 +1303,7 @@ const en = {
           coOccuringConditions: {
             title: 'Co-occurrence of Top 10 Conditions',
             label: '# of participants',
+            empty: 'No co-occurring conditions for this query',
           },
           sampleType: {
             cardTitle: 'Sample Type',

--- a/src/views/DataExploration/components/PageContent/tabs/Summary/CoOccuringConditions/index.module.css
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/CoOccuringConditions/index.module.css
@@ -11,6 +11,10 @@
   height: 100%;
 }
 
+:global([class^="root-upset-"] text[class^="hoverBarTextStyle-upset"])  {
+  opacity: 0;
+}
+
 :global([class^="root-upset-"] text[class^="setTextStyle-upset"])  {
   font-size: 10px;
 }

--- a/src/views/DataExploration/components/PageContent/tabs/Summary/CoOccuringConditions/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/CoOccuringConditions/index.tsx
@@ -29,6 +29,7 @@ const computeUpsetTextSize = () => {
 
     const csNodeTransform = csNode.getAttribute('transform');
     if (!csNodeTransform) return;
+
     const match = csNodeTransform.match(/translate\(([^,]+),/);
     if (!match) return;
 
@@ -79,7 +80,8 @@ const CoOccuringConditionsGraphCard = () => {
     const textElements = document.querySelectorAll(SETS_NAME_QUERY);
     textElements.forEach((element: any) => {
       if (!element.getAttribute(ATTRIBUTE_ID)) {
-        element.setAttribute(ATTRIBUTE_ID, element.textContent);
+        // remove (HP:XXXXXXX) code
+        element.setAttribute(ATTRIBUTE_ID, element.textContent.replace(/\s*\(HP:\d+\)/g, ''));
       }
     });
 
@@ -120,29 +122,40 @@ const CoOccuringConditionsGraphCard = () => {
           ) : (
             <div className={styles.wrapper}>
               <div ref={gridRef} className={styles.content}>
-                <UpSetJS
-                  setLabelAlignment={'left'}
-                  sets={sets}
-                  setName={intl.get(
-                    'screen.dataExploration.tabs.summary.coOccuringConditions.label',
-                  )}
-                  combinationName={intl.get(
-                    'screen.dataExploration.tabs.summary.coOccuringConditions.label',
-                  )}
-                  exportButtons={false}
-                  selection={selection}
-                  combinations={{
-                    min: 2,
-                    limit: 25,
-                    type: 'distinctIntersection',
-                  }}
-                  widthRatios={[0.12249999999999998, 0.22749999999999998]}
-                  heightRatios={[0.55]}
-                  emptySelection={false}
-                  width={900}
-                  height={600}
-                  onHover={(s) => setSelection(s)}
-                />
+                {sets.length > 1 ? (
+                  <UpSetJS
+                    setLabelAlignment={'left'}
+                    sets={sets}
+                    setName={intl.get(
+                      'screen.dataExploration.tabs.summary.coOccuringConditions.label',
+                    )}
+                    combinationName={intl.get(
+                      'screen.dataExploration.tabs.summary.coOccuringConditions.label',
+                    )}
+                    exportButtons={false}
+                    selection={selection}
+                    combinations={{
+                      min: 2,
+                      limit: 25,
+                      type: 'distinctIntersection',
+                    }}
+                    widthRatios={[0.12249999999999998, 0.22749999999999998]}
+                    heightRatios={[0.55]}
+                    emptySelection={false}
+                    width={900}
+                    height={600}
+                    onHover={(s) => setSelection(s)}
+                  />
+                ) : (
+                  <Empty
+                    imageType="grid"
+                    size="large"
+                    noPadding
+                    description={intl.get(
+                      'screen.dataExploration.tabs.summary.coOccuringConditions.empty',
+                    )}
+                  />
+                )}
               </div>
             </div>
           )}
@@ -155,29 +168,40 @@ const CoOccuringConditionsGraphCard = () => {
           ) : (
             <div className={styles.wrapper}>
               <div id="upset" ref={gridRef} className={styles.content}>
-                <UpSetJS
-                  setLabelAlignment={'left'}
-                  sets={sets}
-                  setName={intl.get(
-                    'screen.dataExploration.tabs.summary.coOccuringConditions.label',
-                  )}
-                  combinationName={intl.get(
-                    'screen.dataExploration.tabs.summary.coOccuringConditions.label',
-                  )}
-                  exportButtons={false}
-                  selection={selection}
-                  combinations={{
-                    min: 2,
-                    limit: 25,
-                    type: 'distinctIntersection',
-                  }}
-                  widthRatios={[0.12249999999999998, 0.22749999999999998]}
-                  heightRatios={[0.55]}
-                  emptySelection={false}
-                  width={width}
-                  height={height}
-                  onHover={(s) => setSelection(s)}
-                />
+                {sets.length > 1 ? (
+                  <UpSetJS
+                    setLabelAlignment={'left'}
+                    sets={sets}
+                    setName={intl.get(
+                      'screen.dataExploration.tabs.summary.coOccuringConditions.label',
+                    )}
+                    combinationName={intl.get(
+                      'screen.dataExploration.tabs.summary.coOccuringConditions.label',
+                    )}
+                    exportButtons={false}
+                    selection={selection}
+                    combinations={{
+                      min: 2,
+                      limit: 25,
+                      type: 'distinctIntersection',
+                    }}
+                    widthRatios={[0.12249999999999998, 0.22749999999999998]}
+                    heightRatios={[0.55]}
+                    emptySelection={false}
+                    width={width}
+                    height={height}
+                    onHover={(s) => setSelection(s)}
+                  />
+                ) : (
+                  <Empty
+                    imageType="grid"
+                    size="large"
+                    noPadding
+                    description={intl.get(
+                      'screen.dataExploration.tabs.summary.coOccuringConditions.empty',
+                    )}
+                  />
+                )}
               </div>
             </div>
           )}


### PR DESCRIPTION
# fix(upset): adjust theme

- Closes SJIP-1228

## Description
Remove Hover Text Shifting:
Currently, the hover text over the vertical bars can be hidden if too close to the border of the summary view tile. As a simpler approach instead of trying to wrap the text or shift it left, we will remove this hover text displaying the intersections of the vertical bar

Adjust Histogram Labels:
Remove the HPO terms from the row text on the left histograms. However, we will retain the HPO terms on the tooltips across the diagram

Empty State when No Intersections:
Implement an empty state message when no intersections are found between phenotypes. (use PT_13QPZ5BQ)

## Links
- [JIRA](https://d3b.atlassian.net/browse/SJIP-1228)


## Screenshot or Video
### Before
![image](https://github.com/user-attachments/assets/f8f8d106-3373-49be-8267-756025fb9f2e)
![image](https://github.com/user-attachments/assets/fda095b4-cc4a-4da1-9e37-d72c4e79d2f8)


### After
<!-- Add screenshots/videos of the feature/bug after this PR -->
![2025-02-25_13-25_1](https://github.com/user-attachments/assets/ae3e5343-65e9-450b-aa4a-6337ed3a2c45)
![2025-02-25_13-25](https://github.com/user-attachments/assets/d997791d-e185-4645-b281-5ec81bf95a09)

