### PR TITLE
fix(studyentity): SJIP-1502 change logic to view datasets in exploration

### DIFF
--- a/src/views/StudyEntity/index.tsx
+++ b/src/views/StudyEntity/index.tsx
@@ -580,8 +580,8 @@ const StudyEntity = () => {
             </Title>
             {study?.datasets?.hits.edges.map(({ node: dataset }, index: number) => {
               const titleExtra = [];
-
-              if (dataset.dataset_name && dataset.is_harmonized) {
+              const nOfDocRefs = dataset?.number_of_document_references ?? 0;
+              if (nOfDocRefs >= 1) {
                 titleExtra.push(
                   <Button
                     className={style.datasetBtn}


### PR DESCRIPTION
# fix(studyentity): change logic to view datasets in exploration

- Closes SJIP-1502

## Links
- [JIRA](https://d3b.atlassian.net/browse/SJIP-1502)
- [Design](https://)

## Screenshot or Video
### Before
<img width="3513" height="1906" alt="image" src="https://github.com/user-attachments/assets/34728877-5c85-4489-b64d-6341cf0f2d91" />


### After
<img width="3627" height="1959" alt="image" src="https://github.com/user-attachments/assets/6fad03c4-7505-4a9a-be2f-5959b1e4e161" />


## QA
### Steps to validate
<!-- Add step by step instructions to test this PR -->
1. https://portal-qa.includedcc.org/studies/HTP#dataset