### PR TITLE
fix(participant): SJIP-1563 scroll in tree not in page

### DIFF
--- a/src/components/Biospecimens/Tree/index.tsx
+++ b/src/components/Biospecimens/Tree/index.tsx
@@ -232,37 +232,34 @@ const BiospecimenTree = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [biospecimen, loading]);
 
-  // Auto-scroll to selected element
+  // Auto-scroll to selected element (within the tree container only, not the page)
   useEffect(() => {
-    if (selectedKeys.length > 0) {
-      // delay for DOM to be updated
-      setTimeout(() => {
-        const selectedKey = selectedKeys[0];
+    if (selectedKeys.length === 0) return;
+    // delay for DOM to be updated
+    const timeoutId = setTimeout(() => {
+      const selectedKey = selectedKeys[0];
 
-        // Use SimpleBar ref to access scrollable content
-        const simpleBarInstance = treeContainerRef.current;
-        const scrollElement =
-          simpleBarInstance?.getScrollElement?.() ||
-          simpleBarInstance?.querySelector?.('.simplebar-content-wrapper') ||
-          document.querySelector('.simplebar-content-wrapper');
-        const treeElement =
-          scrollElement?.querySelector('.ant-tree') || document.querySelector('.ant-tree');
+      const simpleBarInstance = treeContainerRef.current;
+      const scrollElement =
+        simpleBarInstance?.getScrollElement?.() ||
+        simpleBarInstance?.querySelector?.('.simplebar-content-wrapper');
+      const treeElement = scrollElement?.querySelector('.ant-tree');
 
-        if (treeElement) {
-          const selectedNode =
-            treeElement.querySelector(`[data-key="${selectedKey}"]`) ||
-            treeElement.querySelector('.ant-tree-node-selected');
+      if (!scrollElement || !treeElement) return;
 
-          if (selectedNode) {
-            selectedNode.scrollIntoView({
-              behavior: 'smooth',
-              block: 'center',
-              inline: 'nearest',
-            });
-          }
-        }
-      }, 100);
-    }
+      const selectedNode =
+        treeElement.querySelector(`[data-key="${selectedKey}"]`) ||
+        treeElement.querySelector('.ant-tree-node-selected');
+
+      if (!selectedNode) return;
+
+      const nodeRect = selectedNode.getBoundingClientRect();
+      const containerRect = scrollElement.getBoundingClientRect();
+      const offset =
+        nodeRect.top - containerRect.top - (containerRect.height - nodeRect.height) / 2;
+      scrollElement.scrollTop += offset;
+    }, 100);
+    return () => clearTimeout(timeoutId);
   }, [selectedKeys]);
 
   const onSearch = (e: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
# fix(participant): scroll in tree not in page

- [SJIP-1563](https://d3b.atlassian.net/browse/SJIP-1563)

## Description
Add a default selection in tree impact page scroll or on participant entity load we only want to select first element not to scroll to it.

## Acceptance Criterias
- on participant load page no scroll to biospecimen section

## Screenshot or Video
### Before
<!-- Add screenshots/videos of the feature/bug before this PR -->

### After

#### Participant entity load
https://github.com/user-attachments/assets/f1279794-085e-42b2-95b4-1990ceb099ec

#### Biospecimen modal => scroll to element in the tree if necessary
https://github.com/user-attachments/assets/a92722cd-e3b2-46d2-8332-2c5e4178af72



[SJIP-1563]: https://d3b.atlassian.net/browse/SJIP-1563?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ