### PR TITLE
feat(participant): SJIP-1563 biospecimen tree display details of first node

### DIFF
--- a/cypress/e2e/Consultation/TableauBiospecimens_2.cy.ts
+++ b/cypress/e2e/Consultation/TableauBiospecimens_2.cy.ts
@@ -1,5 +1,6 @@
 /// <reference types="cypress"/>
 import '../../support/commands';
+import { oneMinute } from '../../support/utils';
 
 beforeEach(() => {
   cy.login();
@@ -15,7 +16,7 @@ describe('Page Data Exploration (Biospecimens) - Valider les liens disponibles',
   it('Lien Participant ID du tableau', () => {
     cy.get('tr[class*="ant-table-row"] [class*="ant-table-cell"]').eq(6).find('[href]').clickAndWait({force: true});
     cy.get('[id="participant-entity-page"]').should('exist');
-    cy.get('[class*="EntityTitle"]').contains('pt-as0aepqm');
+    cy.get('[class*="EntityTitle"]', {timeout: oneMinute}).contains('pt-as0aepqm');
   });
 
   it('Lien Collection ID du tableau', () => {

--- a/cypress/e2e/Telechargement/TableauBiospecimens.cy.ts
+++ b/cypress/e2e/Telechargement/TableauBiospecimens.cy.ts
@@ -17,6 +17,7 @@ beforeEach(() => {
 
   cy.get('div[role="tabpanel"] [class*="ant-table-row"]').eq(0).find('[type="checkbox"]').check({force: true});
   cy.clickAndIntercept('div[id="content"] svg[data-icon="download"]', 'POST', '**/download', 1, false/*beVisible*/, 1);
+  cy.contains('Your download is being prepared').should('not.exist', {timeout: oneMinute});
   cy.waitUntilFile(oneMinute);
 });
 

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -629,10 +629,17 @@ Cypress.Commands.add('visitParticipantEntityMock', () => {
             req.reply(mockResponseDSStatusBody);
           };
         });
+        cy.intercept('POST', '**/graphql', (req) => {
+          if (req.body.query.includes('getParticipantCount')) {
+            req.alias = 'postPartCountGraphql';
+            req.reply(mockResponseDSStatusBody);
+          };
+        });
         cy.visit('/participants/mock');
         cy.wait('@postPartGraphql');
         cy.wait('@postTreeGraphql');
         cy.wait('@postDSStatusGraphql');
+        cy.wait('@postPartCountGraphql');
       });
     });
   });

--- a/src/components/Biospecimens/Tree/index.tsx
+++ b/src/components/Biospecimens/Tree/index.tsx
@@ -218,11 +218,16 @@ const BiospecimenTree = ({
   }, []);
 
   useEffect(() => {
-    if (!loading && biospecimen) {
+    if (loading) return;
+    if (biospecimen) {
       setSelectedKeys([biospecimen.sample_id]);
       const nodeDetails = getNodeDetails(biospecimen.fhir_id, dataParsed);
       nodeDetails &&
         setDescriptions(getSampleDetails(nodeDetails, hasParticipantLink, participantId));
+    } else if (dataParsed.length > 0) {
+      const firstCollectionSample = dataParsed[0];
+      setSelectedKeys([firstCollectionSample.key]);
+      setDescriptions(getCollectionDetails(firstCollectionSample));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [biospecimen, loading]);


### PR DESCRIPTION
# feat(participant): biospecimen tree display details of first collection node

- [SJIP-1563](https://d3b.atlassian.net/browse/SJIP-1563)

## Description
Default select first collection sample in biospecimen tree to populate metadata panel

## Acceptance Criterias
- On page load / scroll to the Biospecimen section, the first collection sample in the tree is selected by default
- The right metadata panel displays the metadata for that collection sample on initial render
- If the user selects a different node, the panel updates accordingly as it does today

## Screenshot or Video

### After

#### Participant entity

https://github.com/user-attachments/assets/83e9cfd4-3dd6-439d-a6d7-d3daede0796e

#### Data explo / biospecimen tab => no impact

https://github.com/user-attachments/assets/18e50b91-de3e-4de7-beaa-c06251535036


[SJIP-1563]: https://d3b.atlassian.net/browse/SJIP-1563?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ