### PR TITLE
fix(participant): SJIP-656 family unit display

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -2176,6 +2176,7 @@ const en = {
       age_tooltip_phenotype: 'Age at Phenotype',
       biospecimens: 'Biospecimens',
       condition_source_texts: 'Condition (Source Text)',
+      'control only': 'Control only',
       count: '{count, plural, =0 {Participant} =1 {Participant} other {Participants}}',
       dbgap: 'dbGaP',
       diagnosis: 'Diagnosis',

--- a/src/locales/es.ts
+++ b/src/locales/es.ts
@@ -2044,6 +2044,7 @@ const es = {
       age_tooltip_phenotype: 'Edad en el fenotipo',
       biospecimens: 'Biospecímenes',
       condition_source_texts: 'Condición (Texto Fuente)',
+      'control only': 'Sólo control',
       count: '{count, plural, =0 {Participante} =1 {Participante} other {Participantes}}',
       dbgap: 'dbGaP',
       diagnosis: 'Diagnóstico',


### PR DESCRIPTION
# fix(participant): family unit display

[SJIP-656](https://d3b.atlassian.net/browse/SJIP-656)

## Description
Control only not displayed for family unit in participant tab and entity

## Acceptance Criterias
Display control only label.

## Screenshot or Video
### Before
Empty cell

### After
<img width="1543" height="561" alt="Capture d’écran, le 2025-09-29 à 14 55 03" src="https://github.com/user-attachments/assets/826690cc-423f-4a59-8b5c-c078b23a3c6f" />
<img width="1543" height="561" alt="Capture d’écran, le 2025-09-29 à 14 53 26" src="https://github.com/user-attachments/assets/6f436ac3-ba13-482c-b8d9-612be65f603f" />
<img width="1724" height="903" alt="Capture d’écran, le 2025-09-29 à 14 51 01" src="https://github.com/user-attachments/assets/27cf11f6-4316-4aef-8ad0-69b93347ca4b" />
<img width="1724" height="903" alt="Capture d’écran, le 2025-09-29 à 14 47 51" src="https://github.com/user-attachments/assets/a6a29be8-168a-4eb9-9ef7-9c2fceab5083" />



[SJIP-656]: https://d3b.atlassian.net/browse/SJIP-656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ