### PR TITLE
fix(study): SJIP-1237 update DSC dataset id for cavatica btn

### DIFF
--- a/src/views/StudyEntity/index.tsx
+++ b/src/views/StudyEntity/index.tsx
@@ -80,7 +80,7 @@ import style from './index.module.css';
 
 const { Text, Title } = Typography;
 
-const DSC_DATASET_ID = 'DS-Connect-UNHAR';
+const DSC_DATASET_ID = 'Dataset-Metadata-DSC-UH-Clinical';
 const DSC_STUDY_ID = 'DSC';
 
 const queryId = 'include-study-repo-key';


### PR DESCRIPTION
# fix(study): update DSC dataset id for cavatica btn

[SJIP-1237](https://d3b.atlassian.net/browse/SJIP-1237)

## Description
The button for analyze in cavatica is no longer present in QA

## Acceptance Criterias
Display cavatica button for dataset in DSC study entity

## Screenshot or Video
### Before
<img width="1533" alt="Capture d’écran, le 2025-02-27 à 16 10 11" src="https://github.com/user-attachments/assets/6fa4ddf5-bfdf-490a-9cf2-bf095fcd25ec" />


### After
<img width="1533" alt="Capture d’écran, le 2025-02-27 à 16 10 40" src="https://github.com/user-attachments/assets/1c297cc1-bd98-4e90-b7ba-39d6e8ead919" />
