### PR TITLE
feat: SJIP-1538 Adjust Cypress tests to fix some issues

### DIFF
--- a/cypress/e2e/Consultation/TableauStudies_1.cy.ts
+++ b/cypress/e2e/Consultation/TableauStudies_1.cy.ts
@@ -40,8 +40,8 @@ describe('Page des études - Vérifier les informations affichées', () => {
     cy.get('tr[data-row-key="HTP"] [class="ant-table-cell"]').eq(16).contains('Adult').should('exist');
     cy.get('tr[data-row-key="HTP"] [class="ant-table-cell"]').eq(17).contains('Investigator Assessment').should('exist');
     cy.get('tr[data-row-key="HTP"] [class="ant-table-cell"]').eq(17).contains('Medical Record').should('exist');
+    cy.get('tr[data-row-key="HTP"] [class="ant-table-cell"]').eq(18).contains('Clinical Trial').should('exist');
     cy.get('tr[data-row-key="HTP"] [class="ant-table-cell"]').eq(18).contains('Case-Control').should('exist');
-    cy.get('tr[data-row-key="HTP"] [class="ant-table-cell"]').eq(18).contains('longitudinal').should('exist');
     cy.get('tr[data-row-key="HTP"] [class="ant-table-cell"]').eq(19).contains('Joaquin M. Espinosa').should('exist');
     cy.get('tr[data-row-key="HTP"] [class="ant-table-cell"]').eq(20).contains('2016').should('exist');
     cy.get('tr[data-row-key="HTP"] [class="ant-table-cell"]').eq(21).contains('2025').should('exist');

--- a/cypress/e2e/Consultation/TableauStudies_2.cy.ts
+++ b/cypress/e2e/Consultation/TableauStudies_2.cy.ts
@@ -28,6 +28,13 @@ describe('Page des études - Valider les liens disponibles', () => {
     });
   });
 
+  it('Lien \'See more\' de dbGap du tableau', () => {
+    cy.get('tr[data-row-key="HTP"] [class*="ant-table-cell"]').eq(5).find('[class*="ExpandableCell_fuiExpandableCellBtn"]').contains('See more').clickAndWait({force: true});
+    cy.get('tr[data-row-key="HTP"] [class*="ant-table-cell"]').eq(5).contains('phs002330').should('exist');
+    cy.get('tr[data-row-key="HTP"] [class*="ant-table-cell"]').eq(5).find('[class*="ExpandableCell_fuiExpandableCellBtn"]').contains('See less').clickAndWait({force: true});
+    cy.get('tr[data-row-key="HTP"] [class*="ant-table-cell"]').eq(5).contains('phs002330').should('not.exist');
+  });
+
   it('Lien Participants du tableau', () => {
     cy.get('tr[data-row-key="HTP"] [class="ant-table-cell"]').eq(6).find('[href]').clickAndWait({force: true});
     cy.get('[class*="Participants_participantTabWrapper"]').should('exist'); // data-cy="ProTable_Participants"
@@ -54,5 +61,13 @@ describe('Page des études - Valider les liens disponibles', () => {
     cy.get('tr[data-row-key="HTP"] [class*="ant-table-cell"]').eq(17).contains('Participant or Caregiver Report').should('exist');
     cy.get('tr[data-row-key="HTP"] [class*="ant-table-cell"]').eq(17).find('[class*="ExpandableCell_fuiExpandableCellBtn"]').contains('See less').clickAndWait({force: true});
     cy.get('tr[data-row-key="HTP"] [class*="ant-table-cell"]').eq(17).contains('Participant or Caregiver Report').should('not.exist');
+  });
+
+  it('Lien \'See more\' de Design du tableau', () => {
+    cy.hideColumn('Description');
+    cy.get('tr[data-row-key="HTP"] [class*="ant-table-cell"]').eq(17).find('[class*="ExpandableCell_fuiExpandableCellBtn"]').contains('See more').clickAndWait({force: true});
+    cy.get('tr[data-row-key="HTP"] [class*="ant-table-cell"]').eq(17).contains('longitudinal').should('exist');
+    cy.get('tr[data-row-key="HTP"] [class*="ant-table-cell"]').eq(17).find('[class*="ExpandableCell_fuiExpandableCellBtn"]').contains('See less').clickAndWait({force: true});
+    cy.get('tr[data-row-key="HTP"] [class*="ant-table-cell"]').eq(17).contains('longitudinal').should('not.exist');
   });
 });

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -174,6 +174,17 @@ Cypress.Commands.add('deleteSetIfExists', (dataNodeKey: string, setName: string)
   });
 });
 
+Cypress.Commands.add('hideColumn', (column: string|RegExp, eq: number = 0) => {
+  cy.intercept('PUT', '**/user').as('getPOSTuser');
+
+  cy.get('div[class="ant-popover-inner"]')
+    .find('div[class="ant-space-item"]').contains(column)
+    .find('[type="checkbox"]').uncheck({force: true});
+  cy.wait('@getPOSTuser', {timeout: oneMinute});
+  cy.get('[class*="Header_logo"]').clickAndWait({force: true});
+  cy.waitWhileSpin(oneMinute);
+});
+
 Cypress.Commands.add('login', () => {
   cy.session(['user'], () => {
     cy.visit('/dashboard');

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -15,6 +15,7 @@ declare namespace Cypress {
     deleteFilterIfExists(filterName: string): cy & CyEventEmitter;
     deleteSet(dataNodeKey: string, setName: string): cy & CyEventEmitter;
     deleteSetIfExists(dataNodeKey: string, setName: string): cy & CyEventEmitter;
+    hideColumn(column: string|RegExp): cy & CyEventEmitter;
     login(): cy & CyEventEmitter;
     logout(): cy & CyEventEmitter;
     removeFilesFromFolder(folder: string): cy & CyEventEmitter;


### PR DESCRIPTION
# feat: SJIP-1538 Adjust Cypress tests to fix some issues

## 📌 Contexte

Ajustement des tests Cypress de la page des études pour corriger des problèmes liés aux colonnes du tableau et ajouter de nouveaux tests de validation.

## 📝 Changements

### Tests Cypress

- **TableauStudies_1.cy.ts** : Correction de l'ordre des assertions pour la colonne "Design" (ligne HTP)
  - Ajout de l'assertion "Clinical Trial" à la colonne 18
  - Suppression de l'assertion "longitudinal" qui est maintenant testée via le lien "See more"

- **TableauStudies_2.cy.ts** : Ajout de deux nouveaux tests pour valider les liens "See more"
  - Test du lien "See more" pour la colonne dbGap (affichage/masquage de phs002330)
  - Test du lien "See more" pour la colonne Design (affichage/masquage de longitudinal)

### Commandes Cypress

- **commands.ts** : Ajout de la commande personnalisée `hideColumn`
  - Permet de masquer une colonne du tableau via le panneau de configuration
  - Attend la réponse de l'API utilisateur avant de continuer

- **index.d.ts** : Ajout de la déclaration TypeScript pour la nouvelle commande `hideColumn`

## 🧪 Tests

Les tests impactés ont été exécutés localement et passent avec succès :
- `TableauStudies_1.cy.ts`
- `TableauStudies_2.cy.ts`

## 🔗 Issues liées

<!-- Begin JIRA Issues -->
SJIP-1538
<!-- End JIRA Issues --> 