### PR TITLE
feat(summary): SJIP-1481 reverse data in hpo and mondo graphs

### DIFF
--- a/src/views/DataExploration/components/PageContent/tabs/Summary/MostFrequentDiagnosisGraphCard/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/MostFrequentDiagnosisGraphCard/index.tsx
@@ -79,7 +79,7 @@ const MostFrequentDiagnosisGraphCard = () => {
           return 0;
         },
       );
-      setMondo(filterMondoData(treeNodeToChartData(flattenMondoTree)));
+      setMondo(filterMondoData(treeNodeToChartData(flattenMondoTree)).reverse());
     });
   }, [JSON.stringify(sqon)]);
 

--- a/src/views/DataExploration/components/PageContent/tabs/Summary/MostFrequentPhenotypesGraphCard/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/MostFrequentPhenotypesGraphCard/index.tsx
@@ -102,7 +102,7 @@ const MostFrequentPhenotypesGraphCard = () => {
           return 0;
         },
       );
-      setPhenotypes(filterPhenotypesData(treeNodeToChartData(flattenHPOTree)));
+      setPhenotypes(filterPhenotypesData(treeNodeToChartData(flattenHPOTree)).reverse());
     });
   }, [JSON.stringify(sqon)]);
 


### PR DESCRIPTION
# feat(summary): reverse data in hpo and mondo grpahs

- [SJIP-1481](https://d3b.atlassian.net/browse/SJIP-1481)

## Description
Set graphs to descending order

## Acceptance Criterias
Reverse data for HPO and MONDO graphs

## Screenshot or Video
### Before
<img width="1476" height="452" alt="Capture d’écran, le 2026-03-16 à 08 55 47" src="https://github.com/user-attachments/assets/26a73ee2-eb23-45d9-9291-a01d09e538f0" />

### After
<img width="1476" height="452" alt="Capture d’écran, le 2026-03-16 à 08 56 38" src="https://github.com/user-attachments/assets/28cb50cb-df4a-43ea-a653-d2d7aad2b004" />


[SJIP-1481]: https://d3b.atlassian.net/browse/SJIP-1481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ