### PR TITLE
feat(participant): SJIP-1389 add sort to biospecimen columns

### DIFF
--- a/src/views/ParticipantEntity/utils/biospecimens.tsx
+++ b/src/views/ParticipantEntity/utils/biospecimens.tsx
@@ -13,11 +13,13 @@ export const getBiospecimensDefaultColumns = (): ProColumnType[] => [
   {
     key: 'sample_id',
     title: intl.get('entities.biospecimen.sample_id'),
+    sorter: { multiple: 1 },
     render: (biospecimen: IBiospecimenEntity) => biospecimen.sample_id || TABLE_EMPTY_PLACE_HOLDER,
   },
   {
     key: 'collection_sample_id',
     title: intl.get('entities.biospecimen.collection_id'),
+    sorter: { multiple: 1 },
     render: (biospecimen: IBiospecimenEntity) =>
       biospecimen.collection_sample_id ? (
         <CollectionIdLink collectionId={biospecimen?.collection_sample_id} />
@@ -28,18 +30,21 @@ export const getBiospecimensDefaultColumns = (): ProColumnType[] => [
   {
     key: 'container_id',
     title: intl.get('entities.biospecimen.container_id'),
+    sorter: { multiple: 1 },
     render: (biospecimen: IBiospecimenEntity) =>
       biospecimen?.container_id || TABLE_EMPTY_PLACE_HOLDER,
   },
   {
     key: 'sample_type',
     title: intl.get('entities.biospecimen.sample_type'),
+    sorter: { multiple: 1 },
     render: (biospecimen: IBiospecimenEntity) =>
       biospecimen?.sample_type || TABLE_EMPTY_PLACE_HOLDER,
   },
   {
     key: 'collection_sample_type',
     title: intl.get('entities.biospecimen.collection_sample_type'),
+    sorter: { multiple: 1 },
     render: (biospecimen: IBiospecimenEntity) =>
       biospecimen?.collection_sample_type || TABLE_EMPTY_PLACE_HOLDER,
   },
@@ -47,6 +52,7 @@ export const getBiospecimensDefaultColumns = (): ProColumnType[] => [
     key: 'age_at_biospecimen_collection',
     title: intl.get('entities.participant.age'),
     tooltip: intl.get('entities.biospecimen.age_tooltip'),
+    sorter: { multiple: 1 },
     render: (biospecimen: IBiospecimenEntity) => (
       <AgeCell ageInDays={biospecimen?.age_at_biospecimen_collection} />
     ),
@@ -54,6 +60,7 @@ export const getBiospecimensDefaultColumns = (): ProColumnType[] => [
   {
     key: 'volume',
     title: intl.get('entities.biospecimen.volume'),
+    sorter: { multiple: 1 },
     render: (biospecimen: IBiospecimenEntity) => biospecimen?.volume || TABLE_EMPTY_PLACE_HOLDER,
     defaultHidden: true,
   },
@@ -68,6 +75,7 @@ export const getBiospecimensDefaultColumns = (): ProColumnType[] => [
     key: 'status',
     title: intl.get('entities.biospecimen.sample_availabilty'),
     defaultHidden: true,
+    sorter: { multiple: 1 },
     render: (biospecimen: IBiospecimenEntity) => {
       const status = biospecimen?.status;
       if (!status) {
@@ -93,6 +101,7 @@ export const getBiospecimensDefaultColumns = (): ProColumnType[] => [
   {
     key: 'parent_sample_id',
     title: intl.get('entities.biospecimen.parent_sample_id'),
+    sorter: { multiple: 1 },
     render: (biospecimen: IBiospecimenEntity) =>
       biospecimen?.parent_sample_id || TABLE_EMPTY_PLACE_HOLDER,
     defaultHidden: true,
@@ -100,6 +109,7 @@ export const getBiospecimensDefaultColumns = (): ProColumnType[] => [
   {
     key: 'parent_sample_type',
     title: intl.get('entities.biospecimen.parent_sample_type'),
+    sorter: { multiple: 1 },
     render: (biospecimen: IBiospecimenEntity) =>
       biospecimen?.parent_sample_type || TABLE_EMPTY_PLACE_HOLDER,
     defaultHidden: true,


### PR DESCRIPTION
# feat(participant): add sort to biospecimen columns

[SJIP-1389](https://d3b.atlassian.net/browse/SJIP-1389)

## Description
Add sort on this columns : 
- Sample ID
- Collection ID
- Container ID
- Sample Type
- Collection sample Type
- Age (if feasible)
- Volume (if feasible)
- Sample Availability
- Parent Sample ID
- Parent Sample Type

## Acceptance Criterias
- Add sort on 10 columns in biospecimen section of participant entity
- Manage sort on front side

## Screenshot or Video
### Before
No sort before

### After

https://github.com/user-attachments/assets/1e4b40ff-41fa-4eb6-bcc3-c7be88e42d07



[SJIP-1389]: https://d3b.atlassian.net/browse/SJIP-1389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ