### PR TITLE
feat(summary): SJIP-118 add participants by age graph

### DIFF
--- a/src/graphql/summary/queries.ts
+++ b/src/graphql/summary/queries.ts
@@ -28,6 +28,181 @@ export const DEMOGRAPHIC_QUERY = `
   }
 `;
 
+export const AGE_QUERY = `
+  query($sqon: JSON) {
+    participant {
+      _0to9T21: hits(
+        filters: {
+          op: "and"
+          content: [
+            $sqon
+            { op: "<=", content: { field: "age_at_first_patient_engagement.value", value: [3650] } }
+            { op: "in", content: { field: "down_syndrome_status", value: ["T21"] } }
+          ]
+        }
+      ) {
+        total
+      }
+      _0to9D21: hits(
+        filters: {
+          op: "and"
+          content: [
+            $sqon
+            { op: "<=", content: { field: "age_at_first_patient_engagement.value", value: [3650] } }
+            { op: "in", content: { field: "down_syndrome_status", value: ["D21"] } }
+          ]
+        }
+      ) {
+        total
+      }
+      _10to19T21: hits(
+        filters: {
+          op: "and"
+          content: [
+            $sqon
+            { op: "between", content: { field: "age_at_first_patient_engagement.value", value: [3651, 7300] } }
+            { op: "in", content: { field: "down_syndrome_status", value: ["T21"] } }
+          ]
+        }
+      ) {
+        total
+      }
+      _10to19D21: hits(
+        filters: {
+          op: "and"
+          content: [
+            $sqon
+            { op: "between", content: { field: "age_at_first_patient_engagement.value", value: [3651, 7300] } }
+            { op: "in", content: { field: "down_syndrome_status", value: ["D21"] } }
+          ]
+        }
+      ) {
+        total
+      }
+      _20to29T21: hits(
+        filters: {
+          op: "and"
+          content: [
+            $sqon
+            { op: "between", content: { field: "age_at_first_patient_engagement.value", value: [7301, 10950] } }
+            { op: "in", content: { field: "down_syndrome_status", value: ["T21"] } }
+          ]
+        }
+      ) {
+        total
+      }
+      _20to29D21: hits(
+        filters: {
+          op: "and"
+          content: [
+            $sqon
+            { op: "between", content: { field: "age_at_first_patient_engagement.value", value: [7301, 10950] } }
+            { op: "in", content: { field: "down_syndrome_status", value: ["D21"] } }
+          ]
+        }
+      ) {
+        total
+      }
+      _30to39T21: hits(
+        filters: {
+          op: "and"
+          content: [
+            $sqon
+            { op: "between", content: { field: "age_at_first_patient_engagement.value", value: [10951, 14600] } }
+            { op: "in", content: { field: "down_syndrome_status", value: ["T21"] } }
+          ]
+        }
+      ) {
+        total
+      }
+      _30to39D21: hits(
+        filters: {
+          op: "and"
+          content: [
+            $sqon
+            { op: "between", content: { field: "age_at_first_patient_engagement.value", value: [10951, 14600] } }
+            { op: "in", content: { field: "down_syndrome_status", value: ["D21"] } }
+          ]
+        }
+      ) {
+        total
+      }
+      _40to49T21: hits(
+        filters: {
+          op: "and"
+          content: [
+            $sqon
+            { op: "between", content: { field: "age_at_first_patient_engagement.value", value: [14601, 18250] } }
+            { op: "in", content: { field: "down_syndrome_status", value: ["T21"] } }
+          ]
+        }
+      ) {
+        total
+      }
+      _40to49D21: hits(
+        filters: {
+          op: "and"
+          content: [
+            $sqon
+            { op: "between", content: { field: "age_at_first_patient_engagement.value", value: [14601, 18250] } }
+            { op: "in", content: { field: "down_syndrome_status", value: ["D21"] } }
+          ]
+        }
+      ) {
+        total
+      }
+      _50to59T21: hits(
+        filters: {
+          op: "and"
+          content: [
+            $sqon
+            { op: "between", content: { field: "age_at_first_patient_engagement.value", value: [18251, 21900] } }
+            { op: "in", content: { field: "down_syndrome_status", value: ["T21"] } }
+          ]
+        }
+      ) {
+        total
+      }
+      _50to59D21: hits(
+        filters: {
+          op: "and"
+          content: [
+            $sqon
+            { op: "between", content: { field: "age_at_first_patient_engagement.value", value: [18251, 21900] } }
+            { op: "in", content: { field: "down_syndrome_status", value: ["D21"] } }
+          ]
+        }
+      ) {
+        total
+      }
+      _60plusT21: hits(
+        filters: {
+          op: "and"
+          content: [
+            $sqon
+            { op: ">", content: { field: "age_at_first_patient_engagement.value", value: [21900] } }
+            { op: "in", content: { field: "down_syndrome_status", value: ["T21"] } }
+          ]
+        }
+      ) {
+        total
+      }
+      _60plusD21: hits(
+        filters: {
+          op: "and"
+          content: [
+            $sqon
+            { op: ">", content: { field: "age_at_first_patient_engagement.value", value: [21900] } }
+            { op: "in", content: { field: "down_syndrome_status", value: ["D21"] } }
+          ]
+        }
+      ) {
+        total
+      }
+    }
+  }
+`;
+
 export const DATATYPE_QUERY = `
   query($sqon: JSON) {
     participant {

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1272,6 +1272,13 @@ const en = {
               legendAxisLeft: 'Data Types',
               legendAxisBottom: '# of participants',
             },
+            participantsByAgeGraph: {
+              tooltips: 'Participants',
+              T21: 'Trisomy 21',
+              D21: 'Controls',
+              legendAxisLeft: 'Age at First Patient Engagement (years)',
+              legendAxisBottom: '# of participants',
+            },
             sampleTypeGraph: {
               legendAxisLeft: 'Sample Types',
               legendAxisBottom: '# of participants',
@@ -1304,6 +1311,7 @@ const en = {
           },
           availableData: {
             dataCategoryTitle: 'Participants by Data Category',
+            participantsByAge: 'Participants by Age at First Patient Engagement',
             dataTypeTitle: 'Participants by Data Type',
             studiesTitle: 'Participants by Study',
             sampleTypeTitle: 'Participants by Sample Type',
@@ -1314,6 +1322,9 @@ const en = {
             title: 'Co-occurrence of Top 10 Conditions',
             label: '# of participants',
             empty: 'No co-occurring conditions for this query',
+          },
+          participantsByAge: {
+            cardTitle: 'Participants by Age at First Patient Engagement',
           },
           sampleType: {
             cardTitle: 'Sample Type',

--- a/src/views/DataExploration/components/PageContent/tabs/Summary/ParticipantsByAge/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/ParticipantsByAge/index.tsx
@@ -1,0 +1,338 @@
+import intl from 'react-intl-universal';
+import BarChart from '@ferlab/ui/core/components/Charts/Bar';
+import Empty from '@ferlab/ui/core/components/Empty';
+import { updateActiveQueryField } from '@ferlab/ui/core/components/QueryBuilder/utils/useQueryBuilderState';
+import { ArrangerValues } from '@ferlab/ui/core/data/arranger/formatting';
+import { RangeOperators } from '@ferlab/ui/core/data/sqon/operators';
+import ResizableGridCard from '@ferlab/ui/core/layout/ResizableGridLayout/ResizableGridCard';
+import { INDEXES } from 'graphql/constants';
+import useParticipantResolvedSqon from 'graphql/participants/useParticipantResolvedSqon';
+import { AGE_QUERY } from 'graphql/summary/queries';
+import { isEmpty } from 'lodash';
+import { ARRANGER_API_PROJECT_URL } from 'provider/ApolloProvider';
+import { DATA_EXPLORATION_QB_ID } from 'views/DataExploration/utils/constant';
+
+import useApi from 'hooks/useApi';
+import { getResizableGridDictionary } from 'utils/translation';
+
+import { PARTCIPANTS_BY_AGE_CARD_ID, UID } from '../utils/grid';
+
+const AGE_RANGE = ['[0-9]', '[10-19]', '[20-29]', '[30-39]', '[40-49]', '[50-59]', '60+'];
+const T21 = 'T21';
+const D21 = 'D21';
+
+type ParticipantsByAgeQueryResult = {
+  data: {
+    [key: string]: {
+      [key: string]: {
+        total: number;
+      };
+    };
+  };
+};
+
+const addToQuery = (field: string, key: string) => {
+  const sqon = buildSqonFromRange(key);
+  return updateActiveQueryField({
+    queryBuilderId: DATA_EXPLORATION_QB_ID,
+    field,
+    value: sqon.value,
+    operator: sqon.op,
+    index: INDEXES.PARTICIPANT,
+  });
+};
+
+const transformParticipantsByAge = (results: ParticipantsByAgeQueryResult) => {
+  const datum: any[] = [];
+  const data = Object.keys(results?.data?.participant || {}).map((key) => ({
+    id: buildLabelFromGraphQLKey(key),
+    group: key.substring(key.length - 3),
+    value: results?.data?.participant[key]?.total || 0,
+  }));
+
+  AGE_RANGE.forEach((key) => {
+    const range = data.filter((d) => d.id === key);
+    datum.push({
+      id: key,
+      label: key,
+      T21: range.find((d) => d.group === T21)?.value ?? 0,
+      D21: range.find((d) => d.group === D21)?.value ?? 0,
+    });
+  });
+
+  return datum;
+};
+
+const buildLabelFromGraphQLKey = (key: string) => {
+  switch (key) {
+    case '_0to9T21':
+    case '_0to9D21':
+      return AGE_RANGE[0];
+    case '_10to19T21':
+    case '_10to19D21':
+      return AGE_RANGE[1];
+    case '_20to29T21':
+    case '_20to29D21':
+      return AGE_RANGE[2];
+    case '_30to39T21':
+    case '_30to39D21':
+      return AGE_RANGE[3];
+    case '_40to49T21':
+    case '_40to49D21':
+      return AGE_RANGE[4];
+    case '_50to59T21':
+    case '_50to59D21':
+      return AGE_RANGE[5];
+    case '_60plusT21':
+    default:
+      return AGE_RANGE[6];
+  }
+};
+
+const buildSqonFromRange = (rangeValue: string) => {
+  switch (rangeValue) {
+    case '[0-9]':
+      return {
+        op: RangeOperators['<='],
+        value: [3650],
+      };
+
+    case '[10-19]':
+      return {
+        op: RangeOperators['between'],
+        value: [3651, 7300],
+      };
+    case '[20-29]':
+      return {
+        op: RangeOperators['between'],
+        value: [7301, 10950],
+      };
+
+    case '[30-39]':
+      return {
+        op: RangeOperators['between'],
+        value: [10951, 14600],
+      };
+    case '[40-49]':
+      return {
+        op: RangeOperators['between'],
+        value: [14601, 18250],
+      };
+    case '[50-59]':
+      return {
+        op: RangeOperators['between'],
+        value: [18251, 21900],
+      };
+    case '60+':
+      return {
+        op: RangeOperators['>'],
+        value: [21900],
+      };
+    default:
+      return {
+        op: undefined,
+        value: [ArrangerValues.missing],
+      };
+  }
+};
+
+const ParticipantsByAgeGraphCard = () => {
+  const { sqon } = useParticipantResolvedSqon(DATA_EXPLORATION_QB_ID);
+  const { loading, result } = useApi<any>({
+    config: {
+      url: ARRANGER_API_PROJECT_URL,
+      method: 'POST',
+      data: {
+        query: AGE_QUERY,
+        variables: { sqon },
+      },
+    },
+  });
+
+  const participantsByAgeResults = transformParticipantsByAge(result);
+
+  return (
+    <ResizableGridCard
+      gridUID={UID}
+      id={PARTCIPANTS_BY_AGE_CARD_ID}
+      dictionary={getResizableGridDictionary()}
+      theme="shade"
+      loading={loading}
+      loadingType="spinner"
+      headerTitle={intl.get('screen.dataExploration.tabs.summary.availableData.participantsByAge')}
+      tsvSettings={{
+        data: [participantsByAgeResults],
+        headers: [
+          'label',
+          intl.get(`screen.dataExploration.tabs.summary.graphs.participantsByAgeGraph.${T21}`),
+          intl.get(`screen.dataExploration.tabs.summary.graphs.participantsByAgeGraph.${D21}`),
+        ],
+        contentMap: ['label', 'T21', 'D21'],
+      }}
+      modalContent={
+        <BarChart
+          data={participantsByAgeResults}
+          groupMode="grouped"
+          axisLeft={{
+            legend: intl.get(
+              'screen.dataExploration.tabs.summary.graphs.participantsByAgeGraph.legendAxisLeft',
+            ),
+            legendPosition: 'middle',
+            legendOffset: -64,
+          }}
+          tooltipLabel={() =>
+            intl.get('screen.dataExploration.tabs.summary.graphs.participantsByAgeGraph.tooltips')
+          }
+          axisBottom={{
+            legend: intl.get(
+              'screen.dataExploration.tabs.summary.graphs.participantsByAgeGraph.legendAxisBottom',
+            ),
+            legendPosition: 'middle',
+            legendOffset: 35,
+          }}
+          legends={[
+            {
+              data: [
+                {
+                  id: T21,
+                  label: intl.get(
+                    `screen.dataExploration.tabs.summary.graphs.participantsByAgeGraph.${T21}`,
+                  ),
+                  color: '#e8c1a0',
+                },
+                {
+                  id: D21,
+                  label: intl.get(
+                    `screen.dataExploration.tabs.summary.graphs.participantsByAgeGraph.${D21}`,
+                  ),
+                  color: '#f47560',
+                },
+              ],
+              dataFrom: 'keys',
+              anchor: 'top',
+              direction: 'row',
+              justify: false,
+              translateX: 0,
+              translateY: -16,
+              itemsSpacing: 1,
+              itemWidth: 100,
+              itemHeight: 10,
+              itemDirection: 'left-to-right',
+              itemOpacity: 0.85,
+              symbolSize: 10,
+              effects: [
+                {
+                  on: 'hover',
+                  style: {
+                    itemOpacity: 1,
+                  },
+                },
+              ],
+            },
+          ]}
+          colorBy="id"
+          keys={[T21, D21]}
+          onClick={(datum: any) =>
+            addToQuery('age_at_first_patient_engagement.value', datum.indexValue as string)
+          }
+          margin={{
+            bottom: 48,
+            left: 80,
+            right: 12,
+            top: 16,
+          }}
+          layout="vertical"
+        />
+      }
+      modalSettings={{
+        width: 800,
+        height: 400,
+      }}
+      content={
+        <>
+          {isEmpty(participantsByAgeResults) ? (
+            <Empty imageType="grid" size="large" noPadding />
+          ) : (
+            <BarChart
+              data={participantsByAgeResults}
+              groupMode="grouped"
+              axisLeft={{
+                legend: intl.get(
+                  'screen.dataExploration.tabs.summary.graphs.participantsByAgeGraph.legendAxisLeft',
+                ),
+                legendPosition: 'middle',
+                legendOffset: -64,
+              }}
+              tooltipLabel={() =>
+                intl.get(
+                  'screen.dataExploration.tabs.summary.graphs.participantsByAgeGraph.tooltips',
+                )
+              }
+              axisBottom={{
+                legend: intl.get(
+                  'screen.dataExploration.tabs.summary.graphs.participantsByAgeGraph.legendAxisBottom',
+                ),
+                legendPosition: 'middle',
+                legendOffset: 35,
+              }}
+              legends={[
+                {
+                  data: [
+                    {
+                      id: T21,
+                      label: intl.get(
+                        `screen.dataExploration.tabs.summary.graphs.participantsByAgeGraph.${T21}`,
+                      ),
+                      color: '#e8c1a0',
+                    },
+                    {
+                      id: D21,
+                      label: intl.get(
+                        `screen.dataExploration.tabs.summary.graphs.participantsByAgeGraph.${D21}`,
+                      ),
+                      color: '#f47560',
+                    },
+                  ],
+                  dataFrom: 'keys',
+                  anchor: 'top',
+                  direction: 'row',
+                  justify: false,
+                  translateX: 0,
+                  translateY: -16,
+                  itemsSpacing: 1,
+                  itemWidth: 100,
+                  itemHeight: 10,
+                  itemDirection: 'left-to-right',
+                  itemOpacity: 0.85,
+                  symbolSize: 10,
+                  effects: [
+                    {
+                      on: 'hover',
+                      style: {
+                        itemOpacity: 1,
+                      },
+                    },
+                  ],
+                },
+              ]}
+              colorBy="id"
+              keys={[T21, D21]}
+              onClick={(datum: any) =>
+                addToQuery('age_at_first_patient_engagement.value', datum.indexValue as string)
+              }
+              margin={{
+                bottom: 48,
+                left: 80,
+                right: 12,
+                top: 16,
+              }}
+              layout="vertical"
+            />
+          )}
+        </>
+      }
+    />
+  );
+};
+
+export default ParticipantsByAgeGraphCard;

--- a/src/views/DataExploration/components/PageContent/tabs/Summary/utils/grid.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/utils/grid.tsx
@@ -7,6 +7,7 @@ import DataTypeGraphCard from '../DataTypeGraphCard';
 import DemographicsGraphCard from '../DemographicGraphCard';
 import MostFrequentDiagnosisGraphCard from '../MostFrequentDiagnosisGraphCard';
 import MostFrequentPhenotypesGraphCard from '../MostFrequentPhenotypesGraphCard';
+import ParticipantsByAgeGraphCard from '../ParticipantsByAge';
 import SampleTypeGraphCard from '../SampleType';
 import StudiesGraphCard from '../StudiesGraphCard';
 
@@ -21,6 +22,7 @@ export const DEMOGRAPHICS_GRAPH_CARD_ID = 'demographics-graph-card';
 export const AGE_AT_DIAGNOSIS_GRAPH_CARD_ID = 'age-at-diagnosis-graph-card';
 export const DATA_CATEGORY_GRAPH_CARD_ID = 'data-category-graph-card';
 export const STUDIES_GRAPH_CARD_ID = 'studies-graph-card';
+export const PARTCIPANTS_BY_AGE_CARD_ID = 'participants-by-age-card';
 export const DATA_TYPE_GRAPH_CARD_ID = 'data-type-graph-card';
 
 export const getDefaultLayouts = (): IResizableGridLayoutConfig[] => [
@@ -118,26 +120,26 @@ export const getDefaultLayouts = (): IResizableGridLayoutConfig[] => [
       minH: 4,
       minW: 6,
       h: 4,
-      w: 8,
+      w: 6,
       x: 0,
       y: 4,
       isResizable: false,
     },
     lg: {
       h: 4,
-      w: 12,
+      w: 10,
       x: 0,
       y: 4,
     },
     md: {
       h: 4,
-      w: 8,
+      w: 7,
       x: 0,
       y: 4,
     },
     sm: {
       h: 4,
-      w: 7,
+      w: 6,
       x: 0,
       y: 4,
     },
@@ -155,9 +157,9 @@ export const getDefaultLayouts = (): IResizableGridLayoutConfig[] => [
     },
   },
   {
-    title: intl.get('screen.dataExploration.tabs.summary.studies.cardTitle'),
-    id: STUDIES_GRAPH_CARD_ID,
-    component: <StudiesGraphCard />,
+    title: intl.get('screen.dataExploration.tabs.summary.participantsByAge.cardTitle'),
+    id: PARTCIPANTS_BY_AGE_CARD_ID,
+    component: <ParticipantsByAgeGraphCard />,
     base: {
       minH: 2,
       minW: 2,
@@ -168,20 +170,20 @@ export const getDefaultLayouts = (): IResizableGridLayoutConfig[] => [
     },
     lg: {
       h: 4,
-      w: 4,
-      x: 12,
+      w: 6,
+      x: 10,
       y: 4,
     },
     md: {
       h: 4,
-      w: 4,
-      x: 9,
+      w: 5,
+      x: 7,
       y: 4,
     },
     sm: {
       h: 4,
-      w: 3,
-      x: 7,
+      w: 4,
+      x: 6,
       y: 4,
     },
     xs: {
@@ -205,31 +207,31 @@ export const getDefaultLayouts = (): IResizableGridLayoutConfig[] => [
       minH: 2,
       minW: 4,
       h: 2,
-      w: 6,
+      w: 4,
       x: 0,
       y: 8,
     },
     lg: {
       h: 2,
-      w: 8,
+      w: 6,
       x: 0,
       y: 8,
     },
     md: {
       h: 2,
-      w: 6,
+      w: 4,
       x: 0,
       y: 8,
     },
     sm: {
       h: 2,
-      w: 5,
+      w: 3,
       x: 0,
       y: 8,
     },
     xs: {
       h: 2,
-      w: 6,
+      w: 4,
       x: 0,
       y: 19,
     },
@@ -238,6 +240,49 @@ export const getDefaultLayouts = (): IResizableGridLayoutConfig[] => [
       w: 4,
       x: 0,
       y: 18,
+    },
+  },
+  {
+    title: intl.get('screen.dataExploration.tabs.summary.studies.cardTitle'),
+    id: STUDIES_GRAPH_CARD_ID,
+    component: <StudiesGraphCard />,
+    base: {
+      minH: 2,
+      minW: 2,
+      h: 2,
+      w: 2,
+      x: 6,
+      y: 8,
+    },
+    lg: {
+      h: 2,
+      w: 2,
+      x: 6,
+      y: 8,
+    },
+    md: {
+      h: 2,
+      w: 2,
+      x: 4,
+      y: 8,
+    },
+    sm: {
+      h: 2,
+      w: 2,
+      x: 3,
+      y: 8,
+    },
+    xs: {
+      h: 2,
+      w: 2,
+      x: 4,
+      y: 18,
+    },
+    xxs: {
+      h: 2,
+      w: 4,
+      x: 0,
+      y: 20,
     },
   },
   {
@@ -280,7 +325,7 @@ export const getDefaultLayouts = (): IResizableGridLayoutConfig[] => [
       h: 2,
       w: 4,
       x: 0,
-      y: 20,
+      y: 22,
     },
   },
   {
@@ -323,7 +368,7 @@ export const getDefaultLayouts = (): IResizableGridLayoutConfig[] => [
       h: 3,
       w: 4,
       x: 0,
-      y: 22,
+      y: 24,
     },
   },
   {
@@ -366,7 +411,7 @@ export const getDefaultLayouts = (): IResizableGridLayoutConfig[] => [
       h: 3,
       w: 4,
       x: 0,
-      y: 25,
+      y: 27,
     },
   },
 ];


### PR DESCRIPTION
# feat(summary): add participants by age graph

- Closes SJIP-118

## Description
Goal: Add Vertical bar chart for Participants by Age at First Patient Engagement. A conversion of Age at First Patient Engagement from days to years  will be required. If a patient’s age is 12 years and 120 days, the patient would fall in the 12 years bracket in the group 10-19 ages for example.

Y-axis: # of participants

X-axis: Age at First Patient Engagement (years)

Age ranges will be in increments of 10. Eg. 0-9 , 10-19, 20-29…) 

mouseover tooltip on the bars: “Participants: number of participants"

Distinguish between controls and Trisomy 21 participants by having 2 bar pers age range with different colors. The controls and Trisomy 21 results can be found under the down syndrome status=t21 field.

Add a legend for the colour between controls and Trisomy 21. 


## Acceptance Criterias
<!-- List all acceptance criteria from the ticket -->

## Links
- [JIRA](https://d3b.atlassian.net/browse/SJIP-118)

## Screenshot or Video
![image](https://github.com/user-attachments/assets/90631eeb-fe5e-46b7-b0d3-5d4e808e513a)
![image](https://github.com/user-attachments/assets/88b6ee42-b431-4f0d-ada5-805d261de8cb)
![image](https://github.com/user-attachments/assets/71a086d1-313a-4eda-b9eb-64a8cec7526d)
![image](https://github.com/user-attachments/assets/a6e5c942-7943-4ab3-b3ec-0b3e22af8f0b)

![image](https://github.com/user-attachments/assets/1c7a9077-2d8d-4f6f-aa2c-d5f33ee123e2)
