### PR TITLE
feat: SJIP-1440 Update intervention maxO

### DIFF
--- a/src/graphql/participants/models.ts
+++ b/src/graphql/participants/models.ts
@@ -114,6 +114,7 @@ export interface IMaxo {
   id: string;
   code: string;
   display: string;
+  formatted: string;
 }
 
 export interface IParticipantEntity {

--- a/src/graphql/participants/queries.ts
+++ b/src/graphql/participants/queries.ts
@@ -105,6 +105,7 @@ export const SEARCH_PARTICIPANT_QUERY = gql`
                   node {
                     code
                     display
+                    formatted
                   }
                 }
               }

--- a/src/graphql/quickFilter/queries.ts
+++ b/src/graphql/quickFilter/queries.ts
@@ -29,7 +29,7 @@ export const GET_QUICK_FILTER_EXPLO = gql`
             doc_count
           }
         }
-        maxo__code {
+        maxo__formatted {
           buckets {
             key
             doc_count

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1898,6 +1898,7 @@ const en = {
     },
     maxo: {
       code: 'Intervention (MAxO)',
+      formatted: 'Intervention (MAxO)',
     },
 
     // Biospecimen

--- a/src/locales/es.ts
+++ b/src/locales/es.ts
@@ -1763,6 +1763,7 @@ const es = {
     },
     maxo: {
       code: 'Intervention (MAxO)',
+      formatted: 'Intervención (MAxO)',
     },
 
     // Muestras biológicas

--- a/src/utils/translation.ts
+++ b/src/utils/translation.ts
@@ -288,6 +288,7 @@ export const getFacetsDictionary = () => ({
   ethnicity: intl.get('facets.ethnicity'),
   maxo: {
     code: intl.get('facets.maxo.code'),
+    formatted: intl.get('facets.maxo.formatted')
   },
   status: intl.get('facets.status'),
   parent_sample_type: intl.get('facets.parent_sample_type'),

--- a/src/views/DataExploration/components/PageContent/tabs/Participants/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Participants/index.tsx
@@ -272,15 +272,15 @@ const getDefaultColumns = (): ProColumnType[] => [
           nOfElementsWhenCollapsed={1}
           dataSource={maxos}
           renderItem={(maxo, index): React.ReactNode =>
-            maxo.display ? (
+            maxo.formatted ? (
               <div key={index}>
-                {capitalize(maxo.display)} (MAxO:{' '}
+                {capitalize(`${maxo.display} (MAXO:`)}
                 <ExternalLink
-                  href={`http://purl.obolibrary.org/obo/MAXO_${maxo.code?.slice('MAXO:'.length)}`}
+                  href={`http://purl.obolibrary.org/obo/MAXO_${maxo.code?.split(':')[1]}`}
                 >
-                  {maxo.code?.slice('MAXO:'.length)}
+                  {maxo.code?.split(':')[1]}
                 </ExternalLink>
-                )
+                {`)`}
               </div>
             ) : (
               TABLE_EMPTY_PLACE_HOLDER

--- a/src/views/DataExploration/components/PageContent/tabs/Participants/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Participants/index.tsx
@@ -274,7 +274,7 @@ const getDefaultColumns = (): ProColumnType[] => [
           renderItem={(maxo, index): React.ReactNode =>
             maxo.formatted ? (
               <div key={index}>
-                {capitalize(`${maxo.display} (MAXO:`)}
+                {`${capitalize(maxo.display)} (MAxO:`}
                 <ExternalLink
                   href={`http://purl.obolibrary.org/obo/MAXO_${maxo.code?.split(':')[1]}`}
                 >

--- a/src/views/DataExploration/index.tsx
+++ b/src/views/DataExploration/index.tsx
@@ -112,7 +112,7 @@ export const filterGroups: {
             field={'observed_phenotype'}
           />,
           'condition_source_texts',
-          'maxo__code',
+          'maxo__formatted',
           'diagnosis__age_at_event_days',
           'outcomes__age_at_event_days__value',
           'observed_phenotype__age_at_event_days',


### PR DESCRIPTION
# feat: Update intervention maxO

- Closes SJIP-1440

## Description
Goal: Implemented the new field for the formatted version of the MAxO field that has the code + term. Currently, we only show the MAxO ID in the facet which makes it hard for the user to explore the MAxO terms as most people don’t have them memorized and would need to go to the MAxO website to know what the associated term is.

Therefore, like we do for the Diagnosis MONDO and the Phenotype HPO, and also how we display the MAxO term in the column of the table, we will create a formatted MAxO field in ES to be used with the facet



Formatted field: MAxO term (MAxO: MAxO ID)
## Links
- [JIRA](https://d3b.atlassian.net/browse/SJIP-1440)
- [Design](https://)

## Extra Validation
- [ ] QA Done

## Screenshot or Video
### Before
<img width="419" height="309" alt="image" src="https://github.com/user-attachments/assets/89914fd4-6169-41f5-acc4-7a093038a3c8" />


### After
<img width="322" height="430" alt="image" src="https://github.com/user-attachments/assets/de5bf2a6-8e8a-43d0-8d4d-d70647849826" />
<img width="850" height="583" alt="image" src="https://github.com/user-attachments/assets/fa5b69f8-d3b5-41df-9a48-076f3e9c0d88" />

