### PR TITLE
fix(study): SJIP-1370 increase demographic chart legend width

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@apollo/client": "^3.13.8",
         "@dnd-kit/core": "^4.0.3",
         "@dnd-kit/sortable": "^5.1.0",
-        "@ferlab/ui": "^10.25.0",
+        "@ferlab/ui": "^10.25.1",
         "@loadable/component": "^5.16.4",
         "@react-keycloak/core": "^3.2.0",
         "@react-keycloak/web": "^3.4.0",
@@ -3164,9 +3164,9 @@
       }
     },
     "node_modules/@ferlab/ui": {
-      "version": "10.25.0",
-      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-10.25.0.tgz",
-      "integrity": "sha512-1VzWHpMzmraA+vTQw1m2ooHvadCi+07kEy2rHKL7R1+SI9MLLgejDkoxuf8F3r99gGkMzTUBLuSEVrTldzWpLA==",
+      "version": "10.25.1",
+      "resolved": "https://registry.npmjs.org/@ferlab/ui/-/ui-10.25.1.tgz",
+      "integrity": "sha512-iwWtnvmSsSsStMK+nnGvWdLLh2vv5WavaRBersXMyMoj0B7GXj85FIYYoBHAF2i5BXUd+nN2FEpcm65dbKWDJg==",
       "dependencies": {
         "@ant-design/icons": "^4.8.3",
         "@ant-design/icons-svg": "^4.4.2",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@apollo/client": "^3.13.8",
     "@dnd-kit/core": "^4.0.3",
     "@dnd-kit/sortable": "^5.1.0",
-    "@ferlab/ui": "^10.25.0",
+    "@ferlab/ui": "^10.25.1",
     "@loadable/component": "^5.16.4",
     "@react-keycloak/core": "^3.2.0",
     "@react-keycloak/web": "^3.4.0",


### PR DESCRIPTION
# fix(study): increase demographic chart legend width

[SJIP-1370](https://ferlab-crsj.atlassian.net/browse/SJIP-1370)

## Description
Race demographic chart is sliced in download png.

## Acceptance Criterias
- See the legend

## Screenshot or Video
### Before
<img width="1727" alt="Capture d’écran, le 2025-06-11 à 08 34 37" src="https://github.com/user-attachments/assets/d5206117-5fdb-4851-8e73-c7fada7ceffc" />

### After
<img width="1727" alt="Capture d’écran, le 2025-06-11 à 08 29 56" src="https://github.com/user-attachments/assets/f94eefcc-ad77-4263-8f40-89b54360883f" />


[SJIP-1370]: https://d3b.atlassian.net/browse/SJIP-1370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ