### PR TITLE
fix(venn): SJIP-1243 add tab switching, icons and various bugsfix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@apollo/client": "^3.13.1",
         "@dnd-kit/core": "^4.0.3",
         "@dnd-kit/sortable": "^5.1.0",
-        "@ferlab/ui": "^10.16.7",
+        "@ferlab/ui": "^10.17.1",
         "@loadable/component": "^5.16.4",
         "@react-keycloak/core": "^3.2.0",
         "@react-keycloak/web": "^3.4.0",
@@ -3143,9 +3143,9 @@
       }
     },
     "node_modules/@ferlab/ui": {
-      "version": "10.16.7",
-      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-10.16.7.tgz",
-      "integrity": "sha512-EcQt4VN75SK7dTGtxJzu7+O4c/OHG4VUd+Plchts62IterY5nOx/zuNl0X/eRYUev4bsSsexuffs4J8gI92TSw==",
+      "version": "10.17.1",
+      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-10.17.1.tgz",
+      "integrity": "sha512-lCiYBz2Xxy6mcyOakldbITkJ66gcvWRCURiUI0TLJpb3+78Xfq61p6fpFGTKY6VJ+q4N2BvmbKUP/jeidD05Iw==",
       "dependencies": {
         "@ant-design/icons": "^4.8.3",
         "@ant-design/icons-svg": "^4.4.2",
@@ -3160,7 +3160,7 @@
         "antd-img-crop": "^4.2.4",
         "classnames": "^2.2.6",
         "command-line-args": "^5.1.1",
-        "cross-spawn": "^7.0.3",
+        "cross-spawn": "^7.0.6",
         "d3": "^7.9.0",
         "d3-svg-to-png": "^0.3.1",
         "history": "^4.9.0",
@@ -7466,8 +7466,7 @@
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "dev": true
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "node_modules/abs-svg-path": {
       "version": "0.1.1",
@@ -7587,7 +7586,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
       "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-      "dev": true,
       "dependencies": {
         "clean-stack": "^2.0.0",
         "indent-string": "^4.0.0"
@@ -9239,7 +9237,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -9969,9 +9966,9 @@
       "devOptional": true
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -14856,7 +14853,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
       "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -20203,7 +20199,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
       "integrity": "sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==",
-      "dev": true,
       "dependencies": {
         "abbrev": "1"
       },
@@ -20218,7 +20213,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
       "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
-      "dev": true,
       "dependencies": {
         "hosted-git-info": "^4.0.1",
         "is-core-module": "^2.5.0",
@@ -23153,7 +23147,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
       "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-      "dev": true,
       "dependencies": {
         "aggregate-error": "^3.0.0"
       },
@@ -29921,7 +29914,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
       "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
-      "dev": true,
       "dependencies": {
         "spdx-expression-parse": "^3.0.0",
         "spdx-license-ids": "^3.0.0"
@@ -29930,14 +29922,12 @@
     "node_modules/spdx-exceptions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
-      "dev": true
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A=="
     },
     "node_modules/spdx-expression-parse": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
       "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
-      "dev": true,
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
@@ -29946,8 +29936,7 @@
     "node_modules/spdx-license-ids": {
       "version": "3.0.12",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
-      "integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==",
-      "dev": true
+      "integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA=="
     },
     "node_modules/spdy": {
       "version": "4.0.2",
@@ -32151,7 +32140,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-      "dev": true,
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
@@ -33117,8 +33105,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
       "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
-      "dev": true,
-      "peer": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.7"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@apollo/client": "^3.13.1",
     "@dnd-kit/core": "^4.0.3",
     "@dnd-kit/sortable": "^5.1.0",
-    "@ferlab/ui": "^10.16.7",
+    "@ferlab/ui": "^10.17.1",
     "@loadable/component": "^5.16.4",
     "@react-keycloak/core": "^3.2.0",
     "@react-keycloak/web": "^3.4.0",

--- a/src/components/uiKit/search/SetSearch/index.tsx
+++ b/src/components/uiKit/search/SetSearch/index.tsx
@@ -56,7 +56,7 @@ const SetSearch = ({
   const [values, setValues] = useState<string[]>(getDefaultValues(getSetFieldId(type), sqon));
   const [options, setOptions] = useState<OptionsType[]>([]);
 
-  const getTypedSets = () => savedSets.filter((set) => set.setType === type);
+  const getTypedSets = () => savedSets.filter((set) => set.setType === type && !set.is_invisible);
 
   const getSetName = (setId: string) => getTypedSets().find(({ id }) => id === setId)?.tag;
 

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1189,7 +1189,7 @@ const en = {
           max: 'Max 10,000 at a time',
         },
         save: {
-          placeholder: 'My {entity} set',
+          nameTemplate: 'Combined set',
           cancel: 'Cancel',
           checkbox: {
             label: 'Save this set for future reference',

--- a/src/store/venn/thunks.ts
+++ b/src/store/venn/thunks.ts
@@ -21,10 +21,11 @@ export const fetchVennData = createAsyncThunk<
   },
   {
     qbSqons: ISyntheticSqon[];
-    index: INDEXES;
+    index?: INDEXES;
   },
   { rejectValue: string; state: RootState }
 >('venn/fetch', async (args, thunkAPI) => {
+  const index = args.index ?? INDEXES.PARTICIPANT;
   const entitySqons: ISqonGroupFilter[] = args.qbSqons.map((sqon) => {
     if (args.index === INDEXES.BIOSPECIMEN) {
       return mapFilterForBiospecimen(resolveSyntheticSqon(args.qbSqons, sqon));
@@ -35,13 +36,13 @@ export const fetchVennData = createAsyncThunk<
     return mapFilterForParticipant(resolveSyntheticSqon(args.qbSqons, sqon));
   });
 
-  const { data, error } = await ArrangerApi.fetchVenn(args.qbSqons, entitySqons, args.index);
+  const { data, error } = await ArrangerApi.fetchVenn(args.qbSqons, entitySqons, index);
   return handleThunkApiResponse({
     error,
     data: {
       summary: data.data.summary,
       operations: data.data.operations,
-      index: args.index,
+      index,
     },
     reject: thunkAPI.rejectWithValue,
   });

--- a/src/views/DataExploration/index.tsx
+++ b/src/views/DataExploration/index.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import intl from 'react-intl-universal';
 import { useDispatch } from 'react-redux';
-import { useParams } from 'react-router-dom';
 import {
   ExperimentOutlined,
   FileSearchOutlined,
@@ -197,7 +196,6 @@ const filtersContainer = (
 
 const DataExploration = () => {
   const dispatch = useDispatch();
-  const { tab } = useParams<{ tab: string }>();
   const { activeQuery } = useQueryBuilderState(DATA_EXPLORATION_QB_ID);
   const participantMappingResults = useGetExtendedMappings(INDEXES.PARTICIPANT);
   const fileMappingResults = useGetExtendedMappings(INDEXES.FILE);
@@ -470,7 +468,7 @@ const DataExploration = () => {
       <TreeFacetModal key="mondo_tree" type={RemoteComponentList.MondoTree} field={'mondo'} />
       <SidebarMenu
         className={styles.sideMenu}
-        menuItems={menuItems} /* defaultSelectedKey={tab} */
+        menuItems={menuItems}
         quickFilter={{
           dictionary: getFiltersDictionary(),
           handleFacetClick,
@@ -492,7 +490,6 @@ const DataExploration = () => {
           biospecimenMapping={biospecimenMappingResults}
           participantMapping={participantMappingResults}
           filterGroups={filterGroups}
-          tabId={tab}
         />
       </ScrollContent>
     </div>


### PR DESCRIPTION
# fix(venn): add tab switching, icons and various bugsfix

- Closes SJIP-1243

## Description
1.**Goal**: Implement the following detailed modifications for the Venn diagram. 
After creating a set from the venn, redirect to the [entity] tab in the data exploration that was selected on the top right of the venn. I.e. if a user selected files on the top right of the venn and that is the count represented, after clicking “View set” it will redirect to the Data Files tab

2.**Issue**: Phantom sets should not appear in the saved set sidebar for all entities.

3.**Goal**: add logos based on entity types on the dropdown list. 

4.**Issue**: Update colour for logo disabled state colour, it should be the same as the text:

5.**Goal**: Currently, in order to save a name in the Venn for phantom sets, we need to provide a new name for the set despite never seeing the phantom set anywhere in the portal. Verify if we can remove this restriction of having unique names for phantom saved sets since the user won’t necessarily know what they inputted previously.

In this modal, if the saved set checkbox is selected, then yes, we would enforce the restriction for a unique name. But if it is not selected (i.e. phantom saved set), we would not have the restriction for that unique name.

Pre-populated name in the input box: “Combined set”
## Links
- [JIRA](https://d3b.atlassian.net/browse/SJIP-1243)

## Screenshot or Video

https://github.com/user-attachments/assets/ae626bf0-8041-49e0-88a4-485f3e0f16b0
![image](https://github.com/user-attachments/assets/f12339f8-db77-4f82-a20f-3cb9a0170b76)
![image](https://github.com/user-attachments/assets/46c325dd-c146-42fa-a5e2-4e64189ad544)
![image](https://github.com/user-attachments/assets/24b5e10e-8b77-4b89-bee1-35642c2f8dcd)
![image](https://github.com/user-attachments/assets/81084421-8284-45e4-bf16-c8f267d901f1)
![image](https://github.com/user-attachments/assets/ecb5638c-dde4-41c9-9911-bd6f80d1d692)
