### PR TITLE
fix(summary): SJIP-1575 fix on click mondo and phenotype graphs

### DIFF
--- a/src/views/DataExploration/components/PageContent/tabs/Summary/MostFrequentDiagnosisGraphCard/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/MostFrequentDiagnosisGraphCard/index.tsx
@@ -66,7 +66,7 @@ const MostFrequentDiagnosisGraphCard = () => {
 
   useEffect(() => {
     setMondoLoading(true);
-    phenotypeStore.current?.fetch({ field: 'mondo', sqon }).then(() => {
+    phenotypeStore.current?.fetch({ field: 'mondo', sqon, filterThemselves: true }).then(() => {
       setMondoLoading(false);
       const flattenMondoTree = getFlattenTree(phenotypeStore.current?.tree as TreeNode).sort(
         (a, b) => {

--- a/src/views/DataExploration/components/PageContent/tabs/Summary/MostFrequentPhenotypesGraphCard/index.tsx
+++ b/src/views/DataExploration/components/PageContent/tabs/Summary/MostFrequentPhenotypesGraphCard/index.tsx
@@ -89,21 +89,23 @@ const MostFrequentPhenotypesGraphCard = () => {
 
   useEffect(() => {
     setPhenotypesLoading(true);
-    phenotypeStore.current?.fetch({ field: 'observed_phenotype', sqon }).then(() => {
-      setPhenotypesLoading(false);
-      const flattenHPOTree = getFlattenTree(phenotypeStore.current?.tree as TreeNode).sort(
-        (a, b) => {
-          if ((a.exactTagCount ?? 0) > (b.exactTagCount ?? 0)) {
-            return -1;
-          }
-          if ((a.exactTagCount ?? 0) < (b.exactTagCount ?? 0)) {
-            return 1;
-          }
-          return 0;
-        },
-      );
-      setPhenotypes(filterPhenotypesData(treeNodeToChartData(flattenHPOTree)).reverse());
-    });
+    phenotypeStore.current
+      ?.fetch({ field: 'observed_phenotype', sqon, filterThemselves: true })
+      .then(() => {
+        setPhenotypesLoading(false);
+        const flattenHPOTree = getFlattenTree(phenotypeStore.current?.tree as TreeNode).sort(
+          (a, b) => {
+            if ((a.exactTagCount ?? 0) > (b.exactTagCount ?? 0)) {
+              return -1;
+            }
+            if ((a.exactTagCount ?? 0) < (b.exactTagCount ?? 0)) {
+              return 1;
+            }
+            return 0;
+          },
+        );
+        setPhenotypes(filterPhenotypesData(treeNodeToChartData(flattenHPOTree)).reverse());
+      });
   }, [JSON.stringify(sqon)]);
 
   return (


### PR DESCRIPTION
# fix(summary): fix on click mondo and phenotype graphs

- [SJIP-1575](https://d3b.atlassian.net/browse/SJIP-1575)

## Description
Mondo and phenotypes graphs don't show the right data after click.

## Acceptance Criterias
Display data filtered by sqon after click

## Screenshot or Video

https://github.com/user-attachments/assets/ae7dc0e3-5a30-4a71-80e0-ef7224347075




[SJIP-1575]: https://d3b.atlassian.net/browse/SJIP-1575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ