### PR TITLE
fix(table): SJIP-1336 fix table behaviour on select all pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@apollo/client": "^3.13.1",
         "@dnd-kit/core": "^4.0.3",
         "@dnd-kit/sortable": "^5.1.0",
-        "@ferlab/ui": "^10.24.0",
+        "@ferlab/ui": "^10.24.2",
         "@loadable/component": "^5.16.4",
         "@react-keycloak/core": "^3.2.0",
         "@react-keycloak/web": "^3.4.0",
@@ -3143,9 +3143,9 @@
       }
     },
     "node_modules/@ferlab/ui": {
-      "version": "10.24.0",
-      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-10.24.0.tgz",
-      "integrity": "sha512-jQkQzZm6sXV8Gc28JjcCF23z1Gf5XKYPYWV9AUPPXjFO4KXnvs4j+x9rbHGLe2aqcXJjzkCnsmwIksAm411b0A==",
+      "version": "10.24.2",
+      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-10.24.2.tgz",
+      "integrity": "sha512-upEmOo5y9kgF2a6P+mjhLPKsPUi75t0YEJ+EQlu8W/jCTapOSGRh5i3MVgLd+zaoSRQ/SdSdauzaIH4ZEqLRuw==",
       "dependencies": {
         "@ant-design/icons": "^4.8.3",
         "@ant-design/icons-svg": "^4.4.2",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@apollo/client": "^3.13.1",
     "@dnd-kit/core": "^4.0.3",
     "@dnd-kit/sortable": "^5.1.0",
-    "@ferlab/ui": "^10.24.0",
+    "@ferlab/ui": "^10.24.2",
     "@loadable/component": "^5.16.4",
     "@react-keycloak/core": "^3.2.0",
     "@react-keycloak/web": "^3.4.0",


### PR DESCRIPTION
# fix(table): fix table behaviour on select all pages

- Closes SJIP-1336

## Description
When using the "Select All Results" option in the table (data Explo, Variant explo), and then manually deselecting a few rows, the "selected" count does not update accordingly.

The select all should be “deactivated” and the selection count should come back to represent the number of rows in the table page. For example in the image below, we have a total of 9431 rows with the Select All, but deselecting 2 rows should “deactivate” the select all and the count should be representative of the page results so it would be 18 items selected (assuming I have a page view of 20).

Problem occurs in all projects

## Links
- [JIRA](https://ferlab-crsj.atlassian.net/browse/SJIP-1336)

## Screenshot or Video

https://github.com/user-attachments/assets/630e0d5b-a42b-4a34-b571-48566bbb62a8

