### PR TITLE
feat(apollo): SJIP-1576 memoize apollo client to avoid recreating it on each render

### DIFF
--- a/src/provider/ApolloProvider.tsx
+++ b/src/provider/ApolloProvider.tsx
@@ -31,13 +31,15 @@ const getAuthLink = () =>
   }));
 
 const Provider = ({ children }: IProvider): ReactElement => {
+  const header = getAuthLink();
+
   const client = useMemo<ApolloClient<NormalizedCacheObject>>(
     () =>
       new ApolloClient({
         cache: new InMemoryCache({ addTypename: false }),
-        link: getAuthLink().concat(arrangerLink),
+        link: header.concat(arrangerLink),
       }),
-    [],
+    [header],
   );
   return <ApolloProvider client={client}>{children}</ApolloProvider>;
 };

--- a/src/provider/ApolloProvider.tsx
+++ b/src/provider/ApolloProvider.tsx
@@ -1,4 +1,4 @@
-import { ReactElement } from 'react';
+import { ReactElement, useMemo } from 'react';
 import {
   ApolloClient,
   ApolloProvider,
@@ -31,12 +31,14 @@ const getAuthLink = () =>
   }));
 
 const Provider = ({ children }: IProvider): ReactElement => {
-  const header = getAuthLink();
-
-  const client: ApolloClient<NormalizedCacheObject> = new ApolloClient({
-    cache: new InMemoryCache({ addTypename: false }),
-    link: header.concat(arrangerLink),
-  });
+  const client = useMemo<ApolloClient<NormalizedCacheObject>>(
+    () =>
+      new ApolloClient({
+        cache: new InMemoryCache({ addTypename: false }),
+        link: getAuthLink().concat(arrangerLink),
+      }),
+    [],
+  );
   return <ApolloProvider client={client}>{children}</ApolloProvider>;
 };
 


### PR DESCRIPTION
# feat(apollo): memoize apollo client to avoid recreating it on each render

[SJIP-1576](https://d3b.atlassian.net/browse/SJIP-1576)

## Description
The `ApolloClient` was being recreated on every render of the `Provider`, which also
reset the `InMemoryCache` each time. This PR memoizes the client creation with `useMemo`,
so it is only recreated when the `backend` changes.

### Changes
- Wrapped the `ApolloClient` instantiation in a `useMemo`
- The client (and its cache) is now preserved across renders

## Acceptance Criterias
- Verify data loads correctly (FHIR / Arranger)
- Verify no regression on pages using Apollo

## Screenshot or Video
### Before
<!-- Add screenshots/videos of the feature/bug before this PR -->

### After
<!-- Add screenshots/videos of the feature/bug after this PR -->


[SJIP-1576]: https://d3b.atlassian.net/browse/SJIP-1576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ