### PR TITLE
feat(summary): SJIP-1275 add onclick on upset plot and info icon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@apollo/client": "^3.13.8",
         "@dnd-kit/core": "^4.0.3",
         "@dnd-kit/sortable": "^5.1.0",
-        "@ferlab/ui": "^10.25.5",
+        "@ferlab/ui": "^10.25.6",
         "@loadable/component": "^5.16.4",
         "@react-keycloak/core": "^3.2.0",
         "@react-keycloak/web": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@apollo/client": "^3.13.8",
     "@dnd-kit/core": "^4.0.3",
     "@dnd-kit/sortable": "^5.1.0",
-    "@ferlab/ui": "^10.25.5",
+    "@ferlab/ui": "^10.25.6",
     "@loadable/component": "^5.16.4",
     "@react-keycloak/core": "^3.2.0",
     "@react-keycloak/web": "^3.4.0",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1376,6 +1376,10 @@ const en = {
             title: 'Co-occurrence of Top 10 Conditions',
             label: '# of participants',
             empty: 'No co-occurring conditions for this query',
+            infoPopover: {
+              content:
+                'The co-occurrence plot is based on participants annotated with the <strong>exact Phenotype HPO term only</strong>. It does <strong>not include descendant terms</strong> as seen in the Phenotype (HPO) browser that can be opened in the facet sidebar which leverages the ontology’s hierarchical structure.',
+            },
           },
           participantsByAge: {
             cardTitle: 'Participants by Age at First Patient Engagement',

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1378,7 +1378,7 @@ const en = {
             empty: 'No co-occurring conditions for this query',
             infoPopover: {
               content:
-                'The co-occurrence plot is based on participants annotated with the <strong>exact Phenotype HPO term only</strong>. It does <strong>not include descendant terms</strong> as seen in the Phenotype (HPO) browser that can be opened in the facet sidebar which leverages the ontology’s hierarchical structure.',
+                'The co-occurrence plot is based on participants annotated with the <strong>exact Phenotype HPO term only</strong>. It does <strong>not include descendant terms</strong> as seen in the Phenotype (HPO) browser that can be opened from the Participant search criteria in the sidebar which leverages the ontology’s hierarchical structure.<br><br>If phenotypes are added to the query bar by clicking on the upset plot bars, the results will <strong>include all the descendant terms of the selected phenotypes</strong> – not just participants annotated with the <strong>exact term</strong> as shown in the plot.',
             },
           },
           participantsByAge: {

--- a/src/views/DataExploration/components/PageContent/tabs/Summary/CoOccuringConditions/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/CoOccuringConditions/index.tsx
@@ -1,12 +1,17 @@
 import { useEffect, useRef, useState } from 'react';
 import intl from 'react-intl-universal';
 import Empty from '@ferlab/ui/core/components/Empty';
+import { updateActiveQueryField } from '@ferlab/ui/core/components/QueryBuilder/utils/useQueryBuilderState';
+import { TermOperators } from '@ferlab/ui/core/data/sqon/operators';
+import { MERGE_VALUES_STRATEGIES } from '@ferlab/ui/core/data/sqon/types';
 import ResizableGridCard from '@ferlab/ui/core/layout/ResizableGridLayout/ResizableGridCard';
 import { asSets, ISetLike, UpSetJS } from '@upsetjs/react';
+import { INDEXES } from 'graphql/constants';
 import useParticipantResolvedSqon from 'graphql/participants/useParticipantResolvedSqon';
 import { isEmpty, throttle } from 'lodash';
 import { DATA_EXPLORATION_QB_ID } from 'views/DataExploration/utils/constant';
 
+import { RemoteComponentList } from 'store/remote/types';
 import { useCoOccuringConditions } from 'store/upset';
 import { getResizableGridDictionary } from 'utils/translation';
 
@@ -115,6 +120,12 @@ const CoOccuringConditionsGraphCard = () => {
         png: true,
         tsv: false,
       }}
+      infoPopover={{
+        content: intl.getHTML(
+          'screen.dataExploration.tabs.summary.coOccuringConditions.infoPopover.content',
+        ),
+      }}
+      isResizable={false}
       modalContent={
         <>
           {isEmpty(data) ? (
@@ -191,6 +202,28 @@ const CoOccuringConditionsGraphCard = () => {
                     width={width}
                     height={height}
                     onHover={(s) => setSelection(s)}
+                    onClick={(s: any) => {
+                      const values: string[] = [];
+                      s.sets.forEach((set: any) => {
+                        values.push(set.name);
+                      });
+
+                      updateActiveQueryField({
+                        queryBuilderId: DATA_EXPLORATION_QB_ID,
+                        field: 'observed_phenotype.name',
+                        value: values,
+                        operator: TermOperators.in,
+                        index: INDEXES.PARTICIPANT,
+                        merge_strategy: MERGE_VALUES_STRATEGIES.OVERRIDE_VALUES,
+                        remoteComponent: {
+                          id: RemoteComponentList.HPOTree,
+                          props: {
+                            visible: true,
+                            field: 'observed_phenotype',
+                          },
+                        },
+                      });
+                    }}
                   />
                 ) : (
                   <Empty

--- a/src/views/DataExploration/components/PageContent/tabs/Summary/CoOccuringConditions/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/CoOccuringConditions/index.tsx
@@ -204,17 +204,21 @@ const CoOccuringConditionsGraphCard = () => {
                     onHover={(s) => setSelection(s)}
                     onClick={(s: any) => {
                       const values: string[] = [];
-                      s.sets.forEach((set: any) => {
-                        values.push(set.name);
-                      });
+                      if (s.sets) {
+                        s.sets.forEach((set: any) => {
+                          values.push(set.name);
+                        });
+                      } else {
+                        values.push(s.name);
+                      }
 
                       updateActiveQueryField({
                         queryBuilderId: DATA_EXPLORATION_QB_ID,
                         field: 'observed_phenotype.name',
                         value: values,
-                        operator: TermOperators.in,
+                        operator: TermOperators.all,
                         index: INDEXES.PARTICIPANT,
-                        merge_strategy: MERGE_VALUES_STRATEGIES.OVERRIDE_VALUES,
+                        merge_strategy: MERGE_VALUES_STRATEGIES.APPEND_VALUES,
                         remoteComponent: {
                           id: RemoteComponentList.HPOTree,
                           props: {


### PR DESCRIPTION
# feat(summary): add horizontal bar on click

[SJIP-1275](https://d3b.atlassian.net/browse/SJIP-1275)

## Description
Add the phenotype intersection to the QB

## Acceptance Criterias
- Add icon info in card title
- Add vertical and horizontal onClick to add phenotypes to QB

## Screenshot or Video
### Before
No click and no info icon

### After
<img width="862" alt="Capture d’écran, le 2025-07-03 à 09 47 06" src="https://github.com/user-attachments/assets/0457bae4-d9c3-4dbe-9c4a-5fe64a5906a8" />

https://github.com/user-attachments/assets/c63dec51-1a28-4726-a043-fe5db17a172e


[SJIP-1275]: https://d3b.atlassian.net/browse/SJIP-1275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ