### PR TITLE
fix(transcriptomic): SJIP-1290 add parenthesis for legend and x-axis

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1601,8 +1601,8 @@ const en = {
           title: 'Effect of Karyotype on {symbol}',
           sample_id: 'Sample ID',
           fpkm: 'FPKM',
-          t21: 'T21 {nT21}',
-          control: 'Control {nControl}',
+          t21: 'T21 ({nT21})',
+          control: 'Control ({nControl})',
         },
         sidebar: {
           statisticalParameters: 'Statistical Parameters',


### PR DESCRIPTION
# fix(transcriptomic): add parenthesis for legend and x-axis

- Closes SJIP-1290

## Description
Missing parentheses for the counts after the X -axis variables. It should be T21 (304) and Control (96) in the X-axis labels and also seen in the legend. 

## Links
- [JIRA](https://d3b.atlassian.net/browse/SJIP-1290)

## Extra Validation
- [ ] Reviewer video or screenshots attached
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot or Video
### Before
![image](https://github.com/user-attachments/assets/42b7fc38-37cc-426c-9cae-f4be6bbc1555)


### After
![image](https://github.com/user-attachments/assets/3838f29c-f085-4c46-adc0-e7ab15faf47b)
