### PR TITLE
fix: SJIP-1524 show correct study column title in TSV

### DIFF
--- a/src/store/report/thunks.tsx
+++ b/src/store/report/thunks.tsx
@@ -212,11 +212,9 @@ const fetchTsxReport = async (
     : args.columns.map((col, index) => ({
         index,
         key: col.key,
-        visible: col.defaultHidden === true ? false : true,
+        visible: col.defaultHidden !== true,
       }));
-  colStates = colStates
-    .filter(({ visible }) => !!visible)
-    .map((column) => (column.key === 'study' ? { ...column, key: 'study.study_code' } : column));
+  colStates = colStates.filter(({ visible }) => !!visible);
 
   const columnKeyOrdered = [...colStates].sort((a, b) => a.index - b.index).map(({ key }) => key);
   const tsvColumnsConfig = data!.data[args.index].columnsState.state.columns.filter(({ field }) =>
@@ -259,11 +257,13 @@ const fetchTsxReport = async (
 };
 
 const getTitleFromColumns = (columns: ProColumnType[], field: string) => {
-  const fieldToUse = field === 'study.study_code' ? 'study' : field;
+  let column = columns.find(({ key }) => key === field);
 
-  const column = columns.find(({ key }) => key === fieldToUse);
+  if (!column && field === 'study') {
+    column = columns.find(({ key }) => key === 'study.study_code');
+  }
 
-  if (!column || (column.title && typeof column.title !== 'string')) {
+  if (!column?.title) {
     return startCase(field.replace(/\./g, ' '));
   }
 


### PR DESCRIPTION
# fix: show correct study column title in TSV

- Closes SJIP-1524

## Description
<!-- Add a description of the changes proposed in the pull request -->
Make sure that when downloading a TSV that the column Study displays with the correct title.


## Links
- [JIRA](https://d3b.atlassian.net/browse/SJIP-1524)

<img width="3584" height="1420" alt="image" src="https://github.com/user-attachments/assets/fe08ddf4-572c-44d0-827a-dfb0ca4fa55c" />


## QA
### Steps to validate
<!-- Add step by step instructions to test this PR -->
1. Download TSV in exploration
2. Download TSV in studies page