### PR TITLE
fix(files): SJIP-1505 send warning access file to cavatica

### DIFF
--- a/src/utils/dataFiles.ts
+++ b/src/utils/dataFiles.ts
@@ -15,7 +15,11 @@ export const userHasAccessToFile = (
 
   // @see https://d3b.atlassian.net/browse/SJIP-932
   const fileAccess = cloneDeep(file);
-  if (STUDIES_CONTROLLED_AS_REGISTERED_RULES.includes(fileAccess.study.study_code)) {
+  if (
+    STUDIES_CONTROLLED_AS_REGISTERED_RULES.includes(fileAccess.study.study_code) ||
+    fileAccess.access_urls?.startsWith('drs://cavatica-ga4gh-api.sbgenomics.com/') ||
+    fileAccess.access_urls?.startsWith('drs://nci-crdc.datacommons.io/')
+  ) {
     fileAccess.controlled_access = FileAccessType.REGISTERED;
   }
 


### PR DESCRIPTION
# fix(files): send warning access file to cavatica

- Closes SJIP-1505

## Description
- The warning icon for undetermined authorization is blocking when trying to send to Cavatica

## Acceptance Criterias
- be able to send to cavatica a file with undetermined authorization

## Links
- [JIRA](https://d3b.atlassian.net/browse/SJIP-1505)

## Screenshot or Video
### Before

<img width="1723" height="902" alt="Capture d’écran, le 2026-01-13 à 14 44 38" src="https://github.com/user-attachments/assets/49badc34-d0d7-4818-ac88-e1bbdb2ea66a" />

### After

<img width="1723" height="902" alt="Capture d’écran, le 2026-01-13 à 14 44 02" src="https://github.com/user-attachments/assets/405acfe4-e8de-4933-8bad-97ae267a2eba" />
