### PR TITLE
fix(study): SJIP-1559 dataset analyze in cavatica bulk drs

### DIFF
--- a/src/views/StudyEntity/index.tsx
+++ b/src/views/StudyEntity/index.tsx
@@ -826,7 +826,7 @@ const StudyEntity = () => {
               const drsItemsReformatted = rawDrs.map((x) => ({
                 drs_uri: x.drs_uri,
                 [projectOrParentKey]: value.id,
-                name: x.study_name,
+                name: x.file_name,
                 metadata: {
                   name: x.file_name,
                   study_name: x.study_name,


### PR DESCRIPTION
# fix(study): dataset analyze in cavatica bulk drs

- [SJIP-1559](https://d3b.atlassian.net/browse/SJIP-1559)

## Description
On the Study Entity page, when a dataset has more than one non-data exploration linked file, the Analyze in Cavatica bulk DRS import only pushes the first file. Subsequent files are silently skipped.

## Acceptance Criterias
API call send file name instead of study name.

## Screenshot or Video
### Before
<img width="1037" height="348" alt="Capture d’écran, le 2026-05-11 à 11 24 41" src="https://github.com/user-attachments/assets/258e3ed6-b624-46f3-8035-0bbae1c186e4" />

### After
<img width="1037" height="348" alt="Capture d’écran, le 2026-05-11 à 11 25 20" src="https://github.com/user-attachments/assets/dc25ed88-b8b4-4b04-bf7a-25663f7cd409" />


[SJIP-1559]: https://d3b.atlassian.net/browse/SJIP-1559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ