### PR TITLE
fix(venn): SJIP-1257 force static width and height for venn

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@apollo/client": "^3.13.1",
         "@dnd-kit/core": "^4.0.3",
         "@dnd-kit/sortable": "^5.1.0",
-        "@ferlab/ui": "^10.17.2",
+        "@ferlab/ui": "^10.17.3",
         "@loadable/component": "^5.16.4",
         "@react-keycloak/core": "^3.2.0",
         "@react-keycloak/web": "^3.4.0",
@@ -3143,9 +3143,9 @@
       }
     },
     "node_modules/@ferlab/ui": {
-      "version": "10.17.2",
-      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-10.17.2.tgz",
-      "integrity": "sha512-PCmacIj7SXj/fRXm7/fFsc5D2DJ3D3rS49Y0eKkTJr7JNqJno+AHqHBy2qOMGSg3fZqQ2gDYwKv4aK2szLTrsA==",
+      "version": "10.17.3",
+      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-10.17.3.tgz",
+      "integrity": "sha512-cC+W3MYAuO4ndL6WOr5o7a5l4vZC3bklL/+9V6BiQC03AV6ZpCzrocK/UIQsqsxnTwl6nkRFwsjbXhHDnleUaA==",
       "dependencies": {
         "@ant-design/icons": "^4.8.3",
         "@ant-design/icons-svg": "^4.4.2",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@apollo/client": "^3.13.1",
     "@dnd-kit/core": "^4.0.3",
     "@dnd-kit/sortable": "^5.1.0",
-    "@ferlab/ui": "^10.17.2",
+    "@ferlab/ui": "^10.17.3",
     "@loadable/component": "^5.16.4",
     "@react-keycloak/core": "^3.2.0",
     "@react-keycloak/web": "^3.4.0",

--- a/src/views/DataExploration/components/PageContent/index.tsx
+++ b/src/views/DataExploration/components/PageContent/index.tsx
@@ -237,6 +237,7 @@ const PageContent = ({
           trackVennViewSet,
           trackVennViewEntityCounts,
         }}
+        vennSize={{ width: 540, height: 498 }}
         savedSets={savedSets}
         handleSubmit={({ index, name, sets, invisible, callback }) => {
           const sqons: ISyntheticSqon[] = sets.map((set) => set.entitySqon);


### PR DESCRIPTION
# fix(venn): force static width and height for venn

- Closes SJIP-1257

## Description
When creating a venn with 2 queries, it caused a shifting of the display. Below are the two queries used. It doesn’t happen all the time but I opened it 5 times and the shifting occurred 2/5 times. 
![image](https://github.com/user-attachments/assets/70e3e3aa-745c-4761-979a-db2d28d02476)


## Links
- [JIRA](https://ferlab-crsj.atlassian.net/browse/SJIP-1257)


## Screenshot or Video
![image](https://github.com/user-attachments/assets/b61a605d-46a8-45e6-a51d-14c341b3023f)
![image](https://github.com/user-attachments/assets/130af0be-7acc-461e-8169-e157d404141a)
