### PR TITLE
fix(participant): SJIP-1448 add not observed and interpretation in table and export

### DIFF
--- a/src/graphql/participants/models.ts
+++ b/src/graphql/participants/models.ts
@@ -23,7 +23,7 @@ export interface IParticipantPhenotype {
   hpo_phenotype_observed_text: string;
   hpo_phenotype_not_observed: string;
   hpo_phenotype_not_observed_text: string;
-  observed: boolean;
+  is_observed: boolean;
 }
 
 export interface IParticipantBiospecimen {

--- a/src/graphql/participants/queries.ts
+++ b/src/graphql/participants/queries.ts
@@ -246,7 +246,8 @@ export const GET_PARTICIPANT_ENTITY = gql`
                     age_at_event_days
                     fhir_id
                     hpo_phenotype_observed
-                    observed
+                    hpo_phenotype_not_observed
+                    is_observed
                     source_text
                   }
                 }

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -2210,6 +2210,7 @@ const en = {
       files: 'Files',
       hpo_term: 'HPO Term',
       hpo_term_tooltip: '# of participants with this exact HPO term',
+      interpretation: 'Interpretation',
       maxo_code: 'Intervention (MAxO)',
       measurement: {
         title: 'Measurement',
@@ -2223,6 +2224,8 @@ const en = {
       mondo_diagnosis: 'Diagnosis (MONDO)',
       mondo_term: 'MONDO Term',
       mondo_term_tooltip: '# of participants with this exact MONDO term',
+      not_observed: 'Not observed',
+      observed: 'Observed',
       other: 'Other',
       participants: 'Participants',
       participant_id: 'Participant ID',

--- a/src/locales/es.ts
+++ b/src/locales/es.ts
@@ -2207,6 +2207,7 @@ const es = {
       files: 'Archivos',
       hpo_term: 'Término HPO',
       hpo_term_tooltip: '# de participantes con este término HPO exacto',
+      interpretation: 'Interpretación',
       maxo_code: 'Intervención (MAxO)',
       measurement: {
         title: 'Medición',
@@ -2220,6 +2221,8 @@ const es = {
       mondo_diagnosis: 'Diagnóstico (MONDO)',
       mondo_term: 'Término MONDO',
       mondo_term_tooltip: '# de participantes con este término MONDO exacto',
+      not_observed: 'No observado',
+      observed: 'Observado',
       other: 'Otro',
       participants: 'Participantes',
       participant_id: 'ID de participante',

--- a/src/store/passport/thunks.test.ts
+++ b/src/store/passport/thunks.test.ts
@@ -129,7 +129,7 @@ describe(`${extractMetadata.name}()`, () => {
                           hpo_phenotype_observed_text: 'hpo_phenotype_observed_text',
                           hpo_phenotype_not_observed: 'hpo_phenotype_not_observed',
                           hpo_phenotype_not_observed_text: 'hpo_phenotype_not_observed_text',
-                          observed: false,
+                          is_observed: false,
                         },
                       },
                     ],

--- a/src/utils/translation.ts
+++ b/src/utils/translation.ts
@@ -288,7 +288,7 @@ export const getFacetsDictionary = () => ({
   ethnicity: intl.get('facets.ethnicity'),
   maxo: {
     code: intl.get('facets.maxo.code'),
-    formatted: intl.get('facets.maxo.formatted')
+    formatted: intl.get('facets.maxo.formatted'),
   },
   status: intl.get('facets.status'),
   parent_sample_type: intl.get('facets.parent_sample_type'),

--- a/src/views/ParticipantEntity/PhenotypeTable/index.tsx
+++ b/src/views/ParticipantEntity/PhenotypeTable/index.tsx
@@ -26,7 +26,14 @@ const PhenotypeTable = ({ participant, loading }: OwnProps) => {
   const dispatch = useDispatch();
 
   const phenotype: IParticipantPhenotype[] =
-    participant?.phenotype?.hits?.edges?.map((e) => ({ key: e.node.fhir_id, ...e.node })) || [];
+    participant?.phenotype?.hits?.edges?.map((e) => ({
+      key: e.node.fhir_id,
+      ...e.node,
+      hpo_phenotype: e.node.hpo_phenotype_observed || e.node.hpo_phenotype_not_observed,
+      interpretation: e.node.is_observed
+        ? intl.get('entities.participant.observed')
+        : intl.get('entities.participant.not_observed'),
+    })) || [];
 
   const phenotypesDefaultColumns = getPhenotypeDefaultColumns();
 

--- a/src/views/ParticipantEntity/utils/getPhenotypeColumns.tsx
+++ b/src/views/ParticipantEntity/utils/getPhenotypeColumns.tsx
@@ -2,6 +2,7 @@ import intl from 'react-intl-universal';
 import ExternalLink from '@ferlab/ui/core/components/ExternalLink';
 import { ProColumnType } from '@ferlab/ui/core/components/ProTable/types';
 import ExpandableCell from '@ferlab/ui/core/components/tables/ExpandableCell';
+import { Tag } from 'antd';
 import { IParticipantPhenotype } from 'graphql/participants/models';
 import { capitalize } from 'lodash';
 import { extractPhenotypeTitleAndCode } from 'views/DataExploration/utils/helper';
@@ -10,12 +11,14 @@ import { TABLE_EMPTY_PLACE_HOLDER } from 'common/constants';
 
 import AgeCell from '../AgeCell';
 import HpoParticipantCount from '../PhenotypeTable/HpoParticipantCount';
+
 const getPhenotypeDefaultColumns = (): ProColumnType[] => [
   {
-    key: 'hpo_phenotype_observed',
+    key: 'hpo_phenotype',
     title: intl.get('entities.participant.phenotype_hpo'),
     render: (phenotype: IParticipantPhenotype) => {
-      const phenotypeNames = phenotype?.hpo_phenotype_observed;
+      const phenotypeNames =
+        phenotype?.hpo_phenotype_observed || phenotype?.hpo_phenotype_not_observed;
       if (!phenotypeNames || phenotypeNames.length === 0) {
         return TABLE_EMPTY_PLACE_HOLDER;
       }
@@ -47,6 +50,19 @@ const getPhenotypeDefaultColumns = (): ProColumnType[] => [
     title: intl.get('entities.participant.source_text'),
     render: (phenotype: IParticipantPhenotype) =>
       phenotype?.source_text ? phenotype.source_text : TABLE_EMPTY_PLACE_HOLDER,
+    width: '30%',
+  },
+  {
+    key: 'interpretation',
+    title: intl.get('entities.participant.interpretation'),
+    render: (phenotype: IParticipantPhenotype) => (
+      <Tag color={phenotype?.is_observed ? 'green' : ''}>
+        {phenotype?.is_observed
+          ? intl.get('entities.participant.observed')
+          : intl.get('entities.participant.not_observed')}
+      </Tag>
+    ),
+    width: '15%',
   },
   {
     key: 'age_at_event_days',
@@ -58,6 +74,7 @@ const getPhenotypeDefaultColumns = (): ProColumnType[] => [
       ) : (
         TABLE_EMPTY_PLACE_HOLDER
       ),
+    width: '10%',
   },
   {
     key: 'hpo_term',
@@ -69,6 +86,7 @@ const getPhenotypeDefaultColumns = (): ProColumnType[] => [
       ) : (
         TABLE_EMPTY_PLACE_HOLDER
       ),
+    width: '10%',
   },
 ];
 


### PR DESCRIPTION
# fix(participant): add not observed and interpretation in table and export

- [SJIP-1448](https://d3b.atlassian.net/browse/SJIP-1448)

## Description
Display not observed phenotype and add interpretation in phenotype table in participant entity

## Acceptance Criterias

- All phenotypes (Observed and Not Observed) are displayed in the Phenotype (HPO) column
- "Interpretation" column appears after Condition (Source Text) with correct tag colours
- Rows previously showing an empty Phenotype column due to Not Observed phenotypes now display the correct HPO term

## Screenshot or Video

### After

#### Observed phenotype

<img width="1717" height="359" alt="Capture d’écran, le 2026-07-08 à 15 07 07" src="https://github.com/user-attachments/assets/a8d54ff4-d5f4-47d8-822c-f4c1628c34b9" />
<img width="748" height="153" alt="Capture d’écran, le 2026-07-08 à 15 14 51" src="https://github.com/user-attachments/assets/02278c24-c791-4411-8d3c-c6207cfb07db" />

#### Not observed phenotype

<img width="1717" height="634" alt="Capture d’écran, le 2026-07-08 à 15 06 21" src="https://github.com/user-attachments/assets/365194b4-f5a4-4f1f-8c7e-53eca02d9634" />
<img width="959" height="324" alt="Capture d’écran, le 2026-07-08 à 15 14 28" src="https://github.com/user-attachments/assets/5e6e2fa5-bf56-4ff7-b39d-b6e0cbfcfc38" />


[SJIP-1448]: https://d3b.atlassian.net/browse/SJIP-1448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ