### PR TITLE
fix(venn): SJIP-1358 fix an issue where the wrong tooltips was displayed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@apollo/client": "^3.13.8",
         "@dnd-kit/core": "^4.0.3",
         "@dnd-kit/sortable": "^5.1.0",
-        "@ferlab/ui": "^10.24.8",
+        "@ferlab/ui": "^10.24.10",
         "@loadable/component": "^5.16.4",
         "@react-keycloak/core": "^3.2.0",
         "@react-keycloak/web": "^3.4.0",
@@ -3162,9 +3162,9 @@
       }
     },
     "node_modules/@ferlab/ui": {
-      "version": "10.24.8",
-      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-10.24.8.tgz",
-      "integrity": "sha512-wQOZG3FuROzc/bbeJCny7wAnTlVPUkmDmA7mi4KFF/Zg0bxkXOA7qk+Vz2/Sob0a5NIajwCOGGBg1Pm0WS4A0w==",
+      "version": "10.24.10",
+      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-10.24.10.tgz",
+      "integrity": "sha512-o2vcW5tFsmFzM2VK+jMf4MnXZ8OsW1HtTuxvVgSb94zPQLOdIHuCB6l2ktLFBVHO0IU9u1R8jC9VIzfTD/8I8A==",
       "dependencies": {
         "@ant-design/icons": "^4.8.3",
         "@ant-design/icons-svg": "^4.4.2",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@apollo/client": "^3.13.8",
     "@dnd-kit/core": "^4.0.3",
     "@dnd-kit/sortable": "^5.1.0",
-    "@ferlab/ui": "^10.24.8",
+    "@ferlab/ui": "^10.24.10",
     "@loadable/component": "^5.16.4",
     "@react-keycloak/core": "^3.2.0",
     "@react-keycloak/web": "^3.4.0",


### PR DESCRIPTION
# fix(venn): fix an issue where the wrong tooltips was displayed

- Closes SJIP-1358

## Description
	
 Currently, when we hover on the Set Definitions in the Set Operations Analytics app, we get the set id which is not useful for the user. 

The correct behaviour is to see the same information in the set definition and see the full saved set name in the tooltip

## Links
- [JIRA](https://d3b.atlassian.net/browse/SJIP-1358)


- [ ] Design/UI Approved from design

## Screenshot or Video
### Before
![image](https://github.com/user-attachments/assets/fc4a7690-772f-49e2-b528-c99b6de76ab8)


### After
![image](https://github.com/user-attachments/assets/c72192c0-0893-44e2-a619-8a8a68d90234)
