### PR TITLE
fix(quickfilter): SJIP-1419 check first level of nested facet

### DIFF
--- a/src/views/DataExploration/utils/quickFilter.tsx
+++ b/src/views/DataExploration/utils/quickFilter.tsx
@@ -67,13 +67,14 @@ export const getFieldWithPrefixFile = (index: string, field: string): string => 
 };
 
 export const getFieldWithPrefixUnderscore = (index: string, field: string): string => {
+  const fieldFormated = field.replace(/\./g, '__');
   switch (index) {
     case INDEXES.BIOSPECIMEN:
-      return `files__biospecimens__${field}`;
+      return `files__biospecimens__${fieldFormated}`;
     case INDEXES.FILE:
-      return `files__${field}`;
+      return `files__${fieldFormated}`;
     default:
-      return field;
+      return fieldFormated;
   }
 };
 


### PR DESCRIPTION
# fix(quick filter): check first level of nested facet

[SJIP-1419](https://d3b.atlassian.net/browse/SJIP-1419)

## Description
Facet values already in query builder need to be checked too in quick filter first and second level.

## Acceptance Criterias
- first level of QF need to be checked like QB values

## Screenshot or Video
### Before

https://github.com/user-attachments/assets/290826bb-a758-409d-b79a-f6c8a3a78820



### After

https://github.com/user-attachments/assets/5e3cac6c-2238-4f95-aa82-4bc29432dd94



[SJIP-1419]: https://d3b.atlassian.net/browse/SJIP-1419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ