### PR TITLE
feat(variant): SJIP-731 add picked symbol on transcript

### DIFF
--- a/cypress/e2e/Consultation/PageVariant_1.cy.ts
+++ b/cypress/e2e/Consultation/PageVariant_1.cy.ts
@@ -98,6 +98,7 @@ describe('Page d\'un variant - Vérifier les informations affichées', () => {
     cy.get('[id="consequence"] div[class*="VariantEntity_expandedTable"] tbody td[class="ant-table-cell"]').eq(0).contains('p.Tyr11Cys').should('exist');
     cy.get('[id="consequence"] div[class*="VariantEntity_expandedTable"] tbody td[class="ant-table-cell"]').eq(1).find('svg[class*="Cell_moderateImpact"]').should('exist');
     cy.get('[id="consequence"] div[class*="VariantEntity_expandedTable"] tbody td[class="ant-table-cell"]').eq(1).contains('Missense').should('exist');
+    cy.get('[id="consequence"] div[class*="VariantEntity_expandedTable"] tbody td[class="ant-table-cell"]').eq(1).find('span[class*="VariantEntity_pickedIcon"]').should('exist');
     cy.get('[id="consequence"] div[class*="VariantEntity_expandedTable"] tbody td[class="ant-table-cell"]').eq(2).contains('c.32T>C').should('exist');
     cy.get('[id="consequence"] div[class*="VariantEntity_expandedTable"] tbody td[class="ant-table-cell"]').eq(3).find('span[class*="ant-typography"]').eq(0).contains('SIFT').should('exist');
     cy.get('[id="consequence"] div[class*="VariantEntity_expandedTable"] tbody td[class="ant-table-cell"]').eq(3).find('span[class*="ant-typography"]').eq(1).contains('Damaging').should('exist');

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1129,6 +1129,7 @@ const en = {
         conservation: 'Conservation',
         phyloP17Way: 'PhyloP17Way',
         pickedTooltip: 'Gene with most deleterious consequence',
+        pickedConsequenceTooltip: 'Most deleterious consequence',
       },
       frequencies: {
         includeStudies: 'INCLUDE Studies',

--- a/src/views/VariantEntity/utils/consequence.tsx
+++ b/src/views/VariantEntity/utils/consequence.tsx
@@ -143,6 +143,9 @@ export const getExpandedColumns = (): ColumnType<any>[] => [
           <Text className={style.consequence}>
             {removeUnderscoreAndCapitalize(consequence.consequence[0])}
           </Text>
+          <Tooltip title={intl.get('screen.variants.consequences.pickedConsequenceTooltip')}>
+            {consequence.picked && <CheckCircleFilled className={style.pickedIcon} />}
+          </Tooltip>
         </>
       );
     },


### PR DESCRIPTION
# feat(variant): add picked symbol on transcript

[SJIP-731](https://d3b.atlassian.net/browse/SJIP-731)

## Description
Currently, we only have the picked symbol on the gene with the most deleterious consequence, but we should also have the symbol for the most deleterious consequence itself (the one that is the highlight at the top of the page). Place on the Consequence instead of the AA 

## Acceptance Criterias
Add picked symbol on transcript

## Screenshot or Video
### Before
<img width="611" alt="Capture d’écran, le 2025-04-10 à 15 08 16" src="https://github.com/user-attachments/assets/3e9de417-0bb8-4b9d-a629-32d3776fe627" />

### After
<img width="611" alt="Capture d’écran, le 2025-04-10 à 15 05 53" src="https://github.com/user-attachments/assets/e6c26443-6c28-46ea-8a4e-ef7d973a9c69" />
