### PR TITLE
fix(hierarchical): SJIP-1330 open sample clicked

### DIFF
--- a/src/components/Biospecimens/Tree/index.tsx
+++ b/src/components/Biospecimens/Tree/index.tsx
@@ -12,7 +12,7 @@ import { Button, Card, Descriptions, Input, Popover, Skeleton, Space, Typography
 import Tree, { DataNode } from 'antd/lib/tree';
 import cx from 'classnames';
 import { useHierarchicalBiospecimen } from 'graphql/biospecimens/actions';
-import { Status } from 'graphql/biospecimens/models';
+import { IBiospecimenEntity, Status } from 'graphql/biospecimens/models';
 
 import CollectionLogo from 'components/assets/biospecimen/collection.svg';
 import ContainerLogo from 'components/assets/biospecimen/container.svg';
@@ -166,17 +166,20 @@ interface BiospecinenTreeProps {
   collectionFhirIds: string[];
   hasParticipantLink?: boolean;
   participantId?: string;
+  biospecimen?: IBiospecimenEntity;
 }
 
 const BiospecimenTree = ({
   hasParticipantLink = false,
   collectionFhirIds,
   participantId,
+  biospecimen,
 }: BiospecinenTreeProps) => {
   const [expandedKeys, setExpandedKeys] = useState<React.Key[]>([]);
   const [searchValue, setSearchValue] = useState('');
   const [autoExpandParent, setAutoExpandParent] = useState(true);
   const [descriptions, setDescriptions] = useState<IDescriptionsItem[]>([]);
+  const [selectedKeys, setSelectedKeys] = useState<React.Key[]>([]);
 
   const onExpand = (newExpandedKeys: React.Key[]) => {
     setExpandedKeys(newExpandedKeys);
@@ -197,6 +200,15 @@ const BiospecimenTree = ({
     setExpandedKeys(allKeys);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useEffect(() => {
+    if (!loading && biospecimen && biospecimen.sample_id) {
+      setSelectedKeys([biospecimen.sample_id]);
+      const nodeDetails = getNodeDetails(biospecimen.sample_id, dataParsed);
+      nodeDetails &&
+        setDescriptions(getSampleDetails(nodeDetails, hasParticipantLink, participantId));
+    }
+  }, [biospecimen, loading]);
 
   const onSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = e.target;
@@ -266,8 +278,10 @@ const BiospecimenTree = ({
                 autoExpandParent={autoExpandParent}
                 showIcon
                 treeData={treeData}
+                selectedKeys={selectedKeys}
                 onSelect={(selectedKeys) => {
                   setDescriptions([]);
+                  setSelectedKeys(selectedKeys);
                   const nodeDetails = getNodeDetails(selectedKeys[0], dataParsed);
                   if (nodeDetails?.type) {
                     switch (nodeDetails.type) {

--- a/src/components/Biospecimens/Tree/index.tsx
+++ b/src/components/Biospecimens/Tree/index.tsx
@@ -202,12 +202,13 @@ const BiospecimenTree = ({
   }, []);
 
   useEffect(() => {
-    if (!loading && biospecimen && biospecimen.sample_id) {
-      setSelectedKeys([biospecimen.sample_id]);
-      const nodeDetails = getNodeDetails(biospecimen.sample_id, dataParsed);
+    if (!loading && biospecimen) {
+      setSelectedKeys([biospecimen.fhir_id]);
+      const nodeDetails = getNodeDetails(biospecimen.fhir_id, dataParsed);
       nodeDetails &&
         setDescriptions(getSampleDetails(nodeDetails, hasParticipantLink, participantId));
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [biospecimen, loading]);
 
   const onSearch = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/graphql/biospecimens/queries.ts
+++ b/src/graphql/biospecimens/queries.ts
@@ -15,6 +15,7 @@ export const SEARCH_BIOSPECIMEN_QUERY = gql`
           searchAfter
           node {
             id
+            fhir_id
             container_id
             status
             sample_id

--- a/src/views/DataExploration/components/PageContent/tabs/Biospecimens/HierarchicalBiospecimenModal.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Biospecimens/HierarchicalBiospecimenModal.tsx
@@ -27,6 +27,7 @@ const HierarchicalBiospecimenModal = ({ biospecimen, isOpen, onClose }: OwnProps
       hasParticipantLink={true}
       collectionFhirIds={biospecimen ? [biospecimen.collection_fhir_id] : []}
       participantId={biospecimen?.participant?.participant_id}
+      biospecimen={biospecimen}
     />
   </Modal>
 );


### PR DESCRIPTION
# fix(hierarchical): open sample clicked

[SJIP-1330](https://d3b.atlassian.net/browse/SJIP-1330)

## Description
Display sample infos on open.

## Acceptance Criterias
- Open details table for sample clicked in biospecimen tab

## Screenshot or Video
### Before
<img width="1714" alt="Capture d’écran, le 2025-04-24 à 13 49 52" src="https://github.com/user-attachments/assets/0f9d0ac7-7c94-40dc-8a21-1614d3bda5c1" />

### After

https://github.com/user-attachments/assets/f5fc454b-0ef2-45a7-a709-b31c4fe713ff

