### PR TITLE
feat(querytool): SJIP-1334 always display compare button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@apollo/client": "^3.13.1",
         "@dnd-kit/core": "^4.0.3",
         "@dnd-kit/sortable": "^5.1.0",
-        "@ferlab/ui": "^10.22.0",
+        "@ferlab/ui": "^10.24.0",
         "@loadable/component": "^5.16.4",
         "@react-keycloak/core": "^3.2.0",
         "@react-keycloak/web": "^3.4.0",
@@ -3143,9 +3143,9 @@
       }
     },
     "node_modules/@ferlab/ui": {
-      "version": "10.22.0",
-      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-10.22.0.tgz",
-      "integrity": "sha512-CTsDMKFMgtJmAtJ9YPfAWi7HRfhRGAS6JXOmqHP2nh7ZjB8TgU5IFXrADSLtzGVw1mTbEiklE1LNHV2CadaJhQ==",
+      "version": "10.24.0",
+      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-10.24.0.tgz",
+      "integrity": "sha512-jQkQzZm6sXV8Gc28JjcCF23z1Gf5XKYPYWV9AUPPXjFO4KXnvs4j+x9rbHGLe2aqcXJjzkCnsmwIksAm411b0A==",
       "dependencies": {
         "@ant-design/icons": "^4.8.3",
         "@ant-design/icons-svg": "^4.4.2",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@apollo/client": "^3.13.1",
     "@dnd-kit/core": "^4.0.3",
     "@dnd-kit/sortable": "^5.1.0",
-    "@ferlab/ui": "^10.22.0",
+    "@ferlab/ui": "^10.24.0",
     "@loadable/component": "^5.16.4",
     "@react-keycloak/core": "^3.2.0",
     "@react-keycloak/web": "^3.4.0",


### PR DESCRIPTION
# feat(querytool): always display compare button

- Closes SJIP-1334

## Description
Goal: Currently, the feature for the venn diagram is fairly hidden. A user needs to select 2-3 queries to be able to have the compare button appear. Therefore, we will always display the Compare button even when there is no selection for the queries. Place it betwene the label button and the new query button with the same styling that it currently has

When <2 queries selected:

Maintain the disable state

tooltip: Select 2 or 3 queries to generate a Venn diagram comparison

When >3 queries selected:

Maintain the disable state

tooltip: Only available with 2 or 3 queries selected

When 2 or 3 queries selected:

Active state as it currently is without a tooltip

## Links
- [JIRA](https://ferlab-crsj.atlassian.net/browse/SJIP-1334)

## Screenshot or Video
![image](https://github.com/user-attachments/assets/967a2e38-6566-422d-8f87-311600855040)
![image](https://github.com/user-attachments/assets/b164dba2-c785-4114-873a-48c4339b8211)
![image](https://github.com/user-attachments/assets/90b1b6cf-03d7-499d-94a7-21fdbcb258e5)
