### PR TITLE
feat(set): SJIP-1353 add sharable saved sets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@apollo/client": "^3.13.8",
         "@dnd-kit/core": "^4.0.3",
         "@dnd-kit/sortable": "^5.1.0",
-        "@ferlab/ui": "^10.24.10",
+        "@ferlab/ui": "^10.25.0",
         "@loadable/component": "^5.16.4",
         "@react-keycloak/core": "^3.2.0",
         "@react-keycloak/web": "^3.4.0",
@@ -3162,9 +3162,9 @@
       }
     },
     "node_modules/@ferlab/ui": {
-      "version": "10.24.10",
-      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-10.24.10.tgz",
-      "integrity": "sha512-o2vcW5tFsmFzM2VK+jMf4MnXZ8OsW1HtTuxvVgSb94zPQLOdIHuCB6l2ktLFBVHO0IU9u1R8jC9VIzfTD/8I8A==",
+      "version": "10.25.0",
+      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-10.25.0.tgz",
+      "integrity": "sha512-1VzWHpMzmraA+vTQw1m2ooHvadCi+07kEy2rHKL7R1+SI9MLLgejDkoxuf8F3r99gGkMzTUBLuSEVrTldzWpLA==",
       "dependencies": {
         "@ant-design/icons": "^4.8.3",
         "@ant-design/icons-svg": "^4.4.2",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@apollo/client": "^3.13.8",
     "@dnd-kit/core": "^4.0.3",
     "@dnd-kit/sortable": "^5.1.0",
-    "@ferlab/ui": "^10.24.10",
+    "@ferlab/ui": "^10.25.0",
     "@loadable/component": "^5.16.4",
     "@react-keycloak/core": "^3.2.0",
     "@react-keycloak/web": "^3.4.0",

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -15,6 +15,8 @@ export const MAIN_SCROLL_WRAPPER_ID = 'main-scroll-wrapper';
 
 export const FILTER_ID_QUERY_PARAM_KEY = 'filterId';
 export const SHARED_FILTER_ID_QUERY_PARAM_KEY = 'sharedFilterId';
+export const SHARED_SET_ID_QUERY_PARAM_KEY = 'sharedSetId';
+export const SHARED_SET_TYPE_QUERY_PARAM_KEY = 'sharedSetType';
 
 export const DEFAULT_GRAVATAR_PLACEHOLDER = `${EnvironmentVariables.configFor(
   'INCLUDE_WEB_ROOT',

--- a/src/common/queryBuilder.ts
+++ b/src/common/queryBuilder.ts
@@ -1,3 +1,4 @@
+import { SetType } from '@ferlab/ui/core/components/BiospecimenRequest/requestBiospecimen.utils';
 import {
   DATA_EPLORATION_FILTER_TAG,
   DATA_EXPLORATION_QB_ID,
@@ -14,4 +15,12 @@ export const FILTER_TAG_PAGE_MAPPING: Record<string, string> = {
 export const FILTER_TAG_QB_ID_MAPPING: Record<string, string> = {
   [DATA_EPLORATION_FILTER_TAG]: DATA_EXPLORATION_QB_ID,
   [VARIANT_FILTER_TAG]: VARIANT_REPO_QB_ID,
+};
+
+export const SET_TYPE_QB_ID_MAPPING: Record<string, string> = {
+  [SetType.BIOSPECIMEN]: DATA_EXPLORATION_QB_ID,
+  [SetType.PARTICIPANT]: DATA_EXPLORATION_QB_ID,
+  [SetType.FILE]: DATA_EXPLORATION_QB_ID,
+  [SetType.VARIANT]: VARIANT_REPO_QB_ID,
+  [SetType.SOMATIC]: 'variant-somatic-repo-key',
 };

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -913,14 +913,6 @@ const en = {
             existingNameError: 'A biospecimen request with this name already exists',
             maximumLength: 'characters maximum',
           },
-          shareModal: {
-            title: 'Share link to biospecimen request?',
-            cancelText: 'Cancel',
-            okText: 'Copy link',
-            content: 'Note that anyone with this link will have access to:',
-            firstPoint: 'The biospecimen request title',
-            secondPoint: 'The list of biospecimens in the request',
-          },
           shareLink: {
             success: { title: 'Success', description: 'Link copied to clipboard' },
             error: { title: 'Error', description: 'Unable to copy link to clipboard' },

--- a/src/locales/es.ts
+++ b/src/locales/es.ts
@@ -917,14 +917,6 @@ const es = {
             existingNameError: 'Ya existe una solicitud de biospecímenes con este nombre',
             maximumLength: 'caracteres máximo',
           },
-          shareModal: {
-            title: '¿Compartir el enlace a la solicitud de biospecímenes?',
-            cancelText: 'Cancelar',
-            okText: 'Copiar enlace',
-            content: 'Ten en cuenta que cualquier persona con este enlace tendrá acceso a:',
-            firstPoint: 'El título de la solicitud de biospecímenes',
-            secondPoint: 'La lista de biospecímenes en la solicitud',
-          },
           shareLink: {
             success: { title: 'Éxito', description: 'Enlace copiado al portapapeles' },
             error: { title: 'Error', description: 'No se pudo copiar el enlace al portapapeles' },

--- a/src/middleware/AuthMiddleware.tsx
+++ b/src/middleware/AuthMiddleware.tsx
@@ -2,13 +2,23 @@ import React, { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 // eslint-disable-next-line max-len
 import { SHARED_BIOSPECIMEN_REQUEST_ID_QUERY_PARAM_KEY } from '@ferlab/ui/core/components/BiospecimenRequest/requestBiospecimen.utils';
+import { addQuery } from '@ferlab/ui/core/components/QueryBuilder/utils/useQueryBuilderState';
+import { SET_ID_PREFIX } from '@ferlab/ui/core/data/sqon/types';
+import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/utils';
 import { useKeycloak } from '@react-keycloak/web';
 
-import { SHARED_FILTER_ID_QUERY_PARAM_KEY } from 'common/constants';
+import {
+  SHARED_FILTER_ID_QUERY_PARAM_KEY,
+  SHARED_SET_ID_QUERY_PARAM_KEY,
+  SHARED_SET_TYPE_QUERY_PARAM_KEY,
+} from 'common/constants';
+import { SET_TYPE_QB_ID_MAPPING } from 'common/queryBuilder';
 import Spinner from 'components/uiKit/Spinner';
 import useQueryParams from 'hooks/useQueryParams';
+import { SetType } from 'services/api/savedSet/models';
 import { useSavedFilter } from 'store/savedFilter';
 import { fetchSavedFilters, fetchSharedSavedFilter } from 'store/savedFilter/thunks';
+import { getSetFieldId } from 'store/savedSet';
 import { fetchSavedSet, fetchSharedBiospecimenRequest } from 'store/savedSet/thunks';
 import { useUser } from 'store/user';
 import { userActions } from 'store/user/slice';
@@ -32,11 +42,30 @@ const AuthMiddleware = ({ children }: Props) => {
       dispatch(fetchSavedSet());
       const sharedFilterId = params.get(SHARED_FILTER_ID_QUERY_PARAM_KEY);
       const biospecimenRequestId = params.get(SHARED_BIOSPECIMEN_REQUEST_ID_QUERY_PARAM_KEY);
+      const sharedSetId = params.get(SHARED_SET_ID_QUERY_PARAM_KEY);
+      const sharedSetType = params.get(SHARED_SET_TYPE_QUERY_PARAM_KEY);
       if (sharedFilterId) {
         dispatch(fetchSharedSavedFilter(sharedFilterId));
       }
       if (biospecimenRequestId) {
         dispatch(fetchSharedBiospecimenRequest(biospecimenRequestId));
+      }
+      if (sharedSetId && sharedSetType) {
+        const setValue = `${SET_ID_PREFIX}${sharedSetId}`;
+
+        addQuery({
+          queryBuilderId: SET_TYPE_QB_ID_MAPPING[sharedSetType],
+          query: generateQuery({
+            newFilters: [
+              generateValueFilter({
+                field: getSetFieldId(sharedSetType as SetType),
+                value: [setValue],
+                index: sharedSetType,
+              }),
+            ],
+          }),
+          setAsActive: true,
+        });
       }
     } else {
       dispatch(userActions.setIsUserLoading(false));

--- a/src/services/api/savedSet/index.ts
+++ b/src/services/api/savedSet/index.ts
@@ -1,9 +1,11 @@
+import { ISyntheticSqon } from '@ferlab/ui/core/data/sqon/types';
 import EnvironmentVariables from 'helpers/EnvVariables';
 
 import { sendRequest } from 'services/api';
 
 import {
   IUserSetOutput,
+  IUserSetOutputAlias,
   TBiospecimenRequest,
   TUserSavedSet,
   TUserSavedSetInsert,
@@ -22,6 +24,16 @@ const fetchAll = () =>
     method: 'GET',
     url: SETS_API_URL,
     headers: headers(),
+  });
+
+const fetchSetsAliases = (sqon: ISyntheticSqon[]) =>
+  sendRequest<{ data: IUserSetOutputAlias[] }>({
+    method: 'POST',
+    url: `${SETS_API_URL}/aliases`,
+    headers: headers(),
+    data: {
+      queries: sqon,
+    },
   });
 
 const shareById = (id: string) =>
@@ -71,6 +83,7 @@ const destroy = (id: string) =>
 
 export const SavedSetApi = {
   fetchAll,
+  fetchSetsAliases,
   create,
   update,
   destroy,

--- a/src/services/api/savedSet/models.ts
+++ b/src/services/api/savedSet/models.ts
@@ -15,6 +15,11 @@ export type TUpdateSet = ISavedSet & {
   newTag?: string;
 };
 
+export type IUserSetOutputAlias = {
+  setId: string;
+  alias: string;
+};
+
 export type IUserSetOutput = {
   updated_date: string;
   id: string;

--- a/src/store/savedSet/slice.ts
+++ b/src/store/savedSet/slice.ts
@@ -8,6 +8,7 @@ import {
   createSavedSet,
   deleteSavedSet,
   fetchSavedSet,
+  fetchSetsAliases,
   fetchSharedBiospecimenRequest,
   saveCompareSets,
   updateSavedSet,
@@ -15,6 +16,7 @@ import {
 
 export const SavedSetState: initialState = {
   savedSets: [],
+  alias: [],
   sharedBiospecimenRequest: undefined,
   isLoading: true,
   isUpdating: false,
@@ -45,6 +47,21 @@ const savedSetSlice = createSlice({
       isLoading: false,
     }));
     builder.addCase(fetchSavedSet.rejected, (state, action) => ({
+      ...state,
+      fetchingError: action.payload,
+      isLoading: false,
+    }));
+    // Fetch Alias
+    builder.addCase(fetchSetsAliases.pending, (state) => {
+      state.isLoading = true;
+      state.fetchingError = undefined;
+    });
+    builder.addCase(fetchSetsAliases.fulfilled, (state, action) => ({
+      ...state,
+      alias: action.payload,
+      isLoading: false,
+    }));
+    builder.addCase(fetchSetsAliases.rejected, (state, action) => ({
       ...state,
       fetchingError: action.payload,
       isLoading: false,

--- a/src/store/savedSet/thunks.ts
+++ b/src/store/savedSet/thunks.ts
@@ -5,7 +5,7 @@ import {
   setQueryBuilderState,
   updateActiveQueryField,
 } from '@ferlab/ui/core/components/QueryBuilder/utils/useQueryBuilderState';
-import { IValueFilter, SET_ID_PREFIX } from '@ferlab/ui/core/data/sqon/types';
+import { ISyntheticSqon, IValueFilter, SET_ID_PREFIX } from '@ferlab/ui/core/data/sqon/types';
 import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/utils';
 import { createAsyncThunk } from '@reduxjs/toolkit';
 import { Modal } from 'antd';
@@ -14,6 +14,7 @@ import { DATA_EXPLORATION_QB_ID } from 'views/DataExploration/utils/constant';
 import { SavedSetApi } from 'services/api/savedSet';
 import {
   IUserSetOutput,
+  IUserSetOutputAlias,
   SetType,
   TBiospecimenRequest,
   TUserSavedSetInsert,
@@ -39,6 +40,20 @@ const fetchSavedSet = createAsyncThunk<IUserSetOutput[], void | string, { reject
     });
   },
 );
+
+const fetchSetsAliases = createAsyncThunk<
+  IUserSetOutputAlias[],
+  ISyntheticSqon[],
+  { rejectValue: string }
+>('sharedsavedsets/fetch', async (sqon, thunkAPI) => {
+  const { data, error } = await SavedSetApi.fetchSetsAliases(sqon);
+
+  return handleThunkApiResponse({
+    error,
+    data: data?.data || [],
+    reject: thunkAPI.rejectWithValue,
+  });
+});
 
 const createSavedSet = createAsyncThunk<
   IUserSetOutput,
@@ -237,6 +252,7 @@ const clearCompareSets = createAsyncThunk<void, void | string, { rejectValue: st
 
 export {
   fetchSavedSet,
+  fetchSetsAliases,
   createSavedSet,
   updateSavedSet,
   deleteSavedSet,

--- a/src/store/savedSet/types.ts
+++ b/src/store/savedSet/types.ts
@@ -1,7 +1,12 @@
 import { ISqonGroupFilter } from '@ferlab/ui/core/data/sqon/types';
 import { ISort } from '@ferlab/ui/core/graphql/types';
 
-import { IUserSetOutput, SetType, TBiospecimenRequest } from 'services/api/savedSet/models';
+import {
+  IUserSetOutput,
+  IUserSetOutputAlias,
+  SetType,
+  TBiospecimenRequest,
+} from 'services/api/savedSet/models';
 
 export interface ISavedSet {
   idField: string;
@@ -20,6 +25,7 @@ export interface IDashboardCompareSets {
 export type initialState = {
   defaultFilter?: ISavedSet;
   savedSets: IUserSetOutput[];
+  alias: IUserSetOutputAlias[];
   sharedBiospecimenRequest?: TBiospecimenRequest;
   isLoading: boolean;
   isUpdating: boolean;

--- a/src/utils/translation.ts
+++ b/src/utils/translation.ts
@@ -4,7 +4,7 @@ import { IProTableDictionary } from '@ferlab/ui/core/components/ProTable/types';
 import { IDictionary as QueryBuilderDict } from '@ferlab/ui/core/components/QueryBuilder/types';
 import { SET_ID_PREFIX } from '@ferlab/ui/core/data/sqon/types';
 
-import { IUserSetOutput } from 'services/api/savedSet/models';
+import { IUserSetOutput, IUserSetOutputAlias } from 'services/api/savedSet/models';
 
 import { numberWithCommas } from './string';
 
@@ -119,6 +119,7 @@ export const getFiltersDictionary = (): FiltersDict => ({
 export const getQueryBuilderDictionary = (
   facetResolver: (key: string) => React.ReactNode,
   savedSets?: IUserSetOutput[],
+  alias?: IUserSetOutputAlias[],
 ): QueryBuilderDict => ({
   queryBuilderHeader: {
     manageFilters: {
@@ -206,7 +207,15 @@ export const getQueryBuilderDictionary = (
     facet: facetResolver,
     setNameResolver: (setId: string) => {
       const set = savedSets?.find((set) => set.id === setId.replace(SET_ID_PREFIX, ''));
-      return set ? set.tag : setId;
+      if (set && set.tag) {
+        return set.tag;
+      }
+      const aliasSetId = alias?.find((a) => a.setId === setId);
+      if (aliasSetId) {
+        return aliasSetId?.alias;
+      }
+
+      return setId;
     },
     facetValueMapping: {
       variant_external_reference: {

--- a/src/views/Dashboard/components/DashboardCards/BiospecimenRequests/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/BiospecimenRequests/index.tsx
@@ -12,7 +12,6 @@ import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/ut
 import copy from 'copy-to-clipboard';
 import { formatDistance } from 'date-fns';
 
-import { SavedSetApi } from '../../../../../services/api/savedSet';
 import { SetType } from '../../../../../services/api/savedSet/models';
 import { globalActions } from '../../../../../store/global/slice';
 import { SUPPORT_EMAIL } from '../../../../../store/report/thunks';
@@ -100,14 +99,6 @@ const BiospecimenRequests = ({ id, className = '' }: DashboardCardProps) => {
               'screen.dashboard.cards.biospecimenRequest.popupConfirm.delete.cancelText',
             ),
           },
-          share: {
-            title: intl.get('screen.dashboard.cards.biospecimenRequest.shareModal.title'),
-            okText: intl.get('screen.dashboard.cards.biospecimenRequest.shareModal.okText'),
-            content: intl.getHTML('screen.dashboard.cards.biospecimenRequest.shareModal.content'),
-            cancelText: intl.getHTML(
-              'screen.dashboard.cards.biospecimenRequest.shareModal.cancelText',
-            ),
-          },
         },
       }}
       handleListItemEdit={(id: string, name: string, callback: () => void) => {
@@ -122,33 +113,16 @@ const BiospecimenRequests = ({ id, className = '' }: DashboardCardProps) => {
         );
       }}
       handleListItemShare={async (id: string) => {
-        // call back to change sharedpublicly boolean
-        const { data } = await SavedSetApi.shareById(id);
-        if (data) {
-          copy(
-            `${window.location.protocol}//${window.location.host}` +
-              `${STATIC_ROUTES.DATA_EXPLORATION_BIOSPECIMENS}?${SHARED_BIOSPECIMEN_REQUEST_ID_QUERY_PARAM_KEY}=${id}`,
-          );
-          dispatch(
-            globalActions.displayNotification({
-              type: 'success',
-              message: intl.get(
-                'screen.dashboard.cards.biospecimenRequest.shareLink.success.title',
-              ),
-              description: intl.get(
-                'screen.dashboard.cards.biospecimenRequest.shareLink.success.description',
-              ),
-            }),
-          );
-          return;
-        }
-
+        copy(
+          `${window.location.protocol}//${window.location.host}` +
+            `${STATIC_ROUTES.DATA_EXPLORATION_BIOSPECIMENS}?${SHARED_BIOSPECIMEN_REQUEST_ID_QUERY_PARAM_KEY}=${id}`,
+        );
         dispatch(
           globalActions.displayNotification({
-            type: 'error',
-            message: intl.get('screen.dashboard.cards.biospecimenRequest.shareLink.error.title'),
+            type: 'success',
+            message: intl.get('screen.dashboard.cards.biospecimenRequest.shareLink.success.title'),
             description: intl.get(
-              'screen.dashboard.cards.biospecimenRequest.shareLink.error.description',
+              'screen.dashboard.cards.biospecimenRequest.shareLink.success.description',
             ),
           }),
         );

--- a/src/views/Dashboard/components/DashboardCards/SavedSets/ListItem/index.tsx
+++ b/src/views/Dashboard/components/DashboardCards/SavedSets/ListItem/index.tsx
@@ -8,6 +8,7 @@ import { addQuery } from '@ferlab/ui/core/components/QueryBuilder/utils/useQuery
 import { SET_ID_PREFIX } from '@ferlab/ui/core/data/sqon/types';
 import { generateQuery, generateValueFilter } from '@ferlab/ui/core/data/sqon/utils';
 import { Checkbox, Col, Modal, Row, Typography } from 'antd';
+import copy from 'copy-to-clipboard';
 import { formatDistance } from 'date-fns';
 import { INDEXES } from 'graphql/constants';
 import { SetActionType } from 'views/DataExploration/components/SetsManagementDropdown';
@@ -18,9 +19,11 @@ import {
 } from 'views/DataExploration/utils/constant';
 import { VARIANT_SAVED_SETS_FIELD } from 'views/Variants/utils/constants';
 
+import { SHARED_SET_ID_QUERY_PARAM_KEY, SHARED_SET_TYPE_QUERY_PARAM_KEY } from 'common/constants';
 import useFeatureToggle from 'hooks/useFeatureToggle';
 import { trackSetActions } from 'services/analytics';
 import { IUserSetOutput } from 'services/api/savedSet/models';
+import { globalActions } from 'store/global';
 import { getSetFieldId } from 'store/savedSet';
 import { deleteSavedSet } from 'store/savedSet/thunks';
 import { STATIC_ROUTES } from 'utils/routes';
@@ -85,6 +88,26 @@ const ListItem = ({ data, icon, queryBuilderId }: OwnProps) => {
         key={data.id}
         className={styles.savedSetListItem}
         onEdit={() => setModalVisible(true)}
+        onShare={() => {
+          copy(
+            `${window.location.protocol}//${window.location.host}${redirectToPage(
+              data.setType,
+            )}?${SHARED_SET_ID_QUERY_PARAM_KEY}=${data.id}&${SHARED_SET_TYPE_QUERY_PARAM_KEY}=${
+              data.setType
+            }`,
+          );
+          dispatch(
+            globalActions.displayNotification({
+              type: 'success',
+              message: intl.get(
+                'screen.dashboard.cards.biospecimenRequest.shareLink.success.title',
+              ),
+              description: intl.get(
+                'screen.dashboard.cards.biospecimenRequest.shareLink.success.description',
+              ),
+            }),
+          );
+        }}
         onDelete={() =>
           Modal.confirm({
             title: intl.get('components.savedSets.popupConfirm.delete.title'),

--- a/src/views/DataExploration/components/PageContent/index.tsx
+++ b/src/views/DataExploration/components/PageContent/index.tsx
@@ -72,7 +72,7 @@ import {
   updateSavedFilter,
 } from 'store/savedFilter/thunks';
 import { getSetFieldId, PROJECT_ID, useSavedSet } from 'store/savedSet';
-import { createSavedSet } from 'store/savedSet/thunks';
+import { createSavedSet, fetchSetsAliases } from 'store/savedSet/thunks';
 import { useVennData } from 'store/venn';
 import { fetchVennData } from 'store/venn/thunks';
 import {
@@ -145,7 +145,7 @@ const PageContent = ({
   const { isEnabled } = useFeatureToggle(FT_FLAG_VENN_COMPARE);
   const navigate = useNavigate();
   const location = useLocation();
-  const { savedSets } = useSavedSet();
+  const { savedSets, alias } = useSavedSet();
   const vennData = useVennData();
   const [vennOpen, setVennOpen] = useState<boolean>(false);
   const { queryList, activeQuery, selectedSavedFilter, savedFilterList } =
@@ -225,6 +225,10 @@ const PageContent = ({
     : undefined;
 
   useEffect(() => {
+    dispatch(fetchSetsAliases(queryList));
+  }, [queryList]);
+
+  useEffect(() => {
     setTabId(tab as TAB_IDS);
   }, [tab]);
 
@@ -288,7 +292,7 @@ const PageContent = ({
 
           setTabId(newTabId as TAB_IDS);
         }}
-        queryPillDictionary={getQueryBuilderDictionary(facetTransResolver, savedSets)}
+        queryPillDictionary={getQueryBuilderDictionary(facetTransResolver, savedSets, alias)}
         error={vennData.error}
         options={[
           {

--- a/src/views/Variants/components/PageContent/index.tsx
+++ b/src/views/Variants/components/PageContent/index.tsx
@@ -39,6 +39,7 @@ import {
   updateSavedFilter,
 } from 'store/savedFilter/thunks';
 import { useSavedSet } from 'store/savedSet';
+import { fetchSetsAliases } from 'store/savedSet/thunks';
 import { useUser } from 'store/user';
 import { combineExtendedMappings } from 'utils/fieldMapper';
 import { getCurrentUrl } from 'utils/helper';
@@ -63,7 +64,7 @@ const addTagToFilter = (filter: ISavedFilter) => ({
 const PageContent = ({ variantMapping, filterGroups }: OwnProps) => {
   const dispatch = useDispatch<any>();
   const { userInfo } = useUser();
-  const { savedSets } = useSavedSet();
+  const { savedSets, alias } = useSavedSet();
   const { queryList, activeQuery, selectedSavedFilter, savedFilterList } =
     useQBStateWithSavedFilters(VARIANT_REPO_QB_ID, SavedFilterTag.VariantsExplorationPage);
   const [queryConfig, setQueryConfig] = useState({
@@ -141,6 +142,10 @@ const PageContent = ({ variantMapping, filterGroups }: OwnProps) => {
     );
   };
 
+  useEffect(() => {
+    dispatch(fetchSetsAliases(queryList));
+  }, [queryList]);
+
   return (
     <Space direction="vertical" size={24} className={styles.variantsPageContent}>
       <div className={styles.pageHeader}>
@@ -200,7 +205,7 @@ const PageContent = ({ variantMapping, filterGroups }: OwnProps) => {
         IconTotal={<LineStyleIcon width={18} height={18} />}
         currentQuery={isEmptySqon(activeQuery) ? {} : activeQuery}
         total={results.total}
-        dictionary={getQueryBuilderDictionary(facetTransResolver, savedSets)}
+        dictionary={getQueryBuilderDictionary(facetTransResolver, savedSets, alias)}
         getResolvedQueryForCount={(sqon) => resolveSyntheticSqon(queryList, sqon)}
         fetchQueryCount={async (sqon) => {
           const { data } = await ArrangerApi.graphqlRequest<{ data: IVariantResultTree }>({


### PR DESCRIPTION
# feat(set): add sharable saved sets

- Closes SJIP-1353

## Description
Add share link button to the saved sets widget across all entity types. A user will be able to copy the url for their saved set and share it with another user.

Unlike the biospecimen requests widget, instead of opening a warning modal, simply show the success message that the url was copied.

The query pill will be the corresponding entity type=saved set name (Participant, Biospecimen, File, Variant).
e.g. Participant = “This is my saved set name”, Variant = “This is my variant set”

## Links
- [JIRA](https://d3b.atlassian.net/browse/SJIP-1353)

## Screenshot or Video
![image](https://github.com/user-attachments/assets/5f10f3ca-aed6-44a8-80a8-f2e29648b441)
![image](https://github.com/user-attachments/assets/24e10dbe-f5c3-4698-8d9d-e1e20f459ac9)
